### PR TITLE
Refactor actor reference documentation for clarity and type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ impl Message<MyQuery> for MyActor {
     }
 }
 
-rsactor::impl_message_handler!(MyActor, [MyMessage, MyQuery]);
+impl_message_handler!(MyActor, [MyMessage, MyQuery]);
 
-async fn demonstrate_blocking_calls(actor_ref: ActorRef) -> Result<()> {
+async fn demonstrate_blocking_calls(actor_ref: ActorRef<MyActor>) -> Result<()> {
     // --- tell_blocking example ---
     // Clone ActorRef for the first blocking task (tell_blocking)
     let actor_ref_clone_tell = actor_ref.clone();
@@ -238,10 +238,7 @@ async fn demonstrate_blocking_calls(actor_ref: ActorRef) -> Result<()> {
         // Send a query and wait for a reply, with a timeout.
         // This call will block the current thread (managed by `spawn_blocking`)
         // until a response is received from the actor or the timeout occurs.
-        // The type parameters for ask_blocking are:
-        // M: The message type (MyQuery). This is the type of the message being sent.
-        // R: The expected reply type (String). This is the type of the response we expect back.
-        actor_ref_clone_ask.ask_blocking::<MyQuery, String>(
+        actor_ref_clone_ask.ask_blocking(
             MyQuery, Some(Duration::from_secs(2))
         )
     });

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -36,7 +36,6 @@ use tokio::runtime::Handle;
 ///   - [`ask_with_timeout`](UntypedActorRef::ask_with_timeout): Send a message and await a reply with a timeout.
 ///   - [`tell`](UntypedActorRef::tell): Send a message without waiting for a reply.
 ///   - [`tell_with_timeout`](UntypedActorRef::tell_with_timeout): Send a message without waiting for a reply with a timeout.
-///   - [`try_tell`](UntypedActorRef::try_tell): Attempt to send a message without blocking.
 ///
 /// - **Blocking Methods for Tokio Blocking Contexts**:
 ///   - [`ask_blocking`](UntypedActorRef::ask_blocking): Send a message and block until a reply is received.


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `src/actor_ref.rs` files to improve code clarity and documentation. The changes primarily involve refining examples and cleaning up unused documentation references.

### Improvements to code clarity in examples:
* Updated the `impl_message_handler!` macro in `README.md` to remove the `rsactor::` prefix, simplifying the macro call.
* Modified the `demonstrate_blocking_calls` function in `README.md` to specify the generic type `ActorRef<MyActor>` instead of the more ambiguous `ActorRef`, improving type clarity.
* Simplified the `ask_blocking` example in `README.md` by removing explicit type parameters `<MyQuery, String>`, as they can be inferred by the compiler.

### Documentation cleanup:
* Removed the unused reference to `try_tell` in the `src/actor_ref.rs` file, as it is no longer part of the documented API.