### PR TITLE
Introduce #[message_handlers] macro and refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.0] - 2025-06-28
+
+### Added
+- `#[message_handlers]` attribute macro with `#[handler]` method attributes for simplified message handling
+- Comprehensive migration guide for moving from `impl_message_handler!` to the new macro approach
+- Better documentation showcasing the recommended patterns
+
+### Deprecated
+- `impl_message_handler!` macro - Use `#[message_handlers]` with `#[handler]` attributes instead
+- `__impl_message_handler_body!` internal helper macro
+- Manual `Message<T>` trait implementations when using the new macro approach
+
+### Changed
+- Documentation now prioritizes the `#[message_handlers]` approach as the recommended method
+- Updated examples to demonstrate the new macro patterns
+- Added migration timeline: deprecated macros will be removed in version 1.0
+
+### Migration Guide
+To migrate from the deprecated approach:
+
+**Before:**
+```rust
+impl Message<MyMessage> for MyActor {
+    type Reply = String;
+    async fn handle(&mut self, msg: MyMessage, actor_ref: &ActorRef<Self>) -> Self::Reply {
+        "response".to_string()
+    }
+}
+
+impl_message_handler!(MyActor, [MyMessage]);
+```
+
+**After:**
+```rust
+#[message_handlers]
+impl MyActor {
+    #[handler]
+    async fn handle_my_message(&mut self, msg: MyMessage, actor_ref: &ActorRef<Self>) -> String {
+        "response".to_string()
+    }
+}
+```
+
+### Breaking Changes
+None in this release. The deprecated macros continue to work but will emit deprecation warnings.
+
+### Note
+The deprecated `impl_message_handler!` macro will be removed in version 1.0. Please migrate to the new `#[message_handlers]` approach.

--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -121,28 +121,26 @@ impl WorkerActor {
         let data = msg.data;
         let requester = msg.requester;
 
-        println!("WorkerActor received task {}: {}", task_id, data);
+        println!("WorkerActor received task {task_id}: {data}");
 
         // Spawn a task to do the processing asynchronously
         tokio::spawn(async move {
             // Simulate some processing time
             let processing_time = (task_id % 3 + 1) as u64;
             println!(
-                "Processing task {} will take {} seconds",
-                task_id, processing_time
+                "Processing task {task_id} will take {processing_time} seconds"
             );
             tokio::time::sleep(Duration::from_secs(processing_time)).await;
 
             // Generate a result
             let result = format!(
-                "Result of task {} with data '{}' (took {}s)",
-                task_id, data, processing_time
+                "Result of task {task_id} with data '{data}' (took {processing_time}s)"
             );
 
             // Send the result back to the requester
             match requester.tell(WorkCompleted { task_id, result }).await {
-                Ok(_) => println!("Worker sent back result for task {}", task_id),
-                Err(e) => eprintln!("Failed to send result for task {}: {:?}", task_id, e),
+                Ok(_) => println!("Worker sent back result for task {task_id}"),
+                Err(e) => eprintln!("Failed to send result for task {task_id}: {e:?}"),
             }
         });
     }
@@ -162,7 +160,7 @@ async fn main() -> Result<()> {
         requester_ref
             .tell(RequestWork {
                 task_id: i,
-                data: format!("Task data {}", i),
+                data: format!("Task data {i}"),
             })
             .await?;
     }

--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -2,7 +2,7 @@
 // which processes the work in a spawned async task and sends the results back to Actor A
 
 use anyhow::Result;
-use rsactor::{Actor, ActorRef, Message};
+use rsactor::{message_handlers, Actor, ActorRef};
 use tokio::time::Duration;
 
 // -------------------------------------------------------------------
@@ -36,10 +36,19 @@ struct RequestWork {
     data: String,
 }
 
-impl Message<RequestWork> for RequesterActor {
-    type Reply = ();
+// Message received when work is completed
+struct WorkCompleted {
+    task_id: usize,
+    result: String,
+}
 
-    async fn handle(&mut self, msg: RequestWork, actor_ref: &ActorRef<Self>) -> Self::Reply {
+// Message to get all results received so far
+struct GetResults;
+
+#[message_handlers]
+impl RequesterActor {
+    #[handler]
+    async fn handle_request_work(&mut self, msg: RequestWork, actor_ref: &ActorRef<Self>) {
         println!(
             "RequesterActor sending work request for task {}",
             msg.task_id
@@ -58,39 +67,25 @@ impl Message<RequestWork> for RequesterActor {
             .await
             .expect("Failed to send task to worker");
     }
-}
 
-// Message received when work is completed
-struct WorkCompleted {
-    task_id: usize,
-    result: String,
-}
-
-impl Message<WorkCompleted> for RequesterActor {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: WorkCompleted, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_work_completed(&mut self, msg: WorkCompleted, _actor_ref: &ActorRef<Self>) {
         println!(
             "RequesterActor received result for task {}: {}",
             msg.task_id, msg.result
         );
         self.received_results.push(msg.result);
     }
-}
 
-// Message to get all results received so far
-struct GetResults;
-
-impl Message<GetResults> for RequesterActor {
-    type Reply = Vec<String>;
-
-    async fn handle(&mut self, _msg: GetResults, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_results(
+        &mut self,
+        _msg: GetResults,
+        _actor_ref: &ActorRef<Self>,
+    ) -> Vec<String> {
         self.received_results.clone()
     }
 }
-
-// Implement the MessageHandler trait for RequesterActor
-rsactor::impl_message_handler!(RequesterActor, [RequestWork, WorkCompleted, GetResults]);
 
 // -------------------------------------------------------------------
 // Actor B (Worker) - Processes work in tokio tasks and replies back
@@ -118,10 +113,10 @@ struct ProcessTask {
     requester: ActorRef<RequesterActor>,
 }
 
-impl Message<ProcessTask> for WorkerActor {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: ProcessTask, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl WorkerActor {
+    #[handler]
+    async fn handle_process_task(&mut self, msg: ProcessTask, _actor_ref: &ActorRef<Self>) {
         let task_id = msg.task_id;
         let data = msg.data;
         let requester = msg.requester;
@@ -152,9 +147,6 @@ impl Message<ProcessTask> for WorkerActor {
         });
     }
 }
-
-// Implement the MessageHandler trait for WorkerActor
-rsactor::impl_message_handler!(WorkerActor, [ProcessTask]);
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -127,15 +127,12 @@ impl WorkerActor {
         tokio::spawn(async move {
             // Simulate some processing time
             let processing_time = (task_id % 3 + 1) as u64;
-            println!(
-                "Processing task {task_id} will take {processing_time} seconds"
-            );
+            println!("Processing task {task_id} will take {processing_time} seconds");
             tokio::time::sleep(Duration::from_secs(processing_time)).await;
 
             // Generate a result
-            let result = format!(
-                "Result of task {task_id} with data '{data}' (took {processing_time}s)"
-            );
+            let result =
+                format!("Result of task {task_id} with data '{data}' (took {processing_time}s)");
 
             // Send the result back to the requester
             match requester.tell(WorkCompleted { task_id, result }).await {

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -226,9 +226,7 @@ async fn main() -> Result<()> {
     // Get the current state
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
-    println!(
-        "Current state: factor={factor:.2}, latest_value={latest_value:?}"
-    );
+    println!("Current state: factor={factor:.2}, latest_value={latest_value:?}");
 
     if let Some(ts) = timestamp {
         println!("Data age: {:?}", ts.elapsed());
@@ -258,9 +256,7 @@ async fn main() -> Result<()> {
     // Get the updated state
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
-    println!(
-        "Updated state: factor={factor:.2}, latest_value={latest_value:?}"
-    );
+    println!("Updated state: factor={factor:.2}, latest_value={latest_value:?}");
 
     if let Some(ts) = timestamp {
         println!("Data age: {:?}", ts.elapsed());

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -94,7 +94,7 @@ impl Actor for SyncDataProcessorActor {
                 let raw_value = rand::random::<f64>() * 100.0;
 
                 // Send the data to our actor using tell_blocking
-                debug!("Sync task sending value {:.2} to actor", raw_value);
+                debug!("Sync task sending value {raw_value:.2} to actor");
 
                 // Use tell_blocking which is designed for tokio blocking contexts
                 // Note: This requires access to a tokio runtime, which is available inside spawn_blocking
@@ -105,7 +105,7 @@ impl Actor for SyncDataProcessorActor {
                     },
                     None,
                 ) {
-                    info!("Failed to send data to actor: {}", e);
+                    info!("Failed to send data to actor: {e}");
                     running = false;
                 }
 
@@ -115,7 +115,7 @@ impl Actor for SyncDataProcessorActor {
                     // Command received
                     Ok(cmd) => match cmd {
                         TaskCommand::ChangeInterval(new_interval) => {
-                            info!("Sync task changing interval to {:?}", new_interval);
+                            info!("Sync task changing interval to {new_interval:?}");
                             interval = new_interval;
                         }
                         TaskCommand::Stop => {
@@ -227,8 +227,7 @@ async fn main() -> Result<()> {
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
     println!(
-        "Current state: factor={:.2}, latest_value={:?}",
-        factor, latest_value
+        "Current state: factor={factor:.2}, latest_value={latest_value:?}"
     );
 
     if let Some(ts) = timestamp {
@@ -238,7 +237,7 @@ async fn main() -> Result<()> {
     // Change the processing factor
     println!("Changing processing factor to 2.5...");
     let new_factor: f64 = actor_ref.ask(SetFactor(2.5)).await?;
-    println!("Factor changed to: {:.2}", new_factor);
+    println!("Factor changed to: {new_factor:.2}");
 
     // Change the task's data generation interval
     println!("Changing the sync task's data generation interval...");
@@ -260,8 +259,7 @@ async fn main() -> Result<()> {
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
     println!(
-        "Updated state: factor={:.2}, latest_value={:?}",
-        factor, latest_value
+        "Updated state: factor={factor:.2}, latest_value={latest_value:?}"
     );
 
     if let Some(ts) = timestamp {
@@ -279,7 +277,7 @@ async fn main() -> Result<()> {
 
     match result {
         rsactor::ActorResult::Completed { actor, killed } => {
-            println!("Actor completed successfully. Killed: {}", killed);
+            println!("Actor completed successfully. Killed: {killed}");
             println!(
                 "Final state: factor={:.2}, latest_value={:?}",
                 actor.factor, actor.latest_value

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -91,8 +91,7 @@ impl Actor for DataProcessorActor {
             self.latest_timestamp = Some(std::time::Instant::now());
 
             debug!(
-                "Generated data: original={:.2}, processed={:.2}",
-                raw_value, processed_value
+                "Generated data: original={raw_value:.2}, processed={processed_value:.2}"
             );
         }
     }
@@ -173,8 +172,7 @@ async fn main() -> Result<()> {
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
     println!(
-        "Current state: factor={:.2}, latest_value={:?}",
-        factor, latest_value
+        "Current state: factor={factor:.2}, latest_value={latest_value:?}"
     );
 
     if let Some(ts) = timestamp {
@@ -184,7 +182,7 @@ async fn main() -> Result<()> {
     // Change the processing factor
     println!("Changing processing factor to 2.5...");
     let new_factor: f64 = actor_ref.ask(SetFactor(2.5)).await?;
-    println!("Factor changed to: {:.2}", new_factor);
+    println!("Factor changed to: {new_factor:.2}");
 
     // Change the task's data generation interval
     println!("Changing the task's data generation interval...");
@@ -209,8 +207,7 @@ async fn main() -> Result<()> {
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
     println!(
-        "Updated state: factor={:.2}, latest_value={:?}",
-        factor, latest_value
+        "Updated state: factor={factor:.2}, latest_value={latest_value:?}"
     );
 
     if let Some(ts) = timestamp {
@@ -226,7 +223,7 @@ async fn main() -> Result<()> {
 
     match result {
         rsactor::ActorResult::Completed { actor, killed } => {
-            println!("Actor completed successfully. Killed: {}", killed);
+            println!("Actor completed successfully. Killed: {killed}");
             println!(
                 "Final state: factor={:.2}, latest_value={:?}",
                 actor.factor, actor.latest_value

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -90,9 +90,7 @@ impl Actor for DataProcessorActor {
             self.latest_value = Some(processed_value);
             self.latest_timestamp = Some(std::time::Instant::now());
 
-            debug!(
-                "Generated data: original={raw_value:.2}, processed={processed_value:.2}"
-            );
+            debug!("Generated data: original={raw_value:.2}, processed={processed_value:.2}");
         }
     }
 }
@@ -171,9 +169,7 @@ async fn main() -> Result<()> {
     // Get the current state
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
-    println!(
-        "Current state: factor={factor:.2}, latest_value={latest_value:?}"
-    );
+    println!("Current state: factor={factor:.2}, latest_value={latest_value:?}");
 
     if let Some(ts) = timestamp {
         println!("Data age: {:?}", ts.elapsed());
@@ -206,9 +202,7 @@ async fn main() -> Result<()> {
     // Get the updated state
     let (factor, latest_value, timestamp): (f64, Option<f64>, Option<std::time::Instant>) =
         actor_ref.ask(GetState).await?;
-    println!(
-        "Updated state: factor={factor:.2}, latest_value={latest_value:?}"
-    );
+    println!("Updated state: factor={factor:.2}, latest_value={latest_value:?}");
 
     if let Some(ts) = timestamp {
         println!("Data age: {:?}", ts.elapsed());

--- a/examples/actor_with_timeout.rs
+++ b/examples/actor_with_timeout.rs
@@ -88,9 +88,7 @@ async fn demonstrate_ask_with_timeout(
     match result {
         Ok(response) => {
             let elapsed = timer.elapsed().as_millis();
-            info!(
-                "✅ Success! Response received in {elapsed}ms: {response}"
-            );
+            info!("✅ Success! Response received in {elapsed}ms: {response}");
         }
         Err(e) => {
             let elapsed = timer.elapsed().as_millis();
@@ -236,9 +234,7 @@ async fn main() -> Result<()> {
             phase,
             ..
         } => {
-            info!(
-                "Actor stop failed: {error}. Killed: {killed}, Phase: {phase}"
-            );
+            info!("Actor stop failed: {error}. Killed: {killed}, Phase: {phase}");
         }
     }
     info!("Example finished successfully");

--- a/examples/actor_with_timeout.rs
+++ b/examples/actor_with_timeout.rs
@@ -89,13 +89,12 @@ async fn demonstrate_ask_with_timeout(
         Ok(response) => {
             let elapsed = timer.elapsed().as_millis();
             info!(
-                "✅ Success! Response received in {}ms: {}",
-                elapsed, response
+                "✅ Success! Response received in {elapsed}ms: {response}"
             );
         }
         Err(e) => {
             let elapsed = timer.elapsed().as_millis();
-            info!("❌ Failed after {}ms. Error: {}", elapsed, e);
+            info!("❌ Failed after {elapsed}ms. Error: {e}");
         }
     }
 }
@@ -119,11 +118,11 @@ async fn demonstrate_tell_with_timeout(
     match result {
         Ok(_) => {
             let elapsed = timer.elapsed().as_millis();
-            info!("✅ Success! Message sent in {}ms", elapsed);
+            info!("✅ Success! Message sent in {elapsed}ms");
         }
         Err(e) => {
             let elapsed = timer.elapsed().as_millis();
-            info!("❌ Failed to send after {}ms. Error: {}", elapsed, e);
+            info!("❌ Failed to send after {elapsed}ms. Error: {e}");
         }
     }
 }
@@ -149,8 +148,8 @@ async fn main() -> Result<()> {
         )
         .await;
     match &result1 {
-        Ok(response) => info!("✅ Success: {}", response),
-        Err(e) => info!("❌ Failed: {}", e),
+        Ok(response) => info!("✅ Success: {response}"),
+        Err(e) => info!("❌ Failed: {e}"),
     }
     assert!(
         result1.is_ok(),
@@ -166,8 +165,8 @@ async fn main() -> Result<()> {
         )
         .await;
     match &result2 {
-        Ok(response) => info!("✅ Success: {}", response),
-        Err(e) => info!("❌ Failed: {}", e),
+        Ok(response) => info!("✅ Success: {response}"),
+        Err(e) => info!("❌ Failed: {e}"),
     }
     assert!(
         result2.is_err(),
@@ -183,8 +182,8 @@ async fn main() -> Result<()> {
         )
         .await;
     match &result3 {
-        Ok(response) => info!("✅ Success: {}", response),
-        Err(e) => info!("❌ Failed: {}", e),
+        Ok(response) => info!("✅ Success: {response}"),
+        Err(e) => info!("❌ Failed: {e}"),
     }
     assert!(
         result3.is_ok(),
@@ -229,7 +228,7 @@ async fn main() -> Result<()> {
 
     match result {
         rsactor::ActorResult::Completed { actor: _, killed } => {
-            info!("Actor stopped successfully. Killed: {}", killed);
+            info!("Actor stopped successfully. Killed: {killed}");
         }
         rsactor::ActorResult::Failed {
             error,
@@ -238,8 +237,7 @@ async fn main() -> Result<()> {
             ..
         } => {
             info!(
-                "Actor stop failed: {}. Killed: {}, Phase: {}",
-                error, killed, phase
+                "Actor stop failed: {error}. Killed: {killed}, Phase: {phase}"
             );
         }
     }

--- a/examples/advanced_derive_demo.rs
+++ b/examples/advanced_derive_demo.rs
@@ -116,11 +116,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (simple_ref, _simple_handle) = spawn::<SimpleActor>(simple_actor);
 
     let name = simple_ref.ask(GetName).await?;
-    println!("Initial name: {}", name);
+    println!("Initial name: {name}");
 
     simple_ref.tell(SetName("Bob".to_string())).await?;
     let new_name = simple_ref.ask(GetName).await?;
-    println!("Updated name: {}", new_name);
+    println!("Updated name: {new_name}");
 
     // Example 2: Counter Actor
     println!("\n🔢 Example 2: Counter Actor");
@@ -136,12 +136,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     for i in 1..=7 {
         let count = counter_ref.ask(Increment).await?;
         let at_max = counter_ref.ask(IsAtMax).await?;
-        println!("Increment {}: count = {}, at_max = {}", i, count, at_max);
+        println!("Increment {i}: count = {count}, at_max = {at_max}");
     }
 
     // Decrement
     let count = counter_ref.ask(Decrement).await?;
-    println!("After decrement: {}", count);
+    println!("After decrement: {count}");
 
     // Example 3: Worker Actor
     println!("\n⚙️  Example 3: Worker Actor");
@@ -152,7 +152,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (worker_ref, _worker_handle) = spawn::<WorkerActor>(worker_actor);
 
     let worker_id = worker_ref.ask(GetWorkerId).await?;
-    println!("Worker ID: {}", worker_id);
+    println!("Worker ID: {worker_id}");
 
     // Assign some tasks
     let tasks = vec![
@@ -164,11 +164,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for task in tasks {
         let result = worker_ref.ask(DoWork(task.to_string())).await?;
-        println!("Result: {}", result);
+        println!("Result: {result}");
     }
 
     let total_tasks = worker_ref.ask(GetTasksCompleted).await?;
-    println!("Total tasks completed: {}", total_tasks);
+    println!("Total tasks completed: {total_tasks}");
 
     // Cleanup
     simple_ref.stop().await?;

--- a/examples/advanced_derive_demo.rs
+++ b/examples/advanced_derive_demo.rs
@@ -1,6 +1,6 @@
 // Advanced example showing different ways to use the Actor derive macro
 
-use rsactor::{impl_message_handler, spawn, Actor, ActorRef, Message};
+use rsactor::{message_handlers, spawn, Actor, ActorRef};
 
 // Simple actor with derive
 #[derive(Actor, Debug)]
@@ -26,23 +26,18 @@ struct WorkerActor {
 struct GetName;
 struct SetName(String);
 
-impl Message<GetName> for SimpleActor {
-    type Reply = String;
-
-    async fn handle(&mut self, _msg: GetName, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl SimpleActor {
+    #[handler]
+    async fn handle_get_name(&mut self, _msg: GetName, _: &ActorRef<Self>) -> String {
         self.name.clone()
     }
-}
 
-impl Message<SetName> for SimpleActor {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: SetName, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_set_name(&mut self, msg: SetName, _: &ActorRef<Self>) {
         self.name = msg.0;
     }
 }
-
-impl_message_handler!(SimpleActor, [GetName, SetName]);
 
 // Messages for CounterActor
 struct Increment;
@@ -50,83 +45,64 @@ struct Decrement;
 struct GetCount;
 struct IsAtMax;
 
-impl Message<Increment> for CounterActor {
-    type Reply = u32;
-
-    async fn handle(&mut self, _msg: Increment, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl CounterActor {
+    #[handler]
+    async fn handle_increment(&mut self, _msg: Increment, _: &ActorRef<Self>) -> u32 {
         if self.count < self.max_count {
             self.count += 1;
         }
         self.count
     }
-}
 
-impl Message<Decrement> for CounterActor {
-    type Reply = u32;
-
-    async fn handle(&mut self, _msg: Decrement, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_decrement(&mut self, _msg: Decrement, _: &ActorRef<Self>) -> u32 {
         if self.count > 0 {
             self.count -= 1;
         }
         self.count
     }
-}
 
-impl Message<GetCount> for CounterActor {
-    type Reply = u32;
-
-    async fn handle(&mut self, _msg: GetCount, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_count(&mut self, _msg: GetCount, _: &ActorRef<Self>) -> u32 {
         self.count
     }
-}
 
-impl Message<IsAtMax> for CounterActor {
-    type Reply = bool;
-
-    async fn handle(&mut self, _msg: IsAtMax, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_is_at_max(&mut self, _msg: IsAtMax, _: &ActorRef<Self>) -> bool {
         self.count >= self.max_count
     }
 }
-
-impl_message_handler!(CounterActor, [Increment, Decrement, GetCount, IsAtMax]);
 
 // Messages for WorkerActor
 struct DoWork(String);
 struct GetTasksCompleted;
 struct GetWorkerId;
 
-impl Message<DoWork> for WorkerActor {
-    type Reply = String;
-
-    async fn handle(&mut self, msg: DoWork, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl WorkerActor {
+    #[handler]
+    async fn handle_do_work(&mut self, msg: DoWork, _: &ActorRef<Self>) -> String {
         // Simulate some work
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         self.tasks_completed += 1;
         format!("Worker {} completed task: {}", self.id, msg.0)
     }
-}
 
-impl Message<GetTasksCompleted> for WorkerActor {
-    type Reply = u32;
-
-    async fn handle(
+    #[handler]
+    async fn handle_get_tasks_completed(
         &mut self,
         _msg: GetTasksCompleted,
-        _actor_ref: &ActorRef<Self>,
-    ) -> Self::Reply {
+        _: &ActorRef<Self>,
+    ) -> u32 {
         self.tasks_completed
     }
-}
 
-impl Message<GetWorkerId> for WorkerActor {
-    type Reply = u32;
-
-    async fn handle(&mut self, _msg: GetWorkerId, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_worker_id(&mut self, _msg: GetWorkerId, _: &ActorRef<Self>) -> u32 {
         self.id
     }
 }
-
-impl_message_handler!(WorkerActor, [DoWork, GetTasksCompleted, GetWorkerId]);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -102,17 +102,17 @@ async fn main() -> Result<()> {
     println!("Sending Increment message...");
     // Send an Increment message and await the reply using `ask`.
     let count_after_inc: u32 = actor_ref.ask(Increment).await?;
-    println!("Reply after Increment: {}", count_after_inc);
+    println!("Reply after Increment: {count_after_inc}");
 
     println!("Sending Decrement message...");
     // Send a Decrement message and await the reply.
     let count_after_dec: u32 = actor_ref.ask(Decrement).await?;
-    println!("Reply after Decrement: {}", count_after_dec);
+    println!("Reply after Decrement: {count_after_dec}");
 
     println!("Sending Increment message again...");
     // Send another Increment message.
     let count_after_inc_2: u32 = actor_ref.ask(Increment).await?;
-    println!("Reply after Increment again: {}", count_after_inc_2);
+    println!("Reply after Increment again: {count_after_inc_2}");
 
     tokio::time::sleep(Duration::from_millis(700)).await;
 

--- a/examples/derive_macro_demo.rs
+++ b/examples/derive_macro_demo.rs
@@ -1,6 +1,6 @@
 // Example of using the Actor derive macro
 
-use rsactor::{impl_message_handler, spawn, Actor, ActorRef, Message};
+use rsactor::{message_handlers, spawn, Actor, ActorRef};
 
 #[derive(Actor)]
 struct MyActor {
@@ -13,33 +13,24 @@ struct GetName;
 struct Increment;
 struct GetCount;
 
-// Implement message handlers
-impl Message<GetName> for MyActor {
-    type Reply = String;
-
-    async fn handle(&mut self, _msg: GetName, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+// Implement message handlers using the #[message_handlers] macro with #[handler] attributes
+#[message_handlers]
+impl MyActor {
+    #[handler]
+    async fn handle_get_name(&mut self, _msg: GetName, _: &ActorRef<Self>) -> String {
         self.name.clone()
     }
-}
 
-impl Message<Increment> for MyActor {
-    type Reply = ();
-
-    async fn handle(&mut self, _msg: Increment, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_increment(&mut self, _msg: Increment, _: &ActorRef<Self>) {
         self.count += 1;
     }
-}
 
-impl Message<GetCount> for MyActor {
-    type Reply = u32;
-
-    async fn handle(&mut self, _msg: GetCount, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_count(&mut self, _msg: GetCount, _: &ActorRef<Self>) -> u32 {
         self.count
     }
 }
-
-// Wire up the message handlers
-impl_message_handler!(MyActor, [GetName, Increment, GetCount]);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/derive_macro_demo.rs
+++ b/examples/derive_macro_demo.rs
@@ -45,16 +45,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test the actor
     let name = actor_ref.ask(GetName).await?;
-    println!("Actor name: {}", name);
+    println!("Actor name: {name}");
 
     let initial_count = actor_ref.ask(GetCount).await?;
-    println!("Initial count: {}", initial_count);
+    println!("Initial count: {initial_count}");
 
     actor_ref.tell(Increment).await?;
     actor_ref.tell(Increment).await?;
 
     let final_count = actor_ref.ask(GetCount).await?;
-    println!("Final count: {}", final_count);
+    println!("Final count: {final_count}");
 
     // Stop the actor
     actor_ref.stop().await?;

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -69,7 +69,7 @@ impl Actor for Philosopher {
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         let (id, name, table_ref) = args;
-        println!("Philosopher {} ({}) is joining the table.", id, name);
+        println!("Philosopher {id} ({name}) is joining the table.");
 
         let philosopher = Self {
             id,
@@ -87,16 +87,14 @@ impl Actor for Philosopher {
         };
         if let Err(e) = table_ref.tell(register_msg).await {
             eprintln!(
-                "Philosopher {} ({}): Failed to send registration to table: {:?}",
-                id, name, e
+                "Philosopher {id} ({name}): Failed to send registration to table: {e:?}"
             );
         }
 
         // Start the initial thinking cycle
         if let Err(e) = actor_ref.tell(StartThinking).await {
             eprintln!(
-                "Philosopher {} ({}): Failed to send StartThinking to self: {:?}",
-                id, name, e
+                "Philosopher {id} ({name}): Failed to send StartThinking to self: {e:?}"
             );
         }
         Ok(philosopher)
@@ -346,7 +344,7 @@ impl Actor for Table {
     type Error = anyhow::Error;
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        println!("Table actor is ready with {} forks.", args);
+        println!("Table actor is ready with {args} forks.");
         Ok(Self {
             forks: vec![true; args], // All forks initially available
             philosophers: HashMap::new(),
@@ -438,8 +436,7 @@ impl Table {
 #[tokio::main]
 async fn main() -> Result<()> {
     println!(
-        "Starting Dining Philosophers simulation ({} philosophers, {}ms)...",
-        NUM_PHILOSOPHERS, SIMULATION_TIME_MS
+        "Starting Dining Philosophers simulation ({NUM_PHILOSOPHERS} philosophers, {SIMULATION_TIME_MS}ms)..."
     );
 
     // Spawn the Table actor
@@ -466,7 +463,7 @@ async fn main() -> Result<()> {
             "Philosopher"
         }
         .to_string();
-        let name = format!("{} #{}", philosopher_name, i);
+        let name = format!("{philosopher_name} #{i}");
         let (p_ref, p_join) = spawn::<Philosopher>((i, name, table_ref.clone()));
         println!(
             "Philosopher {} spawned with Actor ID: {}",
@@ -478,8 +475,7 @@ async fn main() -> Result<()> {
     }
 
     println!(
-        "All philosophers are at the table. Simulation will run for {}ms.",
-        SIMULATION_TIME_MS
+        "All philosophers are at the table. Simulation will run for {SIMULATION_TIME_MS}ms."
     );
     sleep(Duration::from_millis(SIMULATION_TIME_MS)).await;
     println!("Simulation time ended.");
@@ -488,7 +484,7 @@ async fn main() -> Result<()> {
     println!("\nShutting down philosophers...");
     for p_ref in philosopher_refs.iter() {
         p_ref.stop().await.unwrap_or_else(|e| {
-            eprintln!("Error stopping philosopher: {:?}", e);
+            eprintln!("Error stopping philosopher: {e:?}");
         });
     }
 
@@ -498,7 +494,7 @@ async fn main() -> Result<()> {
 
     println!("\nShutting down table...");
     if let Err(e) = table_ref.stop().await {
-        eprintln!("Error stopping table: {:?}", e);
+        eprintln!("Error stopping table: {e:?}");
     }
 
     println!("\nWaiting for table to terminate...");
@@ -511,10 +507,10 @@ async fn main() -> Result<()> {
                 );
             }
             ActorResult::Failed { error, .. } => {
-                eprintln!("Table failed to start: {:?}", error);
+                eprintln!("Table failed to start: {error:?}");
             }
         },
-        Err(e) => eprintln!("Error joining table task: {:?}", e),
+        Err(e) => eprintln!("Error joining table task: {e:?}"),
     }
 
     println!("\n--- Final Eat Counts ---");
@@ -527,10 +523,10 @@ async fn main() -> Result<()> {
                 );
             }
             Ok(ActorResult::Failed { error, phase, .. }) => {
-                eprintln!("Philosopher failed to phase({phase}): {:?}", error);
+                eprintln!("Philosopher failed to phase({phase}): {error:?}");
             }
             Err(e) => {
-                eprintln!("Error joining philosopher task: {:?}", e);
+                eprintln!("Error joining philosopher task: {e:?}");
             }
         }
     }

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -86,16 +86,12 @@ impl Actor for Philosopher {
             philosopher_ref: actor_ref.clone(),
         };
         if let Err(e) = table_ref.tell(register_msg).await {
-            eprintln!(
-                "Philosopher {id} ({name}): Failed to send registration to table: {e:?}"
-            );
+            eprintln!("Philosopher {id} ({name}): Failed to send registration to table: {e:?}");
         }
 
         // Start the initial thinking cycle
         if let Err(e) = actor_ref.tell(StartThinking).await {
-            eprintln!(
-                "Philosopher {id} ({name}): Failed to send StartThinking to self: {e:?}"
-            );
+            eprintln!("Philosopher {id} ({name}): Failed to send StartThinking to self: {e:?}");
         }
         Ok(philosopher)
     }
@@ -474,9 +470,7 @@ async fn main() -> Result<()> {
         philosopher_join_handles.push(p_join);
     }
 
-    println!(
-        "All philosophers are at the table. Simulation will run for {SIMULATION_TIME_MS}ms."
-    );
+    println!("All philosophers are at the table. Simulation will run for {SIMULATION_TIME_MS}ms.");
     sleep(Duration::from_millis(SIMULATION_TIME_MS)).await;
     println!("Simulation time ended.");
 

--- a/examples/message_macro_demo.rs
+++ b/examples/message_macro_demo.rs
@@ -65,21 +65,21 @@ async fn main() -> Result<()> {
 
     println!("➕ Adding 10...");
     let result = actor_ref.ask(Add(10)).await?;
-    println!("   Result: {}", result);
+    println!("   Result: {result}");
 
     println!("✖️  Multiplying by 3...");
     let result = actor_ref.ask(Multiply(3)).await?;
-    println!("   Result: {}", result);
+    println!("   Result: {result}");
 
     println!("📝 Setting to 100...");
     let result = actor_ref.ask(SetCount(100)).await?;
-    println!("   Result: {}", result);
+    println!("   Result: {result}");
 
     println!("📊 Current count: {}", actor_ref.ask(GetCount).await?);
 
     println!("🔄 Resetting...");
     let reset_msg: String = actor_ref.ask(Reset).await?;
-    println!("   {}", reset_msg);
+    println!("   {reset_msg}");
 
     println!("📊 Final count: {}", actor_ref.ask(GetCount).await?);
 
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
             );
         }
         rsactor::ActorResult::Failed { error, .. } => {
-            println!("❌ Calculator failed: {}", error);
+            println!("❌ Calculator failed: {error}");
         }
     }
 

--- a/examples/message_macro_demo.rs
+++ b/examples/message_macro_demo.rs
@@ -1,0 +1,103 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Demo of the #[message_handlers] macro with #[handler] attributes that reduces boilerplate code
+
+use anyhow::Result;
+use rsactor::{message_handlers, Actor, ActorRef};
+
+// Message types
+struct GetCount;
+struct SetCount(u32);
+struct Add(u32);
+struct Multiply(u32);
+struct Reset;
+
+// Define the actor struct
+#[derive(Actor)]
+struct Calculator {
+    value: u32,
+}
+
+// Message handling using the #[message_handlers] macro with #[handler] attributes
+// This automatically generates the Message trait implementations
+#[message_handlers]
+impl Calculator {
+    #[handler]
+    async fn handle_get_count(&mut self, _msg: GetCount, _: &ActorRef<Self>) -> u32 {
+        self.value
+    }
+
+    #[handler]
+    async fn handle_set_count(&mut self, msg: SetCount, _: &ActorRef<Self>) -> u32 {
+        self.value = msg.0;
+        self.value
+    }
+
+    #[handler]
+    async fn handle_add(&mut self, msg: Add, _: &ActorRef<Self>) -> u32 {
+        self.value += msg.0;
+        self.value
+    }
+
+    #[handler]
+    async fn handle_multiply(&mut self, msg: Multiply, _: &ActorRef<Self>) -> u32 {
+        self.value *= msg.0;
+        self.value
+    }
+
+    #[handler]
+    async fn handle_reset(&mut self, _msg: Reset, _: &ActorRef<Self>) -> String {
+        let old_value = self.value;
+        self.value = 0;
+        format!("Reset from {} to {}", old_value, self.value)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("🧮 Calculator Actor Demo with #[message_handlers] macro");
+
+    let calculator = Calculator { value: 0 };
+    let (actor_ref, join_handle) = rsactor::spawn::<Calculator>(calculator);
+
+    println!("📊 Initial count: {}", actor_ref.ask(GetCount).await?);
+
+    println!("➕ Adding 10...");
+    let result = actor_ref.ask(Add(10)).await?;
+    println!("   Result: {}", result);
+
+    println!("✖️  Multiplying by 3...");
+    let result = actor_ref.ask(Multiply(3)).await?;
+    println!("   Result: {}", result);
+
+    println!("📝 Setting to 100...");
+    let result = actor_ref.ask(SetCount(100)).await?;
+    println!("   Result: {}", result);
+
+    println!("📊 Current count: {}", actor_ref.ask(GetCount).await?);
+
+    println!("🔄 Resetting...");
+    let reset_msg: String = actor_ref.ask(Reset).await?;
+    println!("   {}", reset_msg);
+
+    println!("📊 Final count: {}", actor_ref.ask(GetCount).await?);
+
+    actor_ref.stop().await?;
+    let result = join_handle.await?;
+
+    match result {
+        rsactor::ActorResult::Completed { actor, killed } => {
+            println!(
+                "✅ Calculator stopped. Final value: {}. Killed: {}",
+                actor.value, killed
+            );
+        }
+        rsactor::ActorResult::Failed { error, .. } => {
+            println!("❌ Calculator failed: {}", error);
+        }
+    }
+
+    println!("🎉 Demo completed!");
+    Ok(())
+}

--- a/examples/unified_macro_demo.rs
+++ b/examples/unified_macro_demo.rs
@@ -1,4 +1,4 @@
-use rsactor::{impl_message_handler, spawn, Actor, ActorRef, Message};
+use rsactor::{message_handlers, spawn, Actor, ActorRef};
 
 // Demo of non-generic actor (original syntax)
 #[derive(Debug)]
@@ -19,25 +19,19 @@ impl Actor for SimpleActor {
 struct Increment;
 struct GetCount;
 
-impl Message<Increment> for SimpleActor {
-    type Reply = ();
-
-    async fn handle(&mut self, _: Increment, _: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl SimpleActor {
+    #[handler]
+    async fn handle_increment(&mut self, _: Increment, _: &ActorRef<Self>) {
         self.counter += 1;
         println!("SimpleActor: incremented to {}", self.counter);
     }
-}
 
-impl Message<GetCount> for SimpleActor {
-    type Reply = i32;
-
-    async fn handle(&mut self, _: GetCount, _: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_count(&mut self, _: GetCount, _: &ActorRef<Self>) -> i32 {
         self.counter
     }
 }
-
-// Using unified macro with non-generic syntax
-impl_message_handler!(SimpleActor, [Increment, GetCount]);
 
 // Demo of generic actor (new syntax)
 #[derive(Debug)]
@@ -58,25 +52,19 @@ impl<T: Send + std::fmt::Debug + Clone + 'static> Actor for GenericActor<T> {
 struct SetValue<T: Send + std::fmt::Debug + 'static>(T);
 struct GetValue;
 
-impl<T: Send + std::fmt::Debug + Clone + 'static> Message<SetValue<T>> for GenericActor<T> {
-    type Reply = ();
-
-    async fn handle(&mut self, msg: SetValue<T>, _: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl<T: Send + std::fmt::Debug + Clone + 'static> GenericActor<T> {
+    #[handler]
+    async fn handle_set_value(&mut self, msg: SetValue<T>, _: &ActorRef<Self>) {
         self.value = Some(msg.0);
         println!("GenericActor: set value to {:?}", self.value);
     }
-}
 
-impl<T: Send + std::fmt::Debug + Clone + 'static> Message<GetValue> for GenericActor<T> {
-    type Reply = Option<T>;
-
-    async fn handle(&mut self, _: GetValue, _: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_value(&mut self, _: GetValue, _: &ActorRef<Self>) -> Option<T> {
         self.value.clone()
     }
 }
-
-// Using unified macro with generic syntax
-impl_message_handler!([T: Send + std::fmt::Debug + Clone + 'static] for GenericActor<T>, [SetValue<T>, GetValue]);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/unified_macro_demo.rs
+++ b/examples/unified_macro_demo.rs
@@ -11,7 +11,7 @@ impl Actor for SimpleActor {
     type Args = i32;
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        println!("SimpleActor started with counter: {}", args);
+        println!("SimpleActor started with counter: {args}");
         Ok(SimpleActor { counter: args })
     }
 }
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     simple_ref.tell(Increment).await?;
     simple_ref.tell(Increment).await?;
     let count: i32 = simple_ref.ask(GetCount).await?;
-    println!("Final count: {}", count);
+    println!("Final count: {count}");
 
     simple_ref.stop().await?;
 
@@ -88,7 +88,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     string_ref.tell(SetValue("Hello World".to_string())).await?;
     let string_value: Option<String> = string_ref.ask(GetValue).await?;
-    println!("String value: {:?}", string_value);
+    println!("String value: {string_value:?}");
 
     string_ref.stop().await?;
 
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     int_ref.tell(SetValue(42)).await?;
     let int_value: Option<i32> = int_ref.ask(GetValue).await?;
-    println!("Integer value: {:?}", int_value);
+    println!("Integer value: {int_value:?}");
 
     int_ref.stop().await?;
 

--- a/examples/weak_reference_demo.rs
+++ b/examples/weak_reference_demo.rs
@@ -29,7 +29,7 @@ impl Actor for PingActor {
         args: Self::Args,
         _actor_ref: &ActorRef<Self>,
     ) -> std::result::Result<Self, Self::Error> {
-        println!("PingActor '{}' started!", args);
+        println!("PingActor '{args}' started!");
         Ok(PingActor {
             name: args,
             ping_count: 0,
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
 
         // Use the strong reference
         let response: String = strong_ref.ask(Ping).await?;
-        println!("   Response: {}", response);
+        println!("   Response: {response}");
     } else {
         println!("2. Failed to upgrade weak reference - actor is dead");
     }
@@ -110,7 +110,7 @@ async fn main() -> Result<()> {
     // Send more messages using the original reference
     let response1: String = actor_ref.ask(Ping).await?;
     let response2: String = actor_ref.ask(Ping).await?;
-    println!("3. Sent more pings: '{}', '{}'", response1, response2);
+    println!("3. Sent more pings: '{response1}', '{response2}'");
 
     // Test weak reference after some activity
     if let Some(strong_ref) = weak_ref.upgrade() {
@@ -136,8 +136,8 @@ async fn main() -> Result<()> {
 
         // Try to use it
         match strong_ref.ask::<Ping, String>(Ping).await {
-            Ok(response) => println!("   Response: {}", response),
-            Err(e) => println!("   Error sending message: {}", e),
+            Ok(response) => println!("   Response: {response}"),
+            Err(e) => println!("   Error sending message: {e}"),
         }
     } else {
         println!("   Failed to upgrade weak reference - actor is no longer available");
@@ -146,7 +146,7 @@ async fn main() -> Result<()> {
     // Stop the actor via join handle
     println!("7. Stopping actor...");
     if let Ok(actor_result) = join_handle.await {
-        println!("   Actor stopped with result: {:?}", actor_result);
+        println!("   Actor stopped with result: {actor_result:?}");
     }
 
     // Final check of weak reference

--- a/examples/weak_reference_demo.rs
+++ b/examples/weak_reference_demo.rs
@@ -10,9 +10,7 @@
 //! - Proper cleanup when actors are dropped
 
 use anyhow::Error as AnyError;
-use rsactor::{
-    impl_message_handler, spawn, Actor, ActorRef, ActorWeak, Message, Result, UntypedActorRef,
-};
+use rsactor::{message_handlers, spawn, Actor, ActorRef, ActorWeak, Result, UntypedActorRef};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -66,28 +64,22 @@ struct Status {
 }
 
 // Message implementations
-impl Message<Ping> for PingActor {
-    type Reply = String;
-
-    async fn handle(&mut self, _msg: Ping, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+#[message_handlers]
+impl PingActor {
+    #[handler]
+    async fn handle_ping(&mut self, _msg: Ping, _: &ActorRef<Self>) -> String {
         self.ping_count += 1;
         format!("{} pong! (count: {})", self.name, self.ping_count)
     }
-}
 
-impl Message<GetStatus> for PingActor {
-    type Reply = Status;
-
-    async fn handle(&mut self, _msg: GetStatus, _actor_ref: &ActorRef<Self>) -> Self::Reply {
+    #[handler]
+    async fn handle_get_status(&mut self, _msg: GetStatus, _: &ActorRef<Self>) -> Status {
         Status {
             name: self.name.clone(),
             ping_count: self.ping_count,
         }
     }
 }
-
-// Wire up message handlers
-impl_message_handler!(PingActor, [Ping, GetStatus]);
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/rsactor-derive/src/lib.rs
+++ b/rsactor-derive/src/lib.rs
@@ -72,11 +72,57 @@
 //!
 //! For complex initialization (async resource setup, validation, etc.),
 //! implement the Actor trait manually.
+//!
+//! ## Message Handlers Attribute Macro
+//!
+//! The `#[message_handlers]` attribute macro combined with `#[handler]` method attributes
+//! provides an automated way to generate Message trait implementations and register message handlers.
+//!
+//! ### Usage
+//!
+//! ```rust
+//! use rsactor::{Actor, ActorRef, message_handlers};
+//!
+//! #[derive(Actor)]
+//! struct MyActor {
+//!     count: u32,
+//! }
+//!
+//! #[message_handlers]
+//! impl MyActor {
+//!     #[handler]
+//!     async fn handle_increment(&mut self, _msg: Increment, _: &ActorRef<Self>) -> u32 {
+//!         self.count += 1;
+//!         self.count
+//!     }
+//!
+//!     #[handler]
+//!     async fn handle_get_count(&mut self, _msg: GetCount, _: &ActorRef<Self>) -> u32 {
+//!         self.count
+//!     }
+//!
+//!     // Regular methods without #[handler] are left unchanged
+//!     fn internal_method(&self) -> u32 {
+//!         self.count * 2
+//!     }
+//! }
+//! ```
+//!
+//! ### Benefits
+//!
+//! - Automatic generation of Message<T> trait implementations
+//! - Automatic implementation of MessageHandler trait for the actor
+//! - Selective processing: only methods with `#[handler]` attribute are processed
+//! - Reduced boilerplate and potential for errors
+//! - Type-safe message handling with compile-time checks
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput};
+use syn::{
+    parse_macro_input, Data, DeriveInput, FnArg, ImplItem, ImplItemFn, ItemImpl, PatType,
+    ReturnType, Type,
+};
 
 /// Derive macro for automatically implementing the Actor trait.
 ///
@@ -170,5 +216,263 @@ fn derive_actor_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
             name,
             "Actor derive macro can only be used on structs and enums",
         )),
+    }
+}
+
+/// Attribute macro for automatically generating Message trait implementations
+/// from method definitions.
+///
+/// This macro analyzes method signatures in an impl block and generates the corresponding
+/// Message trait implementations for methods marked with `#[handler]` attribute, reducing
+/// boilerplate code. It also automatically generates the `impl_message_handler!` macro call
+/// to register the message handlers with the actor.
+///
+/// # Usage
+///
+/// ```rust
+/// use rsactor::{Actor, ActorRef, message_handlers};
+///
+/// #[derive(Actor)]
+/// struct MyActor {
+///     count: u32,
+/// }
+///
+/// #[message_handlers]
+/// impl MyActor {
+///     #[handler]
+///     async fn handle_increment(&mut self, _msg: Increment, _: &ActorRef<Self>) -> u32 {
+///         self.count += 1;
+///         self.count
+///     }
+///
+///     #[handler]
+///     async fn handle_decrement(&mut self, _msg: Decrement, _: &ActorRef<Self>) -> u32 {
+///         self.count -= 1;
+///         self.count
+///     }
+///
+///     // Regular methods without #[handler] are left unchanged
+///     fn get_internal_state(&self) -> u32 {
+///         self.count
+///     }
+/// }
+/// ```
+///
+/// This will automatically generate:
+/// - The Message<MessageType> trait implementations for each handler method
+/// - The MessageHandler trait implementation for the actor
+///
+/// # Requirements
+///
+/// Each method marked with `#[handler]` must follow this signature pattern:
+/// - First parameter: `&mut self`
+/// - Second parameter: `_msg: MessageType` (where MessageType is the message struct)
+/// - Third parameter: `_: &ActorRef<Self>` or `_actor_ref: &ActorRef<Self>`
+/// - Return type: the reply type for the message
+///
+/// # Benefits
+///
+/// - No need to manually implement Message<T> trait for each message type
+/// - No need to manually implement MessageHandler trait
+/// - Reduces boilerplate code and potential for errors
+/// - Automatically keeps message handler registration in sync with method definitions
+/// - Only processes methods marked with `#[handler]`, leaving other methods unchanged
+#[proc_macro_attribute]
+pub fn message_handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemImpl);
+
+    let expanded = match message_impl(input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn message_impl(mut input: ItemImpl) -> syn::Result<TokenStream2> {
+    let actor_type = &input.self_ty;
+    let generics = &input.generics;
+
+    let (message_impls, message_types) =
+        process_handler_methods(&input.items, actor_type, generics)?;
+
+    // Remove `#[handler]` attributes from the impl block for clean output
+    clean_handler_attributes(&mut input.items);
+
+    // Generate MessageHandler implementation directly instead of using deprecated macro
+    let message_handler_impl = generate_message_handler_impl(&message_types, actor_type, generics);
+
+    let result = quote! {
+        #input
+        #(#message_impls)*
+        #message_handler_impl
+    };
+
+    Ok(result)
+}
+
+fn process_handler_methods(
+    items: &[ImplItem],
+    actor_type: &Type,
+    generics: &syn::Generics,
+) -> syn::Result<(Vec<TokenStream2>, Vec<Type>)> {
+    let mut message_impls = Vec::new();
+    let mut message_types = Vec::new();
+
+    for item in items {
+        if let ImplItem::Fn(method) = item {
+            // Check for `#[handler]` attribute
+            if method
+                .attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("handler"))
+            {
+                // Generate message implementation for this method
+                let impl_tokens = generate_message_impl(method, actor_type, generics)?;
+                message_impls.push(impl_tokens);
+
+                // Extract message type
+                if let Some(message_type) = extract_message_type(method)? {
+                    message_types.push(message_type);
+                }
+            }
+        }
+    }
+
+    Ok((message_impls, message_types))
+}
+
+fn clean_handler_attributes(items: &mut [ImplItem]) {
+    for item in items {
+        if let ImplItem::Fn(method) = item {
+            method.attrs.retain(|attr| !attr.path().is_ident("handler"));
+        }
+    }
+}
+
+fn generate_message_handler_impl(
+    message_types: &[Type],
+    actor_type: &Type,
+    generics: &syn::Generics,
+) -> TokenStream2 {
+    if message_types.is_empty() {
+        return quote! {};
+    }
+
+    let message_handler_body = generate_message_handler_body(message_types);
+
+    if generics.params.is_empty() {
+        quote! {
+            impl rsactor::MessageHandler for #actor_type {
+                #message_handler_body
+            }
+        }
+    } else {
+        let params = &generics.params;
+        let where_clause = &generics.where_clause;
+        quote! {
+            impl<#params> rsactor::MessageHandler for #actor_type #where_clause {
+                #message_handler_body
+            }
+        }
+    }
+}
+
+fn generate_message_impl(
+    method: &ImplItemFn,
+    actor_type: &Type,
+    generics: &syn::Generics,
+) -> syn::Result<TokenStream2> {
+    // Parse method signature
+    let inputs = &method.sig.inputs;
+
+    if inputs.len() != 3 {
+        return Err(syn::Error::new_spanned(
+            &method.sig,
+            "Message handler method must have exactly 3 parameters: &mut self, message, &ActorRef<Self>"
+        ));
+    }
+
+    // Extract message type from second parameter
+    let message_type = match &inputs[1] {
+        FnArg::Typed(PatType { ty, .. }) => ty,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                &inputs[1],
+                "Expected typed parameter for message",
+            ))
+        }
+    };
+
+    // Extract return type - handle both explicit return types and unit return (no return type)
+    let return_type = match &method.sig.output {
+        ReturnType::Type(_, ty) => quote! { #ty },
+        ReturnType::Default => quote! { () }, // Default to unit type for functions without explicit return type
+    };
+
+    // Get method name
+    let method_name = &method.sig.ident;
+
+    let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+    // Generate the Message trait implementation
+    let impl_tokens = quote! {
+        impl #impl_generics rsactor::Message<#message_type> for #actor_type #where_clause {
+            type Reply = #return_type;
+
+            async fn handle(
+                &mut self,
+                msg: #message_type,
+                actor_ref: &rsactor::ActorRef<Self>,
+            ) -> Self::Reply {
+                self.#method_name(msg, actor_ref).await
+            }
+        }
+    };
+
+    Ok(impl_tokens)
+}
+
+fn extract_message_type(method: &ImplItemFn) -> syn::Result<Option<Type>> {
+    // Parse method signature
+    let inputs = &method.sig.inputs;
+
+    if inputs.len() != 3 {
+        return Ok(None); // Skip methods that don't match the pattern
+    }
+
+    // Extract message type from second parameter
+    match &inputs[1] {
+        FnArg::Typed(PatType { ty, .. }) => Ok(Some(ty.as_ref().clone())),
+        _ => Ok(None),
+    }
+}
+
+fn generate_message_handler_body(message_types: &[Type]) -> TokenStream2 {
+    quote! {
+        async fn handle(
+            &mut self,
+            _msg_any: Box<dyn std::any::Any + Send>,
+            actor_ref: &rsactor::ActorRef<Self>,
+        ) -> rsactor::Result<Box<dyn std::any::Any + Send>> {
+            let mut _msg_any = _msg_any;
+            #(
+                match _msg_any.downcast::<#message_types>() {
+                    Ok(concrete_msg_box) => {
+                        let reply = <Self as rsactor::Message<#message_types>>::handle(self, *concrete_msg_box, &actor_ref).await;
+                        return Ok(Box::new(reply) as Box<dyn std::any::Any + Send>);
+                    }
+                    Err(original_box_back) => {
+                        _msg_any = original_box_back;
+                    }
+                }
+            )*
+            let expected_msg_types: Vec<&'static str> = vec![#(stringify!(#message_types)),*];
+            return Err(rsactor::Error::UnhandledMessageType {
+                identity: actor_ref.identity(),
+                expected_types: expected_msg_types,
+                actual_type_id: _msg_any.type_id()
+            });
+        }
     }
 }

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -345,9 +345,7 @@ impl UntypedActorRef {
     {
         let rt = Handle::try_current().map_err(|e| Error::Runtime {
             identity: self.identity,
-            details: format!(
-                "Failed to get Tokio runtime handle for tell_blocking: {e}"
-            ),
+            details: format!("Failed to get Tokio runtime handle for tell_blocking: {e}"),
         })?;
 
         match timeout {

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -346,8 +346,7 @@ impl UntypedActorRef {
         let rt = Handle::try_current().map_err(|e| Error::Runtime {
             identity: self.identity,
             details: format!(
-                "Failed to get Tokio runtime handle for tell_blocking: {}",
-                e
+                "Failed to get Tokio runtime handle for tell_blocking: {e}"
             ),
         })?;
 
@@ -414,7 +413,7 @@ impl UntypedActorRef {
     {
         let rt = Handle::try_current().map_err(|e| Error::Runtime {
             identity: self.identity,
-            details: format!("Failed to get Tokio runtime handle for ask_blocking: {}", e),
+            details: format!("Failed to get Tokio runtime handle for ask_blocking: {e}"),
         })?;
 
         match timeout {

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,7 +132,7 @@ impl std::fmt::Display for Error {
                 write!(f, "Runtime error in actor {}: {}", actor_id.name(), details)
             }
             Error::MailboxCapacity { message } => {
-                write!(f, "Mailbox capacity error: {}", message)
+                write!(f, "Mailbox capacity error: {message}")
             }
         }
     }

--- a/tests/actor_ref_drop_tests.rs
+++ b/tests/actor_ref_drop_tests.rs
@@ -166,7 +166,7 @@ async fn test_actor_ref_drop_terminates_actor_after_processing_messages() {
     assert!(final_messages.contains(&"on_stop_called".to_string()));
 
     debug!("Processed messages: {:?}", *final_messages);
-    debug!("Total messages processed: {}", final_count);
+    debug!("Total messages processed: {final_count}");
 }
 
 #[tokio::test]
@@ -223,8 +223,7 @@ async fn test_actor_ref_drop_with_slow_messages() {
     // Verify the actor took time to process all messages before terminating
     assert!(
         elapsed >= std::time::Duration::from_millis(140),
-        "Actor should have taken time to process slow messages, elapsed: {:?}",
-        elapsed
+        "Actor should have taken time to process slow messages, elapsed: {elapsed:?}"
     );
 
     // Verify the actor completed normally
@@ -250,8 +249,8 @@ async fn test_actor_ref_drop_with_slow_messages() {
     assert!(final_messages.contains(&"on_stop_called".to_string()));
 
     debug!("Processed slow messages: {:?}", *final_messages);
-    debug!("Total slow messages processed: {}", final_count);
-    debug!("Processing time: {:?}", elapsed);
+    debug!("Total slow messages processed: {final_count}");
+    debug!("Processing time: {elapsed:?}");
 }
 
 #[tokio::test]
@@ -380,7 +379,7 @@ async fn test_multiple_actor_refs_drop_behavior() {
         "Processed messages from multiple refs: {:?}",
         *final_messages
     );
-    debug!("Total messages processed: {}", final_count);
+    debug!("Total messages processed: {final_count}");
 }
 
 #[tokio::test]
@@ -461,7 +460,7 @@ async fn test_actor_ref_clone_drop_behavior() {
     assert!(final_messages.contains(&"on_stop_called".to_string()));
 
     debug!("Processed messages from clone test: {:?}", *final_messages);
-    debug!("Total messages processed: {}", final_count);
+    debug!("Total messages processed: {final_count}");
 }
 
 #[tokio::test]
@@ -486,7 +485,7 @@ async fn test_actor_ref_drop_vs_explicit_stop() {
         for i in 1..=3 {
             actor_ref
                 .tell(TestMessage {
-                    content: format!("explicit_stop_{}", i),
+                    content: format!("explicit_stop_{i}"),
                     delay_ms: 10,
                 })
                 .await
@@ -527,7 +526,7 @@ async fn test_actor_ref_drop_vs_explicit_stop() {
         for i in 1..=3 {
             actor_ref
                 .tell(TestMessage {
-                    content: format!("drop_behavior_{}", i),
+                    content: format!("drop_behavior_{i}"),
                     delay_ms: 10,
                 })
                 .await

--- a/tests/actor_ref_drop_tests.rs
+++ b/tests/actor_ref_drop_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
+#![allow(deprecated)]
 
 use log::debug;
 use std::sync::Arc;

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
+#![allow(deprecated)]
 
 use std::any::TypeId;
 

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -511,7 +511,7 @@ async fn test_actor_result_debug_format() {
         },
         killed: false,
     };
-    let debug_str = format!("{:?}", completed_result);
+    let debug_str = format!("{completed_result:?}");
     assert!(
         debug_str.contains("Completed"),
         "Debug should contain variant name"
@@ -523,7 +523,7 @@ async fn test_actor_result_debug_format() {
         phase: FailurePhase::OnStart,
         killed: false,
     };
-    let debug_str = format!("{:?}", failed_result);
+    let debug_str = format!("{failed_result:?}");
     assert!(
         debug_str.contains("Failed"),
         "Debug should contain variant name"
@@ -632,11 +632,10 @@ async fn test_error_runtime_tell_blocking_outside_runtime() {
             );
             assert!(
                 details.contains("Failed to get Tokio runtime handle for tell_blocking"),
-                "Error should mention runtime handle failure, got: {}",
-                details
+                "Error should mention runtime handle failure, got: {details}"
             );
         } else {
-            panic!("Expected Error::Runtime, got: {:?}", result);
+            panic!("Expected Error::Runtime, got: {result:?}");
         }
     });
 
@@ -678,11 +677,10 @@ async fn test_error_runtime_ask_blocking_outside_runtime() {
             );
             assert!(
                 details.contains("Failed to get Tokio runtime handle for ask_blocking"),
-                "Error should mention runtime handle failure, got: {}",
-                details
+                "Error should mention runtime handle failure, got: {details}"
             );
         } else {
-            panic!("Expected Error::Runtime, got: {:?}", result);
+            panic!("Expected Error::Runtime, got: {result:?}");
         }
     });
 
@@ -703,7 +701,7 @@ async fn test_error_runtime_display_format() {
         details: "Test runtime error details".to_string(),
     };
 
-    let display_str = format!("{}", error);
+    let display_str = format!("{error}");
     assert!(
         display_str.contains("Runtime error in actor"),
         "Display should mention runtime error"

--- a/tests/derive_macro_tests.rs
+++ b/tests/derive_macro_tests.rs
@@ -1,4 +1,5 @@
 // Tests for the Actor derive macro (structs and enums)
+#![allow(deprecated)]
 
 use rsactor::{impl_message_handler, spawn, Actor, ActorRef, Message};
 

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -1,4 +1,6 @@
 // filepath: /Volumes/Workspace/rust/rsactor/tests/generic_tests.rs
+#![allow(deprecated)]
+
 use anyhow::Result;
 use rsactor::{impl_message_handler, spawn, Actor, ActorRef, ActorResult, Message};
 use std::fmt::Debug;

--- a/tests/message_handlers_macro_tests.rs
+++ b/tests/message_handlers_macro_tests.rs
@@ -1,0 +1,1523 @@
+// Tests for the message_handlers macro with various message types
+
+use anyhow::Error as AnyError;
+use rsactor::{message_handlers, spawn, Actor, ActorRef};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::timeout;
+
+// Test actor for message handlers macro
+#[derive(Debug)]
+struct MessageHandlerTestActor {
+    counter: u32,
+    messages_log: Vec<String>,
+    data_store: HashMap<String, i32>,
+}
+
+impl Actor for MessageHandlerTestActor {
+    type Args = ();
+    type Error = AnyError;
+
+    async fn on_start(
+        _args: Self::Args,
+        _actor_ref: &ActorRef<Self>,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(MessageHandlerTestActor {
+            counter: 0,
+            messages_log: Vec::new(),
+            data_store: HashMap::new(),
+        })
+    }
+}
+
+// Various message types to test different scenarios
+
+// 1. Simple unit struct
+#[derive(Debug, Clone)]
+struct Ping;
+
+// 2. Tuple struct with single value
+#[derive(Debug, Clone)]
+struct SetCounter(u32);
+
+// 3. Named struct with multiple fields
+#[derive(Debug, Clone)]
+struct StoreData {
+    key: String,
+    value: i32,
+}
+
+// 4. Generic struct
+#[derive(Debug, Clone)]
+struct GenericMessage<T> {
+    data: T,
+    label: String,
+}
+
+// 5. Struct with Vec
+#[derive(Debug, Clone)]
+struct BatchUpdate {
+    updates: Vec<(String, i32)>,
+}
+
+// 6. Struct with Option
+#[derive(Debug, Clone)]
+struct OptionalMessage {
+    required_field: String,
+    optional_field: Option<i32>,
+}
+
+// 7. Enum message
+#[derive(Debug, Clone)]
+enum Operation {
+    Add(i32),
+    Subtract(i32),
+    Multiply(i32),
+    Reset,
+}
+
+// 8. Simple struct without external dependencies
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct SimpleMessage {
+    id: u64,
+    content: String,
+    metadata: HashMap<String, String>,
+}
+
+// 9. Complex nested struct
+#[derive(Debug, Clone)]
+struct ComplexMessage {
+    header: MessageHeader,
+    payload: MessagePayload,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MessageHeader {
+    timestamp: u64,
+    sender: String,
+    priority: u8,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MessagePayload {
+    data: Vec<u8>,
+    format: String,
+}
+
+// 10. Query message that returns complex data
+#[derive(Debug, Clone)]
+struct GetStatus;
+
+#[derive(Debug, Clone)]
+struct StatusResponse {
+    counter: u32,
+    messages_count: usize,
+    data_store_size: usize,
+    last_messages: Vec<String>,
+}
+
+// Additional complex generic message types
+
+// 11. Multi-generic struct
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MultiGenericMessage<T, U> {
+    primary: T,
+    secondary: U,
+    context: String,
+}
+
+// 12. Generic with constraints
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct ConstrainedGeneric<T>
+where
+    T: Clone + std::fmt::Debug,
+{
+    data: T,
+    metadata: Vec<String>,
+}
+
+// 13. Nested generics
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct NestedGeneric<T> {
+    outer: GenericContainer<T>,
+    fallback: Option<T>,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct GenericContainer<T> {
+    items: Vec<T>,
+    capacity: usize,
+}
+
+// 14. Generic with lifetime (using owned types for simplicity)
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct GenericWithOwnership<T> {
+    owned_data: Box<T>,
+    reference_data: String, // Simulating lifetime with owned String
+}
+
+// 15. Complex nested generic with multiple type parameters
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct ComplexNested<K, V, M>
+where
+    K: Clone + std::fmt::Debug,
+    V: Clone + std::fmt::Debug,
+    M: Clone + std::fmt::Debug,
+{
+    map_data: HashMap<K, V>,
+    metadata: M,
+    processing_queue: Vec<(K, V)>,
+}
+
+// 16. Generic enum
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+enum GenericOperation<T> {
+    Process(T),
+    Transform { input: T, factor: f64 },
+    Batch(Vec<T>),
+    None,
+}
+
+// 17. Recursive generic (with Box to avoid infinite size)
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct RecursiveGeneric<T> {
+    value: T,
+    children: Vec<Box<RecursiveGeneric<T>>>,
+    depth: usize,
+}
+
+// 18. Generic with associated types simulation
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct GenericProcessor<T, R> {
+    input: T,
+    processor_id: String,
+    expected_output_type: std::marker::PhantomData<R>,
+}
+
+// 19. Generic tuple struct
+#[derive(Debug, Clone)]
+struct GenericTuple<A, B, C>(A, B, C);
+
+// 20. Complex generic with Result and Option
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct ComplexGenericResult<T, E> {
+    results: Vec<Result<T, E>>,
+    summary: Option<String>,
+    retry_count: u32,
+}
+
+// Additional complex generic message types with advanced trait bounds
+
+// 21. Generic with multiple complex trait bounds
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct AdvancedConstrainedGeneric<T>
+where
+    T: Send + Sync + std::fmt::Debug + Clone + 'static + PartialEq + Eq + std::hash::Hash + Default,
+{
+    data: T,
+    hash_map: HashMap<T, String>,
+    default_value: T,
+}
+
+// 22. Generic with lifetime and function bounds
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct FunctionBoundGeneric<T>
+where
+    T: Clone + std::fmt::Debug + Send + 'static,
+{
+    data: T,
+    transformer_id: String,
+    cache: Vec<String>,
+}
+
+// 23. Generic with iterator and collection traits (simplified)
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct IteratorBoundGeneric<T>
+where
+    T: Clone + std::fmt::Debug + Send + 'static,
+{
+    source: Vec<T>,
+    iterator_config: String,
+}
+
+// 24. Generic with serialization bounds (simulated)
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct SerializationBoundGeneric<T>
+where
+    T: std::fmt::Debug + Clone + Send + Sync + 'static + PartialEq + std::fmt::Display,
+{
+    data: T,
+    serialized_cache: String,
+    metadata: HashMap<String, String>,
+}
+
+// 25. Generic with mathematical operation bounds
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MathBoundGeneric<T>
+where
+    T: std::ops::Add<Output = T>
+        + std::ops::Sub<Output = T>
+        + std::ops::Mul<Output = T>
+        + std::ops::Div<Output = T>
+        + Copy
+        + Clone
+        + std::fmt::Debug
+        + Send
+        + 'static
+        + PartialOrd
+        + Default,
+{
+    values: Vec<T>,
+    operations_log: Vec<String>,
+}
+
+// 26. Generic with associated types and complex bounds
+trait CustomProcessor {
+    type Input: Clone + std::fmt::Debug + Send + 'static;
+    type Output: Clone + std::fmt::Debug + Send + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    #[allow(dead_code)]
+    fn process(&self, input: Self::Input) -> Result<Self::Output, Self::Error>;
+}
+
+// Simple implementation for testing
+#[derive(Debug, Clone)]
+struct CustomProcessorImpl;
+
+#[derive(Debug, Clone)]
+struct SimpleError(String);
+
+impl std::fmt::Display for SimpleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SimpleError: {}", self.0)
+    }
+}
+
+impl std::error::Error for SimpleError {}
+
+impl CustomProcessor for CustomProcessorImpl {
+    type Input = String;
+    type Output = i32;
+    type Error = SimpleError;
+
+    fn process(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        input
+            .len()
+            .try_into()
+            .map_err(|_| SimpleError("conversion failed".to_string()))
+    }
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct AssociatedTypeBoundGeneric<P>
+where
+    P: CustomProcessor + Clone + Send + 'static,
+    P::Input: PartialEq + std::hash::Hash,
+    P::Output: std::fmt::Display,
+{
+    processor: P,
+    input_cache: HashMap<P::Input, P::Output>,
+    error_log: Vec<String>,
+}
+
+// 27. Simplified async bound generic
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct AsyncBoundGeneric<T, R>
+where
+    T: Clone + std::fmt::Debug + Send + Sync + 'static,
+    R: Clone + std::fmt::Debug + Send + Sync + 'static,
+{
+    input: T,
+    processor_id: String,
+    result_cache: Option<R>,
+}
+
+// 28. Generic with nested trait bounds and where clauses
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct NestedTraitBoundGeneric<T, U, V>
+where
+    T: Into<U> + Clone + std::fmt::Debug + Send + 'static,
+    U: From<T> + Into<V> + Clone + std::fmt::Debug + Send + 'static,
+    V: From<U> + Clone + std::fmt::Debug + Send + 'static + std::fmt::Display,
+{
+    original: T,
+    intermediate: Option<U>,
+    final_result: Option<V>,
+}
+
+// 29. Generic with error handling bounds
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct CustomError {
+    message: String,
+    code: i32,
+}
+
+impl std::fmt::Display for CustomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CustomError({}): {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for CustomError {}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct ErrorHandlingGeneric<T, E>
+where
+    T: Clone + std::fmt::Debug + Send + 'static,
+    E: std::error::Error + Clone + std::fmt::Debug + Send + Sync + 'static,
+{
+    operations: Vec<Result<T, E>>,
+    error_recovery: HashMap<String, T>,
+}
+
+// 30. Generic with phantom data and complex bounds
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct PhantomComplexGeneric<T, U, V>
+where
+    T: Clone + std::fmt::Debug + Send + 'static + PartialEq + Eq + std::hash::Hash,
+    U: Clone + std::fmt::Debug + Send + 'static + std::fmt::Display,
+    V: Clone + std::fmt::Debug + Send + 'static,
+{
+    data: HashMap<T, U>,
+    phantom: std::marker::PhantomData<V>,
+    type_info: String,
+}
+
+// Message handlers implementation using the macro
+#[message_handlers]
+impl MessageHandlerTestActor {
+    #[handler]
+    async fn handle_ping(&mut self, _msg: Ping, _: &ActorRef<Self>) -> String {
+        self.counter += 1;
+        self.messages_log.push("Ping received".to_string());
+        format!("Pong #{}", self.counter)
+    }
+
+    #[handler]
+    async fn handle_set_counter(&mut self, msg: SetCounter, _: &ActorRef<Self>) -> u32 {
+        let old_value = self.counter;
+        self.counter = msg.0;
+        self.messages_log
+            .push(format!("Counter set from {} to {}", old_value, msg.0));
+        old_value
+    }
+
+    #[handler]
+    async fn handle_store_data(&mut self, msg: StoreData, _: &ActorRef<Self>) -> bool {
+        let existed = self.data_store.contains_key(&msg.key);
+        self.data_store.insert(msg.key.clone(), msg.value);
+        self.messages_log
+            .push(format!("Stored {}={}", msg.key, msg.value));
+        !existed // return true if it's a new key
+    }
+
+    #[handler]
+    async fn handle_generic_string(
+        &mut self,
+        msg: GenericMessage<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        self.messages_log
+            .push(format!("Generic string: {} - {}", msg.label, msg.data));
+        format!("Processed: {}", msg.data)
+    }
+
+    #[handler]
+    async fn handle_generic_number(&mut self, msg: GenericMessage<i32>, _: &ActorRef<Self>) -> i32 {
+        self.messages_log
+            .push(format!("Generic number: {} - {}", msg.label, msg.data));
+        msg.data * 2
+    }
+
+    #[handler]
+    async fn handle_batch_update(&mut self, msg: BatchUpdate, _: &ActorRef<Self>) -> usize {
+        let count = msg.updates.len();
+        for (key, value) in msg.updates {
+            self.data_store.insert(key, value);
+        }
+        self.messages_log
+            .push(format!("Batch updated {} items", count));
+        count
+    }
+
+    #[handler]
+    async fn handle_optional_message(
+        &mut self,
+        msg: OptionalMessage,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let response = match msg.optional_field {
+            Some(value) => format!("{}: {}", msg.required_field, value),
+            None => format!("{}: no value", msg.required_field),
+        };
+        self.messages_log
+            .push(format!("Optional message: {}", response));
+        response
+    }
+
+    #[handler]
+    async fn handle_operation(&mut self, msg: Operation, _: &ActorRef<Self>) -> u32 {
+        let old_value = self.counter;
+        match msg {
+            Operation::Add(n) => self.counter += n as u32,
+            Operation::Subtract(n) => self.counter = self.counter.saturating_sub(n as u32),
+            Operation::Multiply(n) => self.counter *= n as u32,
+            Operation::Reset => self.counter = 0,
+        }
+        self.messages_log
+            .push(format!("Operation: {} -> {}", old_value, self.counter));
+        self.counter
+    }
+
+    #[handler]
+    async fn handle_simple_message(&mut self, msg: SimpleMessage, _: &ActorRef<Self>) -> u64 {
+        self.messages_log.push(format!(
+            "Simple message: id={}, content={}",
+            msg.id, msg.content
+        ));
+        msg.id
+    }
+
+    #[handler]
+    async fn handle_complex_message(&mut self, msg: ComplexMessage, _: &ActorRef<Self>) -> usize {
+        let payload_size = msg.payload.data.len();
+        self.messages_log.push(format!(
+            "Complex message from {} at {}, payload size: {}",
+            msg.header.sender, msg.header.timestamp, payload_size
+        ));
+        payload_size
+    }
+
+    #[handler]
+    async fn handle_get_status(&mut self, _msg: GetStatus, _: &ActorRef<Self>) -> StatusResponse {
+        let last_messages = self
+            .messages_log
+            .iter()
+            .rev()
+            .take(5)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+
+        StatusResponse {
+            counter: self.counter,
+            messages_count: self.messages_log.len(),
+            data_store_size: self.data_store.len(),
+            last_messages,
+        }
+    }
+
+    // Handlers for additional complex generic message types
+
+    #[handler]
+    async fn handle_multi_generic_message(
+        &mut self,
+        msg: MultiGenericMessage<String, i32>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        self.messages_log.push(format!(
+            "Multi-generic: {} + {} in context '{}'",
+            msg.primary, msg.secondary, msg.context
+        ));
+        format!("Combined: {} + {}", msg.primary, msg.secondary)
+    }
+
+    #[handler]
+    async fn handle_multi_generic_vec_bool(
+        &mut self,
+        msg: MultiGenericMessage<Vec<u8>, bool>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        self.messages_log.push(format!(
+            "Multi-generic vec+bool: {} bytes, flag: {}, context: '{}'",
+            msg.primary.len(),
+            msg.secondary,
+            msg.context
+        ));
+        msg.primary.len()
+    }
+
+    #[handler]
+    async fn handle_constrained_generic_string(
+        &mut self,
+        msg: ConstrainedGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        self.messages_log.push(format!(
+            "Constrained generic: {:?} with {} metadata items",
+            msg.data,
+            msg.metadata.len()
+        ));
+        msg.metadata.len()
+    }
+
+    #[handler]
+    async fn handle_constrained_generic_number(
+        &mut self,
+        msg: ConstrainedGeneric<i64>,
+        _: &ActorRef<Self>,
+    ) -> i64 {
+        self.messages_log.push(format!(
+            "Constrained generic number: {:?} with metadata",
+            msg.data
+        ));
+        msg.data * 10
+    }
+
+    #[handler]
+    async fn handle_nested_generic_string(
+        &mut self,
+        msg: NestedGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        let item_count = msg.outer.items.len();
+        self.messages_log.push(format!(
+            "Nested generic: {} items, fallback: {:?}",
+            item_count, msg.fallback
+        ));
+        item_count
+    }
+
+    #[handler]
+    async fn handle_nested_generic_number(
+        &mut self,
+        msg: NestedGeneric<i32>,
+        _: &ActorRef<Self>,
+    ) -> i32 {
+        let sum: i32 = msg.outer.items.iter().sum();
+        self.messages_log.push(format!(
+            "Nested generic numbers: sum={}, fallback: {:?}",
+            sum, msg.fallback
+        ));
+        sum
+    }
+
+    #[handler]
+    async fn handle_generic_with_ownership(
+        &mut self,
+        msg: GenericWithOwnership<f64>,
+        _: &ActorRef<Self>,
+    ) -> f64 {
+        self.messages_log.push(format!(
+            "Generic with ownership: value={}, ref_data='{}'",
+            *msg.owned_data, msg.reference_data
+        ));
+        *msg.owned_data * 2.0
+    }
+
+    #[handler]
+    async fn handle_complex_nested(
+        &mut self,
+        msg: ComplexNested<String, i32, bool>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        let queue_size = msg.processing_queue.len();
+        self.messages_log.push(format!(
+            "Complex nested: {} items in queue, metadata: {}",
+            queue_size, msg.metadata
+        ));
+        queue_size
+    }
+
+    #[handler]
+    async fn handle_generic_operation_string(
+        &mut self,
+        msg: GenericOperation<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let result = match msg {
+            GenericOperation::Process(s) => format!("Processed: {}", s),
+            GenericOperation::Transform { input, factor } => {
+                format!("Transformed: {} (factor: {})", input, factor)
+            }
+            GenericOperation::Batch(items) => format!("Batch: {} items", items.len()),
+            GenericOperation::None => "None operation".to_string(),
+        };
+        self.messages_log
+            .push(format!("Generic operation result: {}", result));
+        result
+    }
+
+    #[handler]
+    async fn handle_generic_operation_number(
+        &mut self,
+        msg: GenericOperation<i32>,
+        _: &ActorRef<Self>,
+    ) -> i32 {
+        let result = match msg {
+            GenericOperation::Process(n) => n * 2,
+            GenericOperation::Transform { input, factor } => (input as f64 * factor) as i32,
+            GenericOperation::Batch(items) => items.iter().sum(),
+            GenericOperation::None => 0,
+        };
+        self.messages_log
+            .push(format!("Generic operation number result: {}", result));
+        result
+    }
+
+    #[handler]
+    async fn handle_recursive_generic(
+        &mut self,
+        msg: RecursiveGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        self.messages_log.push(format!(
+            "Recursive generic: value='{}', depth={}, children={}",
+            msg.value,
+            msg.depth,
+            msg.children.len()
+        ));
+        msg.depth
+    }
+
+    #[handler]
+    async fn handle_generic_processor(
+        &mut self,
+        msg: GenericProcessor<String, i32>,
+        _: &ActorRef<Self>,
+    ) -> i32 {
+        self.messages_log.push(format!(
+            "Generic processor: input='{}', processor_id='{}'",
+            msg.input, msg.processor_id
+        ));
+        msg.input.len() as i32
+    }
+
+    #[handler]
+    async fn handle_generic_tuple(
+        &mut self,
+        msg: GenericTuple<String, i32, bool>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        self.messages_log
+            .push(format!("Generic tuple: ({}, {}, {})", msg.0, msg.1, msg.2));
+        "Tuple processed".to_string() // Fixed clippy warning
+    }
+
+    #[handler]
+    async fn handle_complex_generic_result(
+        &mut self,
+        msg: ComplexGenericResult<String, i32>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        let success_count = msg.results.iter().filter(|r| r.is_ok()).count();
+        self.messages_log.push(format!(
+            "Complex generic result: {}/{} successful, retry_count: {}",
+            success_count,
+            msg.results.len(),
+            msg.retry_count
+        ));
+        success_count
+    }
+
+    // Handlers for additional complex generic message types with advanced trait bounds
+
+    #[handler]
+    async fn handle_advanced_constrained_generic(
+        &mut self,
+        msg: AdvancedConstrainedGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let hash_size = msg.hash_map.len();
+        self.messages_log.push(format!(
+            "Advanced constrained: data='{}', hash_size={}, default='{}'",
+            msg.data, hash_size, msg.default_value
+        ));
+        format!("processed_{}_{}", msg.data, hash_size)
+    }
+
+    #[handler]
+    async fn handle_math_bound_generic(
+        &mut self,
+        msg: MathBoundGeneric<f64>,
+        _: &ActorRef<Self>,
+    ) -> f64 {
+        let sum: f64 = msg.values.iter().sum();
+        self.messages_log.push(format!(
+            "Math bound: {} values, sum={}, operations: {:?}",
+            msg.values.len(),
+            sum,
+            msg.operations_log
+        ));
+        sum
+    }
+
+    #[handler]
+    async fn handle_phantom_complex_generic(
+        &mut self,
+        msg: PhantomComplexGeneric<String, String, i32>,
+        _: &ActorRef<Self>,
+    ) -> usize {
+        let data_size = msg.data.len();
+        self.messages_log.push(format!(
+            "Phantom complex: {} items, type_info='{}'",
+            data_size, msg.type_info
+        ));
+        data_size
+    }
+
+    #[handler]
+    async fn handle_function_bound_generic(
+        &mut self,
+        msg: FunctionBoundGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let transformed = format!("transformed_{}", msg.data);
+        self.messages_log.push(format!(
+            "Function bound: data='{}', transformer_id='{}'",
+            msg.data, msg.transformer_id
+        ));
+        transformed
+    }
+
+    #[handler]
+    async fn handle_iterator_bound_generic(
+        &mut self,
+        msg: IteratorBoundGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let first_item = msg.source.first().cloned().unwrap_or_default();
+        self.messages_log.push(format!(
+            "Iterator bound: first_item='{}', config='{}'",
+            first_item, msg.iterator_config
+        ));
+        first_item
+    }
+
+    #[handler]
+    async fn handle_serialization_bound_generic(
+        &mut self,
+        msg: SerializationBoundGeneric<String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        self.messages_log.push(format!(
+            "Serialization bound: data='{}', cached='{}'",
+            msg.data, msg.serialized_cache
+        ));
+        msg.data
+    }
+
+    #[handler]
+    async fn handle_associated_type_bound_generic(
+        &mut self,
+        msg: AssociatedTypeBoundGeneric<CustomProcessorImpl>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let cache_size = msg.input_cache.len();
+        self.messages_log.push(format!(
+            "Associated type bound: cache_size={}, errors={}",
+            cache_size,
+            msg.error_log.len()
+        ));
+        format!("processed_with_cache_size_{}", cache_size)
+    }
+
+    #[handler]
+    async fn handle_nested_trait_bound_generic(
+        &mut self,
+        msg: NestedTraitBoundGeneric<String, String, String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let original = msg.original.clone();
+        let result = msg
+            .final_result
+            .unwrap_or_else(|| msg.intermediate.unwrap_or(msg.original));
+        self.messages_log.push(format!(
+            "Nested trait bound: original='{}', final='{}'",
+            original, result
+        ));
+        result
+    }
+
+    #[handler]
+    async fn handle_async_bound_generic(
+        &mut self,
+        msg: AsyncBoundGeneric<String, String>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let result = format!("async_processed_{}", msg.input);
+        self.messages_log.push(format!(
+            "Async bound: input='{}', processor_id='{}'",
+            msg.input, msg.processor_id
+        ));
+        result
+    }
+
+    #[handler]
+    async fn handle_error_handling_generic(
+        &mut self,
+        msg: ErrorHandlingGeneric<String, CustomError>,
+        _: &ActorRef<Self>,
+    ) -> String {
+        let mut success_count = 0;
+        for result in &msg.operations {
+            if result.is_ok() {
+                success_count += 1;
+            }
+        }
+
+        let response = format!(
+            "Processed {} successful operations out of {}",
+            success_count,
+            msg.operations.len()
+        );
+        self.messages_log.push(format!(
+            "Error handling: successes={}/{}, recovery_options={}",
+            success_count,
+            msg.operations.len(),
+            msg.error_recovery.len()
+        ));
+        response
+    }
+}
+
+#[tokio::test]
+async fn test_simple_unit_struct_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let response: String = actor_ref.ask(Ping).await.unwrap();
+    assert_eq!(response, "Pong #1");
+
+    let response: String = actor_ref.ask(Ping).await.unwrap();
+    assert_eq!(response, "Pong #2");
+}
+
+#[tokio::test]
+async fn test_tuple_struct_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let old_value: u32 = actor_ref.ask(SetCounter(42)).await.unwrap();
+    assert_eq!(old_value, 0);
+
+    let old_value: u32 = actor_ref.ask(SetCounter(100)).await.unwrap();
+    assert_eq!(old_value, 42);
+}
+
+#[tokio::test]
+async fn test_named_struct_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let is_new: bool = actor_ref
+        .ask(StoreData {
+            key: "test_key".to_string(),
+            value: 123,
+        })
+        .await
+        .unwrap();
+    assert!(is_new);
+
+    let is_new: bool = actor_ref
+        .ask(StoreData {
+            key: "test_key".to_string(),
+            value: 456,
+        })
+        .await
+        .unwrap();
+    assert!(!is_new); // same key, so not new
+}
+
+#[tokio::test]
+async fn test_generic_messages() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test generic with String
+    let response: String = actor_ref
+        .ask(GenericMessage {
+            data: "Hello World".to_string(),
+            label: "greeting".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(response, "Processed: Hello World");
+
+    // Test generic with i32
+    let response: i32 = actor_ref
+        .ask(GenericMessage {
+            data: 21,
+            label: "number".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(response, 42);
+}
+
+#[tokio::test]
+async fn test_batch_update_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let updates = vec![
+        ("key1".to_string(), 1),
+        ("key2".to_string(), 2),
+        ("key3".to_string(), 3),
+    ];
+
+    let count: usize = actor_ref.ask(BatchUpdate { updates }).await.unwrap();
+    assert_eq!(count, 3);
+}
+
+#[tokio::test]
+async fn test_optional_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test with Some value
+    let response: String = actor_ref
+        .ask(OptionalMessage {
+            required_field: "test".to_string(),
+            optional_field: Some(42),
+        })
+        .await
+        .unwrap();
+    assert_eq!(response, "test: 42");
+
+    // Test with None value
+    let response: String = actor_ref
+        .ask(OptionalMessage {
+            required_field: "test2".to_string(),
+            optional_field: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(response, "test2: no value");
+}
+
+#[tokio::test]
+async fn test_enum_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Set initial value
+    let _: u32 = actor_ref.ask(SetCounter(10)).await.unwrap();
+
+    let result: u32 = actor_ref.ask(Operation::Add(5)).await.unwrap();
+    assert_eq!(result, 15);
+
+    let result: u32 = actor_ref.ask(Operation::Multiply(2)).await.unwrap();
+    assert_eq!(result, 30);
+
+    let result: u32 = actor_ref.ask(Operation::Subtract(10)).await.unwrap();
+    assert_eq!(result, 20);
+
+    let result: u32 = actor_ref.ask(Operation::Reset).await.unwrap();
+    assert_eq!(result, 0);
+}
+
+#[tokio::test]
+async fn test_simple_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut metadata = HashMap::new();
+    metadata.insert("version".to_string(), "1.0".to_string());
+    metadata.insert("source".to_string(), "test".to_string());
+
+    let msg = SimpleMessage {
+        id: 12345,
+        content: "Test message content".to_string(),
+        metadata,
+    };
+
+    let response: u64 = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, 12345);
+}
+
+#[tokio::test]
+async fn test_complex_nested_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = ComplexMessage {
+        header: MessageHeader {
+            timestamp: 1234567890,
+            sender: "test_sender".to_string(),
+            priority: 1,
+        },
+        payload: MessagePayload {
+            data: vec![1, 2, 3, 4, 5],
+            format: "binary".to_string(),
+        },
+    };
+
+    let payload_size: usize = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(payload_size, 5);
+}
+
+#[tokio::test]
+async fn test_status_query_message() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Send some messages first
+    let _: String = actor_ref.ask(Ping).await.unwrap();
+    let _: u32 = actor_ref.ask(SetCounter(42)).await.unwrap();
+    let _: bool = actor_ref
+        .ask(StoreData {
+            key: "test".to_string(),
+            value: 123,
+        })
+        .await
+        .unwrap();
+
+    // Get status
+    let status: StatusResponse = actor_ref.ask(GetStatus).await.unwrap();
+
+    assert_eq!(status.counter, 42);
+    assert_eq!(status.data_store_size, 1);
+    assert!(status.messages_count >= 3);
+    assert!(!status.last_messages.is_empty());
+}
+
+#[tokio::test]
+async fn test_multiple_message_types_concurrently() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Send multiple different message types concurrently
+    let ping_task = actor_ref.ask(Ping);
+    let counter_task = actor_ref.ask(SetCounter(100));
+    let store_task = actor_ref.ask(StoreData {
+        key: "concurrent_test".to_string(),
+        value: 999,
+    });
+
+    let (ping_result, counter_result, store_result) =
+        tokio::try_join!(ping_task, counter_task, store_task).unwrap();
+
+    // Note: Due to concurrent execution, the ping might be processed after SetCounter
+    // so we just check that all operations completed successfully
+    assert!(ping_result.starts_with("Pong #"));
+    // counter_result could be 0 or 1 depending on execution order
+    assert!(counter_result <= 1);
+    assert!(store_result); // new key
+}
+
+#[tokio::test]
+async fn test_message_with_timeout() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test that messages complete within reasonable time
+    let result = timeout(Duration::from_millis(100), actor_ref.ask(Ping)).await;
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().unwrap(), "Pong #1");
+}
+
+#[tokio::test]
+async fn test_large_batch_processing() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Create a large batch of updates
+    let updates: Vec<(String, i32)> = (0..1000).map(|i| (format!("key_{}", i), i)).collect();
+
+    let count: usize = actor_ref.ask(BatchUpdate { updates }).await.unwrap();
+    assert_eq!(count, 1000);
+
+    // Verify the data was stored
+    let status: StatusResponse = actor_ref.ask(GetStatus).await.unwrap();
+    assert_eq!(status.data_store_size, 1000);
+}
+
+// Complex Generic Type Tests
+
+#[tokio::test]
+async fn test_multi_generic_messages() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test String + i32 combination
+    let msg1 = MultiGenericMessage {
+        primary: "Hello".to_string(),
+        secondary: 42,
+        context: "test_context".to_string(),
+    };
+    let response1: String = actor_ref.ask(msg1).await.unwrap();
+    assert_eq!(response1, "Combined: Hello + 42");
+
+    // Test Vec<u8> + bool combination
+    let msg2 = MultiGenericMessage {
+        primary: vec![1, 2, 3, 4, 5],
+        secondary: true,
+        context: "binary_context".to_string(),
+    };
+    let response2: usize = actor_ref.ask(msg2).await.unwrap();
+    assert_eq!(response2, 5);
+}
+
+#[tokio::test]
+async fn test_constrained_generic_messages() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test with String
+    let msg1 = ConstrainedGeneric {
+        data: "test_data".to_string(),
+        metadata: vec!["meta1".to_string(), "meta2".to_string()],
+    };
+    let response1: usize = actor_ref.ask(msg1).await.unwrap();
+    assert_eq!(response1, 2);
+
+    // Test with i64
+    let msg2 = ConstrainedGeneric {
+        data: 123i64,
+        metadata: vec!["tag1".to_string()],
+    };
+    let response2: i64 = actor_ref.ask(msg2).await.unwrap();
+    assert_eq!(response2, 1230);
+}
+
+#[tokio::test]
+async fn test_nested_generic_messages() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test with String
+    let msg1 = NestedGeneric {
+        outer: GenericContainer {
+            items: vec![
+                "item1".to_string(),
+                "item2".to_string(),
+                "item3".to_string(),
+            ],
+            capacity: 10,
+        },
+        fallback: Some("fallback".to_string()),
+    };
+    let response1: usize = actor_ref.ask(msg1).await.unwrap();
+    assert_eq!(response1, 3);
+
+    // Test with i32
+    let msg2 = NestedGeneric {
+        outer: GenericContainer {
+            items: vec![10, 20, 30, 40],
+            capacity: 5,
+        },
+        fallback: None,
+    };
+    let response2: i32 = actor_ref.ask(msg2).await.unwrap();
+    assert_eq!(response2, 100); // sum of 10+20+30+40
+}
+
+#[tokio::test]
+async fn test_generic_with_ownership() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = GenericWithOwnership {
+        owned_data: Box::new(std::f64::consts::PI),
+        reference_data: "pi_reference".to_string(),
+    };
+
+    let response: f64 = actor_ref.ask(msg).await.unwrap();
+    assert!((response - std::f64::consts::TAU).abs() < 0.01); // PI * 2 = TAU
+}
+
+#[tokio::test]
+async fn test_complex_nested_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut map_data = HashMap::new();
+    map_data.insert("key1".to_string(), 100);
+    map_data.insert("key2".to_string(), 200);
+
+    let msg = ComplexNested {
+        map_data,
+        metadata: true,
+        processing_queue: vec![
+            ("queue1".to_string(), 1),
+            ("queue2".to_string(), 2),
+            ("queue3".to_string(), 3),
+        ],
+    };
+
+    let response: usize = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, 3);
+}
+
+#[tokio::test]
+async fn test_generic_operation_enum() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    // Test with String operations
+    let response1: String = actor_ref
+        .ask(GenericOperation::Process("test_string".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(response1, "Processed: test_string");
+
+    let response2: String = actor_ref
+        .ask(GenericOperation::Transform {
+            input: "transform_me".to_string(),
+            factor: 2.5,
+        })
+        .await
+        .unwrap();
+    assert_eq!(response2, "Transformed: transform_me (factor: 2.5)");
+
+    let response3: String = actor_ref
+        .ask(GenericOperation::Batch(vec![
+            "item1".to_string(),
+            "item2".to_string(),
+        ]))
+        .await
+        .unwrap();
+    assert_eq!(response3, "Batch: 2 items");
+
+    // Test with i32 operations
+    let response4: i32 = actor_ref.ask(GenericOperation::Process(21)).await.unwrap();
+    assert_eq!(response4, 42); // 21 * 2
+
+    let response5: i32 = actor_ref
+        .ask(GenericOperation::Transform {
+            input: 10,
+            factor: 3.5,
+        })
+        .await
+        .unwrap();
+    assert_eq!(response5, 35); // 10 * 3.5 = 35
+
+    let response6: i32 = actor_ref
+        .ask(GenericOperation::Batch(vec![1, 2, 3, 4, 5]))
+        .await
+        .unwrap();
+    assert_eq!(response6, 15); // sum
+}
+
+#[tokio::test]
+async fn test_recursive_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let child1 = RecursiveGeneric {
+        value: "child1".to_string(),
+        children: vec![],
+        depth: 2,
+    };
+
+    let child2 = RecursiveGeneric {
+        value: "child2".to_string(),
+        children: vec![],
+        depth: 2,
+    };
+
+    let msg = RecursiveGeneric {
+        value: "root".to_string(),
+        children: vec![Box::new(child1), Box::new(child2)],
+        depth: 1,
+    };
+
+    let response: usize = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, 1); // depth of root
+}
+
+#[tokio::test]
+async fn test_generic_processor() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = GenericProcessor {
+        input: "process_this_string".to_string(),
+        processor_id: "processor_v2".to_string(),
+        expected_output_type: std::marker::PhantomData::<i32>,
+    };
+
+    let response: i32 = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, 19); // length of "process_this_string"
+}
+
+#[tokio::test]
+async fn test_generic_tuple() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = GenericTuple("tuple_string".to_string(), 123, true);
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "Tuple processed");
+}
+
+#[tokio::test]
+async fn test_complex_generic_result() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = ComplexGenericResult {
+        results: vec![
+            Ok("success1".to_string()),
+            Err(404),
+            Ok("success2".to_string()),
+            Err(500),
+            Ok("success3".to_string()),
+        ],
+        summary: Some("Processing results".to_string()),
+        retry_count: 2,
+    };
+
+    let response: usize = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, 3); // 3 successful results
+}
+
+// Advanced Complex Generic Type Tests
+
+#[tokio::test]
+async fn test_advanced_constrained_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut hash_map = HashMap::new();
+    hash_map.insert("key1".to_string(), "value1".to_string());
+    hash_map.insert("key2".to_string(), "value2".to_string());
+
+    let msg = AdvancedConstrainedGeneric {
+        data: "test_data".to_string(),
+        hash_map,
+        default_value: String::default(),
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "processed_test_data_2");
+}
+
+#[tokio::test]
+async fn test_function_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = FunctionBoundGeneric {
+        data: "input_data".to_string(),
+        transformer_id: "transformer_v1".to_string(),
+        cache: vec!["cached1".to_string(), "cached2".to_string()],
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "transformed_input_data");
+}
+
+#[tokio::test]
+async fn test_iterator_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = IteratorBoundGeneric {
+        source: vec![
+            "item1".to_string(),
+            "item2".to_string(),
+            "item3".to_string(),
+        ],
+        iterator_config: "parallel_config".to_string(),
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "item1");
+}
+
+#[tokio::test]
+async fn test_serialization_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut metadata = HashMap::new();
+    metadata.insert("format".to_string(), "json".to_string());
+    metadata.insert("version".to_string(), "2.0".to_string());
+
+    let msg = SerializationBoundGeneric {
+        data: "serializable_data".to_string(),
+        serialized_cache: "{\"data\":\"serializable_data\"}".to_string(),
+        metadata,
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "serializable_data");
+}
+
+#[tokio::test]
+async fn test_math_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = MathBoundGeneric {
+        values: vec![1.0, 2.5, 3.7, 4.2],
+        operations_log: vec!["add".to_string(), "multiply".to_string()],
+    };
+
+    let response: f64 = actor_ref.ask(msg).await.unwrap();
+    assert!((response - 11.4).abs() < 0.01); // sum of values
+}
+
+#[tokio::test]
+async fn test_associated_type_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut input_cache = HashMap::new();
+    input_cache.insert("test_input".to_string(), 10);
+
+    let msg = AssociatedTypeBoundGeneric {
+        processor: CustomProcessorImpl,
+        input_cache,
+        error_log: vec!["previous_error".to_string()],
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "processed_with_cache_size_1");
+}
+
+#[tokio::test]
+async fn test_async_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = AsyncBoundGeneric {
+        input: "async_input".to_string(),
+        processor_id: "async_processor_v2".to_string(),
+        result_cache: Some("cached_result".to_string()),
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "async_processed_async_input");
+}
+
+#[tokio::test]
+async fn test_nested_trait_bound_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let msg = NestedTraitBoundGeneric {
+        original: "original_value".to_string(),
+        intermediate: Some("intermediate_value".to_string()),
+        final_result: Some("final_result".to_string()),
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "final_result");
+}
+
+#[tokio::test]
+async fn test_error_handling_generic() {
+    let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
+
+    let mut error_recovery = HashMap::new();
+    error_recovery.insert("error_type_1".to_string(), "recovery_value_1".to_string());
+
+    let msg = ErrorHandlingGeneric {
+        operations: vec![
+            Ok("success1".to_string()),
+            Err(CustomError {
+                message: "test error".to_string(),
+                code: 404,
+            }),
+            Ok("success2".to_string()),
+            Err(CustomError {
+                message: "another error".to_string(),
+                code: 500,
+            }),
+        ],
+        error_recovery,
+    };
+
+    let response: String = actor_ref.ask(msg).await.unwrap();
+    assert_eq!(response, "Processed 2 successful operations out of 4");
+}

--- a/tests/message_handlers_macro_tests.rs
+++ b/tests/message_handlers_macro_tests.rs
@@ -461,7 +461,7 @@ impl MessageHandlerTestActor {
             self.data_store.insert(key, value);
         }
         self.messages_log
-            .push(format!("Batch updated {} items", count));
+            .push(format!("Batch updated {count} items"));
         count
     }
 
@@ -476,7 +476,7 @@ impl MessageHandlerTestActor {
             None => format!("{}: no value", msg.required_field),
         };
         self.messages_log
-            .push(format!("Optional message: {}", response));
+            .push(format!("Optional message: {response}"));
         response
     }
 
@@ -653,15 +653,15 @@ impl MessageHandlerTestActor {
         _: &ActorRef<Self>,
     ) -> String {
         let result = match msg {
-            GenericOperation::Process(s) => format!("Processed: {}", s),
+            GenericOperation::Process(s) => format!("Processed: {s}"),
             GenericOperation::Transform { input, factor } => {
-                format!("Transformed: {} (factor: {})", input, factor)
+                format!("Transformed: {input} (factor: {factor})")
             }
             GenericOperation::Batch(items) => format!("Batch: {} items", items.len()),
             GenericOperation::None => "None operation".to_string(),
         };
         self.messages_log
-            .push(format!("Generic operation result: {}", result));
+            .push(format!("Generic operation result: {result}"));
         result
     }
 
@@ -678,7 +678,7 @@ impl MessageHandlerTestActor {
             GenericOperation::None => 0,
         };
         self.messages_log
-            .push(format!("Generic operation number result: {}", result));
+            .push(format!("Generic operation number result: {result}"));
         result
     }
 
@@ -836,7 +836,7 @@ impl MessageHandlerTestActor {
             cache_size,
             msg.error_log.len()
         ));
-        format!("processed_with_cache_size_{}", cache_size)
+        format!("processed_with_cache_size_{cache_size}")
     }
 
     #[handler]
@@ -850,8 +850,7 @@ impl MessageHandlerTestActor {
             .final_result
             .unwrap_or_else(|| msg.intermediate.unwrap_or(msg.original));
         self.messages_log.push(format!(
-            "Nested trait bound: original='{}', final='{}'",
-            original, result
+            "Nested trait bound: original='{original}', final='{result}'"
         ));
         result
     }
@@ -1127,7 +1126,7 @@ async fn test_large_batch_processing() {
     let (actor_ref, _join_handle) = spawn::<MessageHandlerTestActor>(());
 
     // Create a large batch of updates
-    let updates: Vec<(String, i32)> = (0..1000).map(|i| (format!("key_{}", i), i)).collect();
+    let updates: Vec<(String, i32)> = (0..1000).map(|i| (format!("key_{i}"), i)).collect();
 
     let count: usize = actor_ref.ask(BatchUpdate { updates }).await.unwrap();
     assert_eq!(count, 1000);

--- a/tests/panic_handling_tests.rs
+++ b/tests/panic_handling_tests.rs
@@ -53,9 +53,7 @@ impl Actor for PanicTestActor {
     async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<(), Self::Error> {
         if let Some(threshold) = self.panic_threshold {
             if self.counter >= threshold {
-                panic!(
-                    "Counter reached threshold {threshold} - intentional panic in on_run!"
-                );
+                panic!("Counter reached threshold {threshold} - intentional panic in on_run!");
             }
         }
 
@@ -647,9 +645,7 @@ mod stress_tests {
 
         // At least some messages should have been processed
         assert!(success_count > 0);
-        println!(
-            "Processed {success_count} messages before panic, {error_count} failed"
-        );
+        println!("Processed {success_count} messages before panic, {error_count} failed");
 
         // Actor should have panicked
         let join_result = join_handle.await;

--- a/tests/panic_handling_tests.rs
+++ b/tests/panic_handling_tests.rs
@@ -54,8 +54,7 @@ impl Actor for PanicTestActor {
         if let Some(threshold) = self.panic_threshold {
             if self.counter >= threshold {
                 panic!(
-                    "Counter reached threshold {} - intentional panic in on_run!",
-                    threshold
+                    "Counter reached threshold {threshold} - intentional panic in on_run!"
                 );
             }
         }
@@ -649,8 +648,7 @@ mod stress_tests {
         // At least some messages should have been processed
         assert!(success_count > 0);
         println!(
-            "Processed {} messages before panic, {} failed",
-            success_count, error_count
+            "Processed {success_count} messages before panic, {error_count} failed"
         );
 
         // Actor should have panicked
@@ -774,8 +772,8 @@ mod integration_tests {
             } else {
                 let result = actor_ref.ask(WorkItem(i)).await?;
                 match result {
-                    Ok(msg) => println!("Success: {}", msg),
-                    Err(err) => println!("Expected error: {}", err),
+                    Ok(msg) => println!("Success: {msg}"),
+                    Err(err) => println!("Expected error: {err}"),
                 }
             }
         }

--- a/tests/panic_handling_tests.rs
+++ b/tests/panic_handling_tests.rs
@@ -8,6 +8,7 @@
 //! - Tests for panics in on_run method
 //! - Tests for proper error handling vs panicking
 //! - Tests for supervision patterns
+#![allow(deprecated)]
 
 use anyhow::Result;
 use log::info;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
+#![allow(deprecated)]
 
 use log::debug;
 use std::sync::Arc;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -266,10 +266,10 @@ async fn test_actor_ref_kill() {
 
         // Verify that the UpdateCounterMsg(10) was NOT processed because kill took priority.
         let final_counter = *actor.counter.lock().await;
-        assert_eq!(final_counter, 0, "Counter should be 0, indicating UpdateCounterMsg was not processed due to kill priority. Got: {}", final_counter);
+        assert_eq!(final_counter, 0, "Counter should be 0, indicating UpdateCounterMsg was not processed due to kill priority. Got: {final_counter}");
 
         let final_lpmt = actor.last_processed_message_type.lock().await.clone();
-        assert_eq!(final_lpmt, None, "Last processed message type should be None, indicating UpdateCounterMsg was not processed. Got: {:?}", final_lpmt);
+        assert_eq!(final_lpmt, None, "Last processed message type should be None, indicating UpdateCounterMsg was not processed. Got: {final_lpmt:?}");
         assert_eq!(
             actor.id,
             actor_ref.identity(),
@@ -486,7 +486,7 @@ async fn test_set_default_mailbox_capacity_to_zero() {
     let result = set_default_mailbox_capacity(0);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(format!("{}", err).contains("Mailbox capacity error:"));
+    assert!(format!("{err}").contains("Mailbox capacity error:"));
     assert!(
         matches!(err, Error::MailboxCapacity { message } if message == "Global default mailbox capacity must be greater than 0"),
         "Error message for zero capacity didn't match"
@@ -589,7 +589,7 @@ async fn test_actor_panic_in_message_handler() {
     assert!(ask_result.is_err(), "Ask should fail when handler panics");
     if let Err(e) = ask_result {
         // Error could be "reply channel closed" or similar, as the actor task terminates.
-        println!("Ask error after handler panic: {}", e);
+        println!("Ask error after handler panic: {e}");
         assert!(
             e.to_string().contains("Reply channel closed")
                 || e.to_string().contains("Mailbox channel closed")
@@ -603,8 +603,7 @@ async fn test_actor_panic_in_message_handler() {
             // However, if the framework were to catch panics and convert them to runtime failures,
             // this would be the case. Current code does not do this for handler panics.
             panic!(
-                "Expected JoinHandle to return Err due to task panic, but got Ok with result: {:?}",
-                result
+                "Expected JoinHandle to return Err due to task panic, but got Ok with result: {result:?}"
             );
         }
         Err(join_error) => {
@@ -800,8 +799,7 @@ async fn test_actor_ref_ask_blocking_timeout() {
             // Just check that it contains "timed out" which is what we care about
             assert!(
                 e.to_string().contains("timed out"),
-                "Error should indicate a timeout: {}",
-                e
+                "Error should indicate a timeout: {e}"
             );
         }
     });
@@ -906,8 +904,7 @@ async fn test_actor_ref_tell_blocking_timeout_when_mailbox_full() {
         let counter_value = *actor.counter.lock().await;
         assert!(
             counter_value >= 1,
-            "Counter should be at least 1 after SlowMsg and UpdateCounterMsg(1), got: {}",
-            counter_value
+            "Counter should be at least 1 after SlowMsg and UpdateCounterMsg(1), got: {counter_value}"
         );
     } else {
         panic!("Actor state should not be None");
@@ -964,8 +961,7 @@ async fn test_actor_ref_kill_multiple_times() {
         let final_counter = *actor.counter.lock().await;
         assert_eq!(
             final_counter, 0,
-            "Counter should be 0, indicating no messages processed due to kill. Got: {}",
-            final_counter
+            "Counter should be 0, indicating no messages processed due to kill. Got: {final_counter}"
         );
     } else {
         panic!("Actor state should not be None");
@@ -1068,8 +1064,7 @@ async fn test_ask_with_timeout() {
     if let Err(e) = result {
         assert!(
             e.to_string().contains("timed out"),
-            "Error message should mention timeout: {}",
-            e
+            "Error message should mention timeout: {e}"
         );
     }
 
@@ -1426,8 +1421,7 @@ async fn test_untyped_actor_ref_tell_incompatible_after_stop() {
         assert!(
             e.to_string().contains("Mailbox channel closed")
                 || e.to_string().contains("Failed to send message"),
-            "Error should indicate mailbox is closed, got: {}",
-            e
+            "Error should indicate mailbox is closed, got: {e}"
         );
     }
 
@@ -1463,8 +1457,7 @@ async fn test_untyped_actor_ref_ask_incompatible_message_error_handling() {
     if let Err(e) = ask_result {
         assert!(
             e.to_string().contains("received an unhandled message type"),
-            "Ask error should indicate unhandled message type, got: {}",
-            e
+            "Ask error should indicate unhandled message type, got: {e}"
         );
     }
 
@@ -1578,8 +1571,7 @@ async fn test_untyped_actor_ref_tell_vs_ask_behavior_comparison() {
         if let Err(e) = ask_result {
             assert!(
                 e.to_string().contains("received an unhandled message type"),
-                "Ask error should indicate unhandled message type, got: {}",
-                e
+                "Ask error should indicate unhandled message type, got: {e}"
             );
         }
 


### PR DESCRIPTION
This commit introduces the #[message_handlers] and #[handler] attribute macros to simplify the implementation of message handlers. This allows users to write message handling logic for actors with more intuitive and concise code.

Key changes:

- Add #[message_handlers] and #[handler] macros.
- Deprecate the existing impl_message_handler! macro.
- Refactor all examples and tests to use the new macros.
- Update documentation in README.md and lib.rs.
- Add CHANGELOG.md.