### PR TITLE
Add example implementation of Actor A and Actor B with message handling

### DIFF
--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -1,0 +1,177 @@
+// An example demonstrating how Actor A can request work from Actor B,
+// which processes the work in a spawned async task and sends the results back to Actor A
+
+use rsactor::{Actor, ActorRef, Message};
+use anyhow::Result;
+use tokio::time::Duration;
+
+// -------------------------------------------------------------------
+// Actor A (Requester) - Sends requests to Actor B and handles results
+// -------------------------------------------------------------------
+
+struct RequesterActor {
+    worker_ref: ActorRef<WorkerActor>,
+    received_results: Vec<String>,
+}
+
+impl Actor for RequesterActor {
+    type Args = ActorRef<WorkerActor>;
+    type Error = anyhow::Error;
+
+    async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
+        println!("RequesterActor started");
+        Ok(RequesterActor {
+            worker_ref: args,
+            received_results: Vec::new(),
+        })
+    }
+}
+
+// Message to request work from Worker
+struct RequestWork {
+    task_id: usize,
+    data: String,
+}
+
+impl Message<RequestWork> for RequesterActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: RequestWork, actor_ref: &ActorRef<Self>) -> Self::Reply {
+        println!("RequesterActor sending work request for task {}", msg.task_id);
+
+        // Send request to the worker actor
+        let requester = actor_ref.clone();
+
+        // Request the worker to process our task
+        self.worker_ref.tell(ProcessTask {
+            task_id: msg.task_id,
+            data: msg.data,
+            requester,
+        }).await.expect("Failed to send task to worker");
+    }
+}
+
+// Message received when work is completed
+struct WorkCompleted {
+    task_id: usize,
+    result: String,
+}
+
+impl Message<WorkCompleted> for RequesterActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: WorkCompleted, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        println!("RequesterActor received result for task {}: {}", msg.task_id, msg.result);
+        self.received_results.push(msg.result);
+    }
+}
+
+// Message to get all results received so far
+struct GetResults;
+
+impl Message<GetResults> for RequesterActor {
+    type Reply = Vec<String>;
+
+    async fn handle(&mut self, _msg: GetResults, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        self.received_results.clone()
+    }
+}
+
+// Implement the MessageHandler trait for RequesterActor
+rsactor::impl_message_handler!(RequesterActor, [RequestWork, WorkCompleted, GetResults]);
+
+// -------------------------------------------------------------------
+// Actor B (Worker) - Processes work in tokio tasks and replies back
+// -------------------------------------------------------------------
+
+struct WorkerActor;
+
+impl Actor for WorkerActor {
+    type Args = ();
+    type Error = anyhow::Error;
+
+    async fn on_start(_args: Self::Args, _actor_ref: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
+        println!("WorkerActor started");
+        Ok(WorkerActor)
+    }
+}
+
+// Message to process a task
+struct ProcessTask {
+    task_id: usize,
+    data: String,
+    requester: ActorRef<RequesterActor>,
+}
+
+impl Message<ProcessTask> for WorkerActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: ProcessTask, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        let task_id = msg.task_id;
+        let data = msg.data;
+        let requester = msg.requester;
+
+        println!("WorkerActor received task {}: {}", task_id, data);
+
+        // Spawn a task to do the processing asynchronously
+        tokio::spawn(async move {
+            // Simulate some processing time
+            let processing_time = (task_id % 3 + 1) as u64;
+            println!("Processing task {} will take {} seconds", task_id, processing_time);
+            tokio::time::sleep(Duration::from_secs(processing_time)).await;
+
+            // Generate a result
+            let result = format!("Result of task {} with data '{}' (took {}s)",
+                task_id, data, processing_time);
+
+            // Send the result back to the requester
+            match requester.tell(WorkCompleted { task_id, result }).await {
+                Ok(_) => println!("Worker sent back result for task {}", task_id),
+                Err(e) => eprintln!("Failed to send result for task {}: {:?}", task_id, e),
+            }
+        });
+    }
+}
+
+// Implement the MessageHandler trait for WorkerActor
+rsactor::impl_message_handler!(WorkerActor, [ProcessTask]);
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logger
+    env_logger::init();
+
+    // Create the actors
+    let (worker_ref, worker_handle) = rsactor::spawn::<WorkerActor>(());
+    let (requester_ref, requester_handle) = rsactor::spawn::<RequesterActor>(worker_ref.clone());
+
+    // Send multiple work requests
+    for i in 1..=5 {
+        requester_ref.tell(RequestWork {
+            task_id: i,
+            data: format!("Task data {}", i),
+        }).await?;
+    }
+
+    // Wait a bit for all tasks to complete
+    println!("Waiting for all tasks to complete...");
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    // Get all results from the requester
+    let results = requester_ref.ask(GetResults).await?;
+    println!("\nAll received results:");
+    for (i, result) in results.iter().enumerate() {
+        println!("{}: {}", i + 1, result);
+    }
+
+    // Gracefully stop the actors
+    requester_ref.stop().await?;
+    worker_ref.stop().await?;
+
+    // Wait for actors to complete
+    let _requester_result = requester_handle.await?;
+    let _worker_result = worker_handle.await?;
+
+    println!("Example completed successfully");
+    Ok(())
+}

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -26,22 +26,62 @@ impl std::fmt::Display for FailurePhase {
 }
 
 /// Result type returned when an actor's lifecycle completes.
+///
+/// `ActorResult` encapsulates the final state of an actor after its lifecycle has ended,
+/// whether it completed successfully or failed. It provides detailed information about
+/// the actor's termination state, including:
+///
+/// - Whether the actor completed successfully or failed
+/// - Whether the actor was killed forcefully or stopped gracefully
+/// - The phase in which a failure occurred (if applicable)
+/// - The actor instance itself (if recoverable)
+/// - The error that caused a failure (if applicable)
+///
+/// This enum is typically returned by actor supervision systems or when awaiting the
+/// completion of an actor's task.
 #[derive(Debug)]
 pub enum ActorResult<T: Actor> {
     /// Actor completed successfully and can be recovered.
+    ///
+    /// This variant indicates that the actor finished its lifecycle without errors.
     Completed {
+        /// The successfully completed actor instance
         actor: T,
+        /// Whether the actor was killed (`true`) or stopped gracefully (`false`)
         killed: bool,
     },
     /// Actor failed during one of its lifecycle phases.
+    ///
+    /// This variant indicates that the actor encountered an error during execution.
     Failed {
+        /// The actor instance (if recoverable), or None if not recoverable.
+        /// This will be `None` specifically when the failure occurred during the `on_start` phase,
+        /// as the actor wasn't fully initialized.
         actor: Option<T>,
+        /// The error that caused the failure
         error: T::Error,
+        /// The lifecycle phase during which the failure occurred
         phase: FailurePhase,
+        /// Whether the actor was killed (`true`) or was attempting to stop gracefully (`false`)
         killed: bool,
     },
 }
 
+/// Conversion from ActorResult to a tuple of (Option<Actor>, Option<Error>)
+///
+/// This allows extracting both the actor instance and error (if any) in a single operation.
+/// Useful for pattern matching and destructuring in supervision contexts.
+///
+/// # Example
+/// ```ignore
+/// let (maybe_actor, maybe_error) = actor_result.into();
+/// if let Some(actor) = maybe_actor {
+///     // The actor is available (either completed or recovered after failure)
+/// }
+/// if let Some(error) = maybe_error {
+///     // An error occurred
+/// }
+/// ```
 impl<T: Actor> From<ActorResult<T>> for (Option<T>, Option<T::Error>) {
     fn from(result: ActorResult<T>) -> Self {
         match result {
@@ -54,36 +94,62 @@ impl<T: Actor> From<ActorResult<T>> for (Option<T>, Option<T::Error>) {
 
 impl<T: Actor> ActorResult<T> {
     /// Returns `true` if the actor completed successfully.
+    ///
+    /// This method checks if the actor finished its lifecycle without any errors,
+    /// regardless of whether it was killed or stopped normally.
     pub fn is_completed(&self) -> bool {
         matches!(self, ActorResult::Completed { .. })
     }
 
     /// Returns `true` if the actor was killed.
+    ///
+    /// An actor is considered killed if it was terminated forcefully via the `kill()` method,
+    /// regardless of whether it completed successfully or failed. Both `ActorResult::Completed`
+    /// and `ActorResult::Failed` can have `killed: true`.
     pub fn was_killed(&self) -> bool {
         matches!(self, ActorResult::Completed { killed: true, .. } | ActorResult::Failed { killed: true, .. })
     }
 
     /// Returns `true` if the actor stopped normally.
+    ///
+    /// An actor stopped normally if it completed successfully without being killed,
+    /// typically by processing a `StopGracefully` message or reaching the end of its lifecycle.
     pub fn stopped_normally(&self) -> bool {
         matches!(self, ActorResult::Completed { killed: false, .. })
     }
 
     /// Returns `true` if the actor failed to start.
+    ///
+    /// This indicates that the actor failed during the `on_start` lifecycle phase,
+    /// which means it couldn't initialize properly.
     pub fn is_startup_failed(&self) -> bool {
         matches!(self, ActorResult::Failed { phase: FailurePhase::OnStart, .. })
     }
 
     /// Returns `true` if the actor failed during runtime.
+    ///
+    /// This indicates that the actor started successfully but encountered an error
+    /// during its normal operation in the `on_run` lifecycle phase.
     pub fn is_runtime_failed(&self) -> bool {
         matches!(self, ActorResult::Failed { phase: FailurePhase::OnRun, .. })
     }
 
     /// Returns `true` if the actor failed during the stop phase.
+    ///
+    /// This indicates that the actor encountered an error while trying to shut down
+    /// in the `on_stop` lifecycle phase.
     pub fn is_stop_failed(&self) -> bool {
         matches!(self, ActorResult::Failed { phase: FailurePhase::OnStop, .. })
     }
 
     /// Returns the actor instance if available, regardless of the result type.
+    ///
+    /// If the actor completed successfully, it will always return `Some(actor)`.
+    /// If the actor failed, it may return `Some(actor)` or `None` depending on
+    /// when the failure occurred and if the actor instance could be recovered.
+    ///
+    /// If the failure occurred during the `on_start` phase, this will return `None`
+    /// since the actor was not successfully initialized.
     pub fn actor(&self) -> Option<&T> {
         match self {
             ActorResult::Completed { actor, .. } => Some(actor),
@@ -92,6 +158,9 @@ impl<T: Actor> ActorResult<T> {
     }
 
     /// Consumes the result and returns the actor instance if available.
+    ///
+    /// This method is similar to `actor()` but it consumes the `ActorResult`,
+    /// giving ownership of the actor to the caller if available.
     pub fn into_actor(self) -> Option<T> {
         match self {
             ActorResult::Completed { actor, .. } => Some(actor),
@@ -100,6 +169,9 @@ impl<T: Actor> ActorResult<T> {
     }
 
     /// Returns the error if the result represents a failure.
+    ///
+    /// If the actor completed successfully, this returns `None`.
+    /// If the actor failed, this returns `Some(error)` containing the error that caused the failure.
     pub fn error(&self) -> Option<&T::Error> {
         match self {
             ActorResult::Completed { .. } => None,
@@ -108,6 +180,9 @@ impl<T: Actor> ActorResult<T> {
     }
 
     /// Consumes the result and returns the error if it represents a failure.
+    ///
+    /// This method is similar to `error()` but it consumes the `ActorResult`,
+    /// giving ownership of the error to the caller if available.
     pub fn into_error(self) -> Option<T::Error> {
         match self {
             ActorResult::Completed { .. } => None,
@@ -116,16 +191,24 @@ impl<T: Actor> ActorResult<T> {
     }
 
     /// Returns true if the result represents any kind of failure.
+    ///
+    /// This is the logical opposite of `is_completed()`.
     pub fn is_failed(&self) -> bool {
         !self.is_completed()
     }
 
     /// Returns true if the result contains an actor instance.
+    ///
+    /// This checks if the actor instance is available, regardless of
+    /// whether the actor completed successfully or failed.
     pub fn has_actor(&self) -> bool {
         self.actor().is_some()
     }
 
     /// Converts to a standard Result, preserving the actor on success
+    ///
+    /// This transforms the `ActorResult<T>` into a `Result<T, T::Error>`,
+    /// which is useful for integrating with Rust's standard error handling patterns.
     pub fn to_result(self) -> std::result::Result<T, T::Error> {
         match self {
             ActorResult::Completed { actor, .. } => Ok(actor),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,11 +298,17 @@ macro_rules! __impl_message_handler_body {
 /// ## Non-generic form:
 /// * `$actor_type:ty`: The type of the actor for which to implement `MessageHandler`.
 /// * `[$($msg_type:ty),* $(,)?]`: A list of message types that the actor can handle.
+/// ```ignore
+/// impl_message_handler!(MyActor, [Msg1, Msg2]);
+/// ```
 ///
 /// ## Generic form:
 /// * `[$($generics:tt)*]`: Generic type parameters with their trait bounds (as token tree to handle complex bounds)
 /// * `for $actor_type:ty`: The generic actor type for which to implement `MessageHandler`
 /// * `[$($msg_type:ty),* $(,)?]`: A list of message types that the actor can handle
+/// ```ignore
+/// impl_message_handler!([T: Send + Debug + Clone + 'static] for GenericActor<T>, [SetValue<T>, GetValue]);
+/// ```
 ///
 /// # Internals
 /// This macro facilitates dynamic message dispatch by downcasting `Box<dyn std::any::Any + Send>`


### PR DESCRIPTION
This pull request introduces a new example demonstrating asynchronous communication between actors (`RequesterActor` and `WorkerActor`) and significantly enhances the documentation for the `Actor` trait and related components in the library. The most important changes are grouped into two themes: the new example and documentation improvements.

### New Example: Asynchronous Actor Communication
* Added a new example in `examples/actor_async_worker.rs` showcasing how `RequesterActor` can send work requests to `WorkerActor`, which processes tasks asynchronously and sends the results back. The example demonstrates actor lifecycle methods, message handling, and asynchronous task spawning.

### Documentation Improvements
#### `Actor` Trait Enhancements:
* Expanded documentation for error handling in actor lifecycle methods (`on_start`, `on_run`, `on_stop`), detailing how errors are captured in `ActorResult` and providing examples for proper error recovery.
* Improved descriptions of the `on_start`, `on_run`, and `on_stop` methods, including initialization strategies, termination handling, and cleanup operations. Added examples for practical usage. [[1]](diffhunk://#diff-9749c81c451c5ee39af38e72bdca1c6ed288534831f70214e74247074cc6b8aaL132-R237) [[2]](diffhunk://#diff-9749c81c451c5ee39af38e72bdca1c6ed288534831f70214e74247074cc6b8aaL145-R252) [[3]](diffhunk://#diff-9749c81c451c5ee39af38e72bdca1c6ed288534831f70214e74247074cc6b8aaL164-R300)

#### Actor References and Results:
* Updated `ActorRef` and `UntypedActorRef` documentation to include detailed usage guidelines, benefits of type safety, and an overview of message passing methods (e.g., `ask`, `tell`, `stop`, `kill`). [[1]](diffhunk://#diff-220ad64f66ab8d70e463501b8ba5cea5f22ce523d6cd4488ad5e56270464d885L20-R32) [[2]](diffhunk://#diff-220ad64f66ab8d70e463501b8ba5cea5f22ce523d6cd4488ad5e56270464d885R392-R441)
* Enhanced `ActorResult` documentation to clarify the meaning of its variants (`Completed`, `Failed`) and added examples for extracting actor state and errors.