### PR TITLE
Enhance Actor derive macro documentation: support for enums and impro…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,12 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "log"
@@ -379,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -491,18 +485,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,18 +627,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ keywords.workspace = true
 [dependencies]
 tokio.workspace = true
 log.workspace = true
-rsactor-derive = { path = "rsactor-derive" }
+rsactor-derive = { version = "0.8", path = "rsactor-derive" }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/rsactor-derive/src/lib.rs
+++ b/rsactor-derive/src/lib.rs
@@ -9,17 +9,18 @@
 //! ## Actor Derive Macro
 //!
 //! The `#[derive(Actor)]` macro provides a convenient way to implement the Actor trait
-//! for simple structs that don't require complex initialization logic.
+//! for simple structs and enums that don't require complex initialization logic.
 //!
 //! ### Generated Implementation
 //!
 //! When you use `#[derive(Actor)]`, it generates:
-//! - `Args` type set to `Self` (the struct itself)
+//! - `Args` type set to `Self` (the struct or enum itself)
 //! - `Error` type set to `std::convert::Infallible` (never fails)
 //! - `on_start` method that simply returns the provided args
 //!
 //! ### Usage
 //!
+//! #### With Structs
 //! ```rust
 //! use rsactor::Actor;
 //!
@@ -27,6 +28,18 @@
 //! struct MyActor {
 //!     name: String,
 //!     count: u32,
+//! }
+//! ```
+//!
+//! #### With Enums
+//! ```rust
+//! use rsactor::Actor;
+//!
+//! #[derive(Actor)]
+//! enum StateActor {
+//!     Idle,
+//!     Processing(String),
+//!     Completed(i32),
 //! }
 //! ```
 //!
@@ -72,14 +85,27 @@ use syn::{parse_macro_input, Data, DeriveInput};
 /// - `Error` type is set to `std::convert::Infallible`
 /// - `on_start` method returns the args as the actor instance
 ///
-/// # Example
+/// # Examples
 ///
+/// ## Struct Actor
 /// ```rust
 /// use rsactor::Actor;
 ///
 /// #[derive(Actor)]
 /// struct MyActor {
 ///     name: String,
+/// }
+/// ```
+///
+/// ## Enum Actor
+/// ```rust
+/// use rsactor::Actor;
+///
+/// #[derive(Actor)]
+/// enum StateActor {
+///     Idle,
+///     Processing(String),
+///     Completed(i32),
 /// }
 /// ```
 ///
@@ -102,7 +128,7 @@ use syn::{parse_macro_input, Data, DeriveInput};
 ///
 /// # Limitations
 ///
-/// - Only works on structs (not enums or unions)
+/// - Only works on structs and enums (not unions)
 /// - Generates a very basic implementation - for complex initialization logic,
 ///   implement the Actor trait manually
 #[proc_macro_derive(Actor)]
@@ -120,9 +146,9 @@ pub fn derive_actor(input: TokenStream) -> TokenStream {
 fn derive_actor_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
     let name = &input.ident;
 
-    // Check if it's a struct
+    // Check if it's a struct or enum
     match &input.data {
-        Data::Struct(_) => {
+        Data::Struct(_) | Data::Enum(_) => {
             // Generate the Actor implementation
             let expanded = quote! {
                 impl rsactor::Actor for #name {
@@ -142,7 +168,7 @@ fn derive_actor_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
         }
         _ => Err(syn::Error::new_spanned(
             name,
-            "Actor derive macro can only be used on structs",
+            "Actor derive macro can only be used on structs and enums",
         )),
     }
 }

--- a/tests/derive_macro_tests.rs
+++ b/tests/derive_macro_tests.rs
@@ -1,4 +1,4 @@
-// Tests for the Actor derive macro
+// Tests for the Actor derive macro (structs and enums)
 
 use rsactor::{impl_message_handler, spawn, Actor, ActorRef, Message};
 
@@ -166,6 +166,273 @@ async fn test_derive_actor_tuple_struct() {
 
     assert_eq!(first, "hello");
     assert_eq!(second, 456);
+
+    actor_ref.stop().await.unwrap();
+}
+
+// Test with an enum
+#[derive(Actor, Debug, Clone)]
+enum StateActor {
+    Idle,
+    Processing(String),
+    Completed(i32),
+}
+
+struct GetState;
+struct SetState(StateActor);
+struct IsIdle;
+struct GetProcessingData;
+struct GetCompletedValue;
+
+impl Message<GetState> for StateActor {
+    type Reply = StateActor;
+
+    async fn handle(&mut self, _msg: GetState, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        self.clone()
+    }
+}
+
+impl Message<SetState> for StateActor {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: SetState, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        *self = msg.0;
+    }
+}
+
+impl Message<IsIdle> for StateActor {
+    type Reply = bool;
+
+    async fn handle(&mut self, _msg: IsIdle, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        matches!(self, StateActor::Idle)
+    }
+}
+
+impl Message<GetProcessingData> for StateActor {
+    type Reply = Option<String>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetProcessingData,
+        _actor_ref: &ActorRef<Self>,
+    ) -> Self::Reply {
+        match self {
+            StateActor::Processing(data) => Some(data.clone()),
+            _ => None,
+        }
+    }
+}
+
+impl Message<GetCompletedValue> for StateActor {
+    type Reply = Option<i32>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetCompletedValue,
+        _actor_ref: &ActorRef<Self>,
+    ) -> Self::Reply {
+        match self {
+            StateActor::Completed(value) => Some(*value),
+            _ => None,
+        }
+    }
+}
+
+impl_message_handler!(
+    StateActor,
+    [
+        GetState,
+        SetState,
+        IsIdle,
+        GetProcessingData,
+        GetCompletedValue
+    ]
+);
+
+#[tokio::test]
+async fn test_derive_actor_enum_basic() {
+    let actor_instance = StateActor::Idle;
+    let (actor_ref, _join_handle) = spawn::<StateActor>(actor_instance);
+
+    // Test initial state
+    let is_idle = actor_ref.ask(IsIdle).await.unwrap();
+    assert!(is_idle);
+
+    let state = actor_ref.ask(GetState).await.unwrap();
+    assert!(matches!(state, StateActor::Idle));
+
+    actor_ref.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_derive_actor_enum_state_transitions() {
+    let actor_instance = StateActor::Idle;
+    let (actor_ref, _join_handle) = spawn::<StateActor>(actor_instance);
+
+    // Transition to Processing state
+    actor_ref
+        .tell(SetState(StateActor::Processing("working".to_string())))
+        .await
+        .unwrap();
+
+    let is_idle = actor_ref.ask(IsIdle).await.unwrap();
+    assert!(!is_idle);
+
+    let processing_data = actor_ref.ask(GetProcessingData).await.unwrap();
+    assert_eq!(processing_data, Some("working".to_string()));
+
+    // Transition to Completed state
+    actor_ref
+        .tell(SetState(StateActor::Completed(42)))
+        .await
+        .unwrap();
+
+    let completed_value = actor_ref.ask(GetCompletedValue).await.unwrap();
+    assert_eq!(completed_value, Some(42));
+
+    let processing_data = actor_ref.ask(GetProcessingData).await.unwrap();
+    assert_eq!(processing_data, None);
+
+    actor_ref.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_derive_actor_enum_variant_data() {
+    // Test with Processing variant
+    let actor_instance = StateActor::Processing("initial_task".to_string());
+    let (actor_ref, _join_handle) = spawn::<StateActor>(actor_instance);
+
+    let processing_data = actor_ref.ask(GetProcessingData).await.unwrap();
+    assert_eq!(processing_data, Some("initial_task".to_string()));
+
+    let is_idle = actor_ref.ask(IsIdle).await.unwrap();
+    assert!(!is_idle);
+
+    actor_ref.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_derive_actor_enum_completed_variant() {
+    // Test with Completed variant
+    let actor_instance = StateActor::Completed(100);
+    let (actor_ref, _join_handle) = spawn::<StateActor>(actor_instance);
+
+    let completed_value = actor_ref.ask(GetCompletedValue).await.unwrap();
+    assert_eq!(completed_value, Some(100));
+
+    let processing_data = actor_ref.ask(GetProcessingData).await.unwrap();
+    assert_eq!(processing_data, None);
+
+    let is_idle = actor_ref.ask(IsIdle).await.unwrap();
+    assert!(!is_idle);
+
+    actor_ref.stop().await.unwrap();
+}
+
+// Test with a simple enum without data
+#[derive(Actor, Debug, Clone, PartialEq)]
+enum DirectionActor {
+    North,
+    South,
+    East,
+    West,
+}
+
+struct GetDirection;
+struct TurnRight;
+struct TurnLeft;
+
+impl Message<GetDirection> for DirectionActor {
+    type Reply = DirectionActor;
+
+    async fn handle(&mut self, _msg: GetDirection, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        self.clone()
+    }
+}
+
+impl Message<TurnRight> for DirectionActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: TurnRight, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        *self = match self {
+            DirectionActor::North => DirectionActor::East,
+            DirectionActor::East => DirectionActor::South,
+            DirectionActor::South => DirectionActor::West,
+            DirectionActor::West => DirectionActor::North,
+        };
+    }
+}
+
+impl Message<TurnLeft> for DirectionActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _msg: TurnLeft, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+        *self = match self {
+            DirectionActor::North => DirectionActor::West,
+            DirectionActor::West => DirectionActor::South,
+            DirectionActor::South => DirectionActor::East,
+            DirectionActor::East => DirectionActor::North,
+        };
+    }
+}
+
+impl_message_handler!(DirectionActor, [GetDirection, TurnRight, TurnLeft]);
+
+#[tokio::test]
+async fn test_derive_actor_simple_enum() {
+    let actor_instance = DirectionActor::North;
+    let (actor_ref, _join_handle) = spawn::<DirectionActor>(actor_instance);
+
+    // Test initial direction
+    let direction = actor_ref.ask(GetDirection).await.unwrap();
+    assert_eq!(direction, DirectionActor::North);
+
+    // Turn right: North -> East
+    actor_ref.tell(TurnRight).await.unwrap();
+    let direction = actor_ref.ask(GetDirection).await.unwrap();
+    assert_eq!(direction, DirectionActor::East);
+
+    // Turn right: East -> South
+    actor_ref.tell(TurnRight).await.unwrap();
+    let direction = actor_ref.ask(GetDirection).await.unwrap();
+    assert_eq!(direction, DirectionActor::South);
+
+    // Turn left: South -> East
+    actor_ref.tell(TurnLeft).await.unwrap();
+    let direction = actor_ref.ask(GetDirection).await.unwrap();
+    assert_eq!(direction, DirectionActor::East);
+
+    actor_ref.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_derive_actor_enum_full_rotation() {
+    let actor_instance = DirectionActor::North;
+    let (actor_ref, _join_handle) = spawn::<DirectionActor>(actor_instance);
+
+    // Full right rotation
+    for expected in [
+        DirectionActor::East,
+        DirectionActor::South,
+        DirectionActor::West,
+        DirectionActor::North,
+    ] {
+        actor_ref.tell(TurnRight).await.unwrap();
+        let direction = actor_ref.ask(GetDirection).await.unwrap();
+        assert_eq!(direction, expected);
+    }
+
+    // Full left rotation
+    for expected in [
+        DirectionActor::West,
+        DirectionActor::South,
+        DirectionActor::East,
+        DirectionActor::North,
+    ] {
+        actor_ref.tell(TurnLeft).await.unwrap();
+        let direction = actor_ref.ask(GetDirection).await.unwrap();
+        assert_eq!(direction, expected);
+    }
 
     actor_ref.stop().await.unwrap();
 }


### PR DESCRIPTION
This pull request introduces support for enums in the `#[derive(Actor)]` macro, enhancing its flexibility and functionality. It also includes updates to documentation, tests, and examples to reflect the new capabilities.

### Enhancements to `#[derive(Actor)]` Macro:

* Expanded the macro to support enums in addition to structs, allowing for more versatile actor definitions. Updated the implementation logic to handle enums (`Data::Struct(_) | Data::Enum(_)`) and adjusted error messaging accordingly. (`rsactor-derive/src/lib.rs`, [[1]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eL123-R151) [[2]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eL145-R171)

### Documentation Updates:

* Updated documentation in `rsactor-derive/src/lib.rs` to include examples and usage details for enums, alongside structs. Added sections like "#### With Enums" and "## Enum Actor" to clarify usage. (`rsactor-derive/src/lib.rs`, [[1]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eL12-R23) [[2]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eR34-R45) [[3]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eL75-R90) [[4]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eR100-R111) [[5]](diffhunk://#diff-5e23d711b211bf943cf2907a9ffac374952c2139b7944cbffce9ce7ba4eaa20eL105-R131)
* Updated `src/lib.rs` to highlight the new enum support in the macro and provide a detailed example of a state machine actor implemented using enums. (`src/lib.rs`, [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L46-R46) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R91-R145)

### Testing Enhancements:

* Added comprehensive tests for enums in `tests/derive_macro_tests.rs`, including scenarios for state transitions, variant data handling, and simple enums without data. Examples include `StateActor` and `DirectionActor`. (`tests/derive_macro_tests.rs`, [tests/derive_macro_tests.rsR172-R438](diffhunk://#diff-f10bcda045f617834f349663b6c23a94e28982146e115a2acf6428bae8aae5dbR172-R438))

### Dependency Updates:

* Updated `Cargo.toml` to specify the version for `rsactor-derive` dependency (`0.8`) for better dependency management. (`Cargo.toml`, [Cargo.tomlL42-R42](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L42-R42))…ve examples