### PR TITLE
Bump version to 0.7.0 in Cargo.toml and Cargo.lock; update README for…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rsactor"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsactor"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "A Lightweight Rust Actor Framework with Simple Yet Powerful Task Control."

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A Lightweight Rust Actor Framework with Simple Yet Powerful Task Control.
 
 ```toml
 [dependencies]
-rsactor = "0.6" # Check crates.io for the latest version
+rsactor = "0.7" # Check crates.io for the latest version
 ```
 
 ### 2. Basic Usage Example


### PR DESCRIPTION
… dependency version
This pull request updates the version of the `rsactor` crate to `0.7.0` and reflects this change in the documentation.

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the crate version from `0.6.0` to `0.7.0`.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Updated the dependency version in the example from `0.6` to `0.7` to match the new crate version.