### PR TITLE
Refactor actor termination handling and introduce global channel buffer size configuration:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsactor"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rsactor"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75.0"
-description = "A Rust actor library"
+description = "A Simplified Actor Framework for Rust"
 repository = "https://github.com/hiking90/rsactor"
+homepage = "https://github.com/hiking90/rsactor"
 license = "Apache-2.0"
 keywords = ["actor", "rust", "async"]
 

--- a/README.md
+++ b/README.md
@@ -137,23 +137,13 @@ async fn main() -> Result<()> {
     // This is important to ensure the actor has fully stopped and resources are cleaned up.
     // join_handle.await returns a Result containing the actor's final state and stop reason.
     info!("Waiting for CounterActor (ID: {}) to complete its task...", actor_ref.id());
-    match join_handle.await {
-        Ok((stopped_actor, reason)) => {
-            info!(
-                "CounterActor (ID: {}) task completed. Final count: {}. Stop reason: {:?}",
-                actor_ref.id(), // Note: actor_ref.id() is still usable here
-                stopped_actor.count,
-                reason
-            );
-        }
-        Err(e) => {
-            log::error!(
-                "Error waiting for CounterActor (ID: {}) task to complete: {:?}",
-                actor_ref.id(), // It's good practice to log the ID if available
-                e
-            );
-        }
-    }
+    let (stopped_actor, reason) = join_handle.await?;
+    info!(
+        "CounterActor (ID: {}) task completed. Final count: {}. Stop reason: {:?}",
+        actor_ref.id(), // Note: actor_ref.id() is still usable here
+        stopped_actor.count,
+        reason
+    );
 
     info!("Example finished.");
     Ok(())

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,3 @@
-use futures::future::join;
 use rsactor::{ActorRef, Actor, Message, ActorStopReason}; // MODIFIED: Added System
 use anyhow::Result;
 use log::{info, debug}; // ADDED

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,3 +1,4 @@
+use futures::future::join;
 use rsactor::{ActorRef, Actor, Message, ActorStopReason}; // MODIFIED: Added System
 use anyhow::Result;
 use log::{info, debug}; // ADDED
@@ -111,21 +112,14 @@ async fn main() -> Result<()> {
     // - The actor instance (allowing access to its final state).
     // - The ActorStopReason indicating why it stopped.
     println!("Waiting for actor {} to stop...", actor_ref.id());
-    match join_handle.await {
-        Ok((stopped_actor, reason)) => {
-            // Successfully retrieved the actor and its stop reason.
-            println!(
-                "Actor {} stopped. Final count: {}. Reason: {:?}",
-                actor_ref.id(), // actor_ref is still in scope here
-                stopped_actor.count, // Access the final count from the returned actor instance
-                reason // The reason why the actor stopped
-            );
-        }
-        Err(e) => {
-            // An error occurred while joining the actor's task (e.g., if the task panicked).
-            eprintln!("Error joining actor task for actor {}: {:?}", actor_ref.id(), e);
-        }
-    }
+    let (stopped_actor, reason) = join_handle.await?;
+    // Successfully retrieved the actor and its stop reason.
+    println!(
+        "Actor {} stopped. Final count: {}. Reason: {:?}",
+        actor_ref.id(), // actor_ref is still in scope here
+        stopped_actor.count, // Access the final count from the returned actor instance
+        reason // The reason why the actor stopped
+    );
 
     println!("Main function finished.");
     Ok(())


### PR DESCRIPTION
- Separated Terminate for kill into a distinct signal.
- Removed unnecessary oneshot channel creation during tell() operation.
- Added set_main_channel_buffer_size and spawn_with_buffer_size functions to allow changing the main queue's buffer size.