### PR TITLE
Refactor CounterActor example by removing unused intervals and messag…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Jeff Kim <hiking90@gmail.com>"]
 repository = "https://github.com/hiking90/rsactor"
 homepage = "https://github.com/hiking90/rsactor"
 license = "Apache-2.0"
+readme = "README.md"
 keywords = ["actor", "rust", "framework"]
 
 [dependencies]


### PR DESCRIPTION
This pull request makes several updates to the `rsactor` project, including adding a `readme` field to the `Cargo.toml` file and simplifying the example code in the `README.md` file by removing unused features and redundant examples. The changes aim to streamline the codebase and improve clarity for users.

### Metadata Improvements:
* Added a `readme` field to the `Cargo.toml` file to specify the project's README file (`README.md`). This ensures better integration with tools like `crates.io`.

### Simplifications in Example Code:
* Removed unused imports (`tokio::time::Interval`) and associated logic (e.g., `tick_300ms` and `tick_1s`) from the example actor implementation in `README.md`. This simplifies the example and focuses on the core actor functionality. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-L51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-L101)
* Removed the `GetCountMsg` message type and its handling logic to streamline the example. The example now focuses solely on the `IncrementMsg` message type.
* Simplified the `main` function by removing redundant logic, such as inspecting `ActorResult` and using `ask` for `GetCountMsg`. The actor is now explicitly stopped using `actor_ref.stop()` for clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-L166)

### Documentation Cleanup:
* Removed the "Using Blocking Functions with Tokio Tasks" section from the `README.md`. This section contained advanced usage examples (`ask_blocking` and `tell_blocking`) that are no longer necessary for the simplified example.…e handling