### PR TITLE
feat(actor): add opt-in priority channel for control-plane messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Priority channel** (opt-in, off by default): a second mpsc channel of fixed
+  capacity 1 that is polled with higher priority than the regular mailbox
+  but lower priority than the `kill()` (terminate) signal. Designed for
+  short, infrequent control-plane messages such as health checks and
+  pause/resume signals.
+  - `SpawnOptions` builder + `spawn_with_options()` entry point.
+    `SpawnOptions::new().with_priority()` enables the priority channel.
+  - `ActorRef::tell_priority(msg, timeout)` /
+    `ActorRef::ask_priority(msg, timeout)` and their
+    `blocking_tell_priority` / `blocking_ask_priority` counterparts.
+    `Duration` is mandatory — the priority slot has capacity 1, so a wedged
+    actor would otherwise block the sender indefinitely.
+  - `ActorRef::has_priority_channel()` to detect whether the channel was
+    enabled at spawn time.
+  - `Error::PriorityChannelNotEnabled` returned when priority APIs are
+    called on an actor spawned without `with_priority()`. This is a
+    configuration error and is **not** recorded as a dead letter.
+  - `stop()` drains the priority queue before invoking `on_stop` (close-then-
+    drain), so a priority message sent immediately before `stop()` is not
+    lost. `kill()` does not drain.
+  - `metrics` feature now tracks priority messages separately:
+    `priority_message_count`, `avg_priority_processing_time`,
+    `max_priority_processing_time` are exposed both on `MetricsSnapshot`
+    and as `ActorRef` accessors. The regular `message_count` no longer
+    includes priority messages.
+  - **Note on starvation:** the priority branch wins biased select against
+    the regular mailbox, so sustained priority traffic can starve regular
+    handlers. Reserve the priority channel for short, infrequent signals —
+    the `metrics` feature exposes both counters so abuse is detectable.
+  - New example: `examples/priority_signal.rs` (health check + pause/resume).
+
 ## [0.12.0] - 2025-01-18
 
 ### ⚠️ BREAKING CHANGES

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,48 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures"
@@ -142,74 +104,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core",
  "wasip2",
- "wasip3",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -251,13 +160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "ppv-lite86"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "proc-macro2",
- "syn",
+ "zerocopy",
 ]
 
 [[package]]
@@ -280,26 +188,38 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "6.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "chacha20",
- "getrandom",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.10.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rsactor"
@@ -323,54 +243,6 @@ dependencies = [
  "rsactor",
  "syn",
  "tokio",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "serde"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -499,12 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,50 +382,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -579,100 +402,26 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "zerocopy"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
+ "zerocopy-derive",
 ]
 
 [[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
+name = "zerocopy-derive"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
 ]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ required-features = ["test-utils"]
 [[test]]
 name = "deadlock_detection_tests"
 required-features = ["deadlock-detection"]
+
+[[test]]
+name = "priority_signal_tests"
+required-features = ["test-utils"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["actor", "rust", "framework"]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
 anyhow = "1.0"
 futures = "0.3"
-rand = "0.10"
+rand = "0.9"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ A Simple and Efficient In-Process Actor Model Implementation for Rust.
 | -------------------------------- | ------------------------------------------------------------ |
 | `ask` / `ask_with_timeout`       | Send a message and asynchronously await a reply              |
 | `tell` / `tell_with_timeout`     | Send a message without waiting for a reply (fire-and-forget) |
+| `tell_priority` / `ask_priority` | Send through the **opt-in** priority channel (mandatory `Duration`); bypasses the regular mailbox |
 | `blocking_ask` / `blocking_tell` | Blocking versions for `tokio::task::spawn_blocking` contexts (aliases: `ask_blocking` / `tell_blocking`) |
+| `blocking_tell_priority` / `blocking_ask_priority` | Blocking variants of the priority APIs |
 
 - **Macro-Assisted Handlers**: `#[message_handlers]` attribute macro with `#[handler]` method attributes for automatic message handling
+- **Priority Channel** (opt-in): enable via `SpawnOptions::new().with_priority()` and spawn with `spawn_with_options()`. The priority channel is a separate mpsc with fixed capacity 1 that is polled with higher priority than the regular mailbox but lower than `kill()`. Use it for short, infrequent control-plane messages (health checks, pause/resume); see `examples/priority_signal.rs`. Sustained priority traffic can starve regular handlers — the `metrics` feature exposes both counters so you can detect this.
 
 ### Actor Lifecycle
 Three well-defined hooks for managing actor behavior:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -388,6 +388,51 @@ A13: Error handling in `rsActor` happens at several levels:
 
 ## Advanced Usage
 
+**Q: When should I use the priority channel vs the regular mailbox vs `kill()`?**
+
+A: Use this decision tree:
+
+| Need                                                           | Use                          |
+| -------------------------------------------------------------- | ---------------------------- |
+| Normal application messages (any volume)                       | `tell` / `ask`               |
+| **Short, infrequent** control-plane messages that must skip a backed-up mailbox (health checks, pause/resume, config reload, dynamic feature toggles) | `tell_priority` / `ask_priority` |
+| Tear the actor down right now, dropping pending work           | `kill()`                     |
+| Tear the actor down, but finish what's already queued          | `stop()`                     |
+
+The priority channel is **opt-in**: you must spawn the actor with
+`spawn_with_options(args, SpawnOptions::new().with_priority())`. Default
+`spawn()` and `spawn_with_mailbox_capacity()` do **not** create the priority
+channel — calling `tell_priority` on such an actor returns
+`Error::PriorityChannelNotEnabled` (a configuration error; not recorded as a
+dead letter). Check at runtime with `actor_ref.has_priority_channel()`.
+
+A few important properties:
+
+- **Capacity is fixed at 1.** The priority channel exists to serialize "short
+  and rare" signals, not to stream traffic. The slot is freed the instant the
+  actor calls `recv()`, so admission resumes immediately at the next
+  `select!` iteration. The reply channel for `ask_priority` is a separate
+  `oneshot`, so the single mpsc slot does not bottleneck `ask_priority`
+  concurrency.
+- **`Duration` is mandatory.** A wedged actor would otherwise block the
+  sender indefinitely. The timeout fires admission failures predictably and
+  records a dead letter (`DeadLetterReason::Timeout`).
+- **Priority < kill.** `kill()` still wins biased select against the
+  priority channel, so a kill is delivered even when the priority slot is
+  full.
+- **`stop()` drains the priority queue first.** Before `on_stop` runs, the
+  priority receiver is closed (refusing new sends) and any in-flight
+  priority message is processed. So a priority message sent immediately
+  before `stop()` is not lost. `kill()` does **not** drain.
+- **Starvation is your responsibility.** The priority branch is biased above
+  the regular mailbox, so a flood of priority messages will starve regular
+  handlers. Reserve the priority channel for short, infrequent signals; the
+  `metrics` feature exposes `priority_message_count` separately from
+  `message_count` so you can detect abuse.
+
+See `examples/priority_signal.rs` for a worked example with health checks
+and pause/resume signals.
+
 **Q14: Can I use rsActor with blocking code?**
 
 A14: Yes, `rsActor` provides mechanisms for working with blocking code:

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use rand::RngExt;
+use rand::Rng;
 use rsactor::{message_handlers, spawn, Actor, ActorRef, ActorResult};
 use std::collections::HashMap;
 use std::time::Duration;

--- a/examples/priority_signal.rs
+++ b/examples/priority_signal.rs
@@ -1,0 +1,162 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Demonstrates the opt-in priority channel.
+//!
+//! The actor below simulates a worker that processes "long" jobs sequentially
+//! from its regular mailbox. We use the priority channel for two control-plane
+//! messages that must not be queued behind those long jobs:
+//!
+//! - `HealthCheck` (ask): fetches a snapshot of state without waiting in line.
+//! - `PauseProcessing` / `ResumeProcessing` (tell): toggles a flag that the
+//!   long-job handler observes.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example priority_signal
+//! ```
+
+use anyhow::Result;
+use rsactor::{message_handlers, spawn_with_options, Actor, ActorRef, SpawnOptions};
+use std::time::Duration;
+
+#[derive(Debug)]
+struct WorkerActor {
+    jobs_done: u32,
+    paused: bool,
+}
+
+#[derive(Debug)]
+struct ProcessJob {
+    id: u32,
+}
+
+#[derive(Debug)]
+struct HealthCheck;
+
+#[derive(Debug)]
+struct HealthSnapshot {
+    jobs_done: u32,
+    paused: bool,
+}
+
+#[derive(Debug)]
+struct PauseProcessing;
+
+#[derive(Debug)]
+struct ResumeProcessing;
+
+impl Actor for WorkerActor {
+    type Args = ();
+    type Error = anyhow::Error;
+
+    async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self> {
+        Ok(WorkerActor {
+            jobs_done: 0,
+            paused: false,
+        })
+    }
+}
+
+#[message_handlers]
+impl WorkerActor {
+    // Long-running regular handler. Notice how it observes `self.paused`,
+    // which the priority-channel handler can flip mid-stream.
+    #[handler]
+    async fn handle_job(&mut self, msg: ProcessJob, _: &ActorRef<Self>) -> () {
+        if self.paused {
+            // Drop the job in this demo so we can clearly see the pause take effect.
+            println!("[worker] paused — skipping job #{}", msg.id);
+            return;
+        }
+        println!("[worker] starting job #{}", msg.id);
+        // Simulate work that occupies the regular mailbox for a while.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        self.jobs_done += 1;
+        println!("[worker] finished job #{}", msg.id);
+    }
+
+    #[handler]
+    async fn handle_health(&mut self, _: HealthCheck, _: &ActorRef<Self>) -> HealthSnapshot {
+        HealthSnapshot {
+            jobs_done: self.jobs_done,
+            paused: self.paused,
+        }
+    }
+
+    #[handler]
+    async fn handle_pause(&mut self, _: PauseProcessing, _: &ActorRef<Self>) -> () {
+        println!("[worker] *** PAUSE signal received ***");
+        self.paused = true;
+    }
+
+    #[handler]
+    async fn handle_resume(&mut self, _: ResumeProcessing, _: &ActorRef<Self>) -> () {
+        println!("[worker] *** RESUME signal received ***");
+        self.paused = false;
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_target(false)
+        .init();
+
+    println!("=== Priority Channel Demo ===\n");
+
+    // Spawn with the priority channel enabled.
+    let opts = SpawnOptions::new().mailbox_capacity(8).with_priority();
+    let (actor, join) = spawn_with_options::<WorkerActor>((), opts);
+    assert!(actor.has_priority_channel());
+
+    // Queue several long jobs into the regular mailbox.
+    for id in 1..=5 {
+        actor.tell(ProcessJob { id }).await?;
+    }
+
+    // While jobs are being processed, ask for a health snapshot via the
+    // priority channel. The reply arrives without waiting in line behind the
+    // pending jobs.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let snap = actor
+        .ask_priority(HealthCheck, Duration::from_secs(1))
+        .await?;
+    println!(
+        "[main]  health snapshot mid-flight: jobs_done={}, paused={}",
+        snap.jobs_done, snap.paused
+    );
+
+    // Send a pause signal mid-stream.
+    actor
+        .tell_priority(PauseProcessing, Duration::from_secs(1))
+        .await?;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let snap = actor
+        .ask_priority(HealthCheck, Duration::from_secs(1))
+        .await?;
+    println!(
+        "[main]  health snapshot after pause: jobs_done={}, paused={}",
+        snap.jobs_done, snap.paused
+    );
+
+    // Resume and let the remaining queued jobs drain.
+    actor
+        .tell_priority(ResumeProcessing, Duration::from_secs(1))
+        .await?;
+
+    actor.stop().await?;
+    let result = join.await?;
+    if let Some(final_state) = result.actor() {
+        println!(
+            "\n[main]  worker stopped. final jobs_done={}, paused={}",
+            final_state.jobs_done, final_state.paused
+        );
+    }
+
+    println!("\n=== Demo Complete ===");
+    Ok(())
+}

--- a/examples/priority_signal.rs
+++ b/examples/priority_signal.rs
@@ -64,7 +64,7 @@ impl WorkerActor {
     // Long-running regular handler. Notice how it observes `self.paused`,
     // which the priority-channel handler can flip mid-stream.
     #[handler]
-    async fn handle_job(&mut self, msg: ProcessJob, _: &ActorRef<Self>) -> () {
+    async fn handle_job(&mut self, msg: ProcessJob, _: &ActorRef<Self>) {
         if self.paused {
             // Drop the job in this demo so we can clearly see the pause take effect.
             println!("[worker] paused — skipping job #{}", msg.id);
@@ -86,13 +86,13 @@ impl WorkerActor {
     }
 
     #[handler]
-    async fn handle_pause(&mut self, _: PauseProcessing, _: &ActorRef<Self>) -> () {
+    async fn handle_pause(&mut self, _: PauseProcessing, _: &ActorRef<Self>) {
         println!("[worker] *** PAUSE signal received ***");
         self.paused = true;
     }
 
     #[handler]
-    async fn handle_resume(&mut self, _: ResumeProcessing, _: &ActorRef<Self>) -> () {
+    async fn handle_resume(&mut self, _: ResumeProcessing, _: &ActorRef<Self>) {
         println!("[worker] *** RESUME signal received ***");
         self.paused = false;
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -37,6 +37,55 @@ macro_rules! with_actor_scope {
     }};
 }
 
+/// Process a single Envelope from any of the message-receiving paths
+/// (regular mailbox, priority mailbox, or stop-time priority drain).
+///
+/// Centralizes the tracing span, optional metrics guard, and dispatch boilerplate
+/// so the three call sites stay in sync.
+macro_rules! process_envelope {
+    (
+        actor_id = $actor_id:expr,
+        actor = $actor:expr,
+        payload = $payload:expr,
+        reply_channel = $reply_channel:expr,
+        actor_ref = $actor_ref:expr,
+        span_name = $span_name:literal,
+        guard = $guard_type:ident $(,)?
+    ) => {{
+        #[cfg(feature = "tracing")]
+        let msg_span = tracing::debug_span!($span_name);
+        #[cfg(not(feature = "tracing"))]
+        let msg_span = tracing::Span::none();
+
+        #[cfg(feature = "tracing")]
+        let start_time = std::time::Instant::now();
+
+        // Hold the metrics collector by Arc clone (1 atomic increment) rather
+        // than cloning the entire ActorRef (which would clone every channel
+        // sender — 4 atomic increments). The collector must outlive the move
+        // of $actor_ref into handle_message below.
+        #[cfg(feature = "metrics")]
+        let metrics_collector = $actor_ref.metrics.clone();
+        #[cfg(feature = "metrics")]
+        let _metrics_guard = crate::metrics::collector::$guard_type::new(&metrics_collector);
+
+        run_with_actor_scope!(
+            $actor_id,
+            $payload
+                .handle_message(&mut $actor, $actor_ref, $reply_channel)
+                .instrument(msg_span)
+        );
+
+        #[cfg(feature = "tracing")]
+        debug!(
+            "Actor {} processed {} in {:?}",
+            $actor_id,
+            $span_name,
+            start_time.elapsed()
+        );
+    }};
+}
+
 /// Defines the behavior of an actor.
 ///
 /// Actors are fundamental units of computation that communicate by exchanging messages.
@@ -456,6 +505,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     args: T::Args,
     actor_ref: ActorRef<T>,
     mut receiver: mpsc::Receiver<MailboxMessage<T>>,
+    mut priority_receiver: Option<mpsc::Receiver<MailboxMessage<T>>>,
     mut terminate_receiver: mpsc::Receiver<ControlSignal>,
 ) -> ActorResult<T> {
     let actor_id = actor_ref.identity();
@@ -544,40 +594,102 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 break; // Exit the loop
             }
 
+            // Process priority messages with higher priority than the regular mailbox.
+            // When the priority channel is disabled (`None`), this branch becomes a
+            // never-ready future and is effectively skipped on every iteration.
+            maybe_priority = async {
+                match priority_receiver.as_mut() {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending::<Option<MailboxMessage<T>>>().await,
+                }
+            } => {
+                match maybe_priority {
+                    Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref }) => {
+                        process_envelope!(
+                            actor_id = actor_id,
+                            actor = actor,
+                            payload = payload,
+                            reply_channel = reply_channel,
+                            actor_ref = actor_ref,
+                            span_name = "actor_process_priority_message",
+                            guard = PriorityMessageProcessingGuard,
+                        );
+                    }
+                    Some(MailboxMessage::StopGracefully(_)) => {
+                        // Invariant: stop() only writes to the regular mailbox, never the
+                        // priority channel. Hitting this arm would mean a future change
+                        // started routing StopGracefully through priority too — flag it
+                        // loudly in debug builds.
+                        debug_assert!(
+                            false,
+                            "MailboxMessage::StopGracefully observed on the priority channel; \
+                             priority channel must only carry Envelope variants"
+                        );
+                    }
+                    None => {
+                        // All strong priority senders were dropped. A closed receiver
+                        // returns Ready(None) on every poll, which would busy-loop the
+                        // priority branch forever. Disable the branch by clearing the
+                        // receiver — subsequent iterations hit the `None` arm of the
+                        // async block above and resolve to `pending()`. The actor stays
+                        // alive on the regular mailbox until normal termination.
+                        priority_receiver = None;
+                    }
+                }
+            }
+
             // Process incoming messages from the actor's mailbox
             // Messages can be: regular message envelopes or graceful stop signals
             maybe_message = receiver.recv() => {
                 match maybe_message {
                     Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref }) => {
-                        #[cfg(feature = "tracing")]
-                        let msg_span = tracing::debug_span!("actor_process_message");
-                        #[cfg(not(feature = "tracing"))]
-                        let msg_span = tracing::Span::none();
-
-                        #[cfg(feature = "tracing")]
-                        let start_time = std::time::Instant::now();
-
-                        // Create metrics guard to automatically record processing time
-                        // Clone actor_ref first to preserve ownership for handle_message
-                        #[cfg(feature = "metrics")]
-                        let metrics_ref = actor_ref.clone();
-                        #[cfg(feature = "metrics")]
-                        let _metrics_guard = crate::metrics::collector::MessageProcessingGuard::new(
-                            metrics_ref.metrics_collector()
+                        process_envelope!(
+                            actor_id = actor_id,
+                            actor = actor,
+                            payload = payload,
+                            reply_channel = reply_channel,
+                            actor_ref = actor_ref,
+                            span_name = "actor_process_message",
+                            guard = MessageProcessingGuard,
                         );
-
-                        run_with_actor_scope!(
-                            actor_id,
-                            payload.handle_message(&mut actor, actor_ref, reply_channel)
-                                .instrument(msg_span)
-                        );
-
-                        #[cfg(feature = "tracing")]
-                        debug!("Actor {} processed message in {:?}", actor_id, start_time.elapsed());
                     }
                     Some(MailboxMessage::StopGracefully(_)) | None => {
                         #[cfg(feature = "tracing")]
                         debug!("Actor termination due to graceful stop");
+
+                        // Drain any priority messages already enqueued before stopping.
+                        // close() refuses new priority sends (they get Closed errors and
+                        // are recorded as dead letters), then try_recv() pulls everything
+                        // currently in the slot. This closes the race where a sender
+                        // pushed a priority message just before stop() arrived.
+                        if let Some(rx) = priority_receiver.as_mut() {
+                            rx.close();
+                            while let Ok(msg) = rx.try_recv() {
+                                match msg {
+                                    MailboxMessage::Envelope { payload, reply_channel, actor_ref } => {
+                                        process_envelope!(
+                                            actor_id = actor_id,
+                                            actor = actor,
+                                            payload = payload,
+                                            reply_channel = reply_channel,
+                                            actor_ref = actor_ref,
+                                            span_name = "actor_drain_priority_message",
+                                            guard = PriorityMessageProcessingGuard,
+                                        );
+                                    }
+                                    MailboxMessage::StopGracefully(_) => {
+                                        // Same invariant as the priority select! branch:
+                                        // stop() never writes to the priority channel.
+                                        debug_assert!(
+                                            false,
+                                            "MailboxMessage::StopGracefully observed during \
+                                             priority drain; priority channel must only \
+                                             carry Envelope variants"
+                                        );
+                                    }
+                                }
+                            }
+                        }
 
                         // Call on_stop for graceful stop scenario
                         #[cfg(feature = "tracing")]
@@ -655,6 +767,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     // Cleanup: Close channels to signal shutdown completion
     receiver.close(); // Close the message mailbox
     terminate_receiver.close(); // Close the termination signal channel
+    if let Some(rx) = priority_receiver.as_mut() {
+        rx.close(); // Close the optional priority channel
+    }
 
     debug!("Actor {actor_id} lifecycle completed - exiting runtime loop.");
 

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -71,6 +71,9 @@ pub struct ActorRef<T: Actor> {
     id: Identity,
     /// Channel for sending messages to the actor's mailbox
     sender: MailboxSender<T>,
+    /// Optional channel for sending priority messages to the actor.
+    /// `None` when the actor was spawned without `SpawnOptions::with_priority()`.
+    pub(crate) priority_sender: Option<MailboxSender<T>>,
     /// Channel for sending control signals (e.g., terminate) to the actor
     pub(crate) terminate_sender: mpsc::Sender<ControlSignal>,
     /// Per-actor metrics collector (when metrics feature is enabled)
@@ -83,12 +86,14 @@ impl<T: Actor> ActorRef<T> {
     pub(crate) fn new(
         id: Identity,
         sender: MailboxSender<T>,
+        priority_sender: Option<MailboxSender<T>>,
         terminate_sender: mpsc::Sender<ControlSignal>,
         #[cfg(feature = "metrics")] metrics: Arc<MetricsCollector>,
     ) -> Self {
         ActorRef {
             id,
             sender,
+            priority_sender,
             terminate_sender,
             #[cfg(feature = "metrics")]
             metrics,
@@ -100,7 +105,35 @@ impl<T: Actor> ActorRef<T> {
         self.id
     }
 
+    /// Returns `true` if this actor was spawned with the priority channel enabled
+    /// via [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority).
+    ///
+    /// When this returns `false`, calls to [`tell_priority`](Self::tell_priority),
+    /// [`ask_priority`](Self::ask_priority) and their blocking counterparts return
+    /// [`Error::PriorityChannelNotEnabled`](crate::Error::PriorityChannelNotEnabled).
+    #[inline]
+    pub fn has_priority_channel(&self) -> bool {
+        self.priority_sender.is_some()
+    }
+
+    /// Test-only: drops this `ActorRef`'s strong priority sender without affecting
+    /// the regular mailbox or the terminate channel.
+    ///
+    /// Used to write deterministic tests for the
+    /// [`ActorWeak::upgrade`](crate::ActorWeak::upgrade) policy where every strong
+    /// priority sender is dropped while the actor is still alive on its other
+    /// channels. Production code has no reason to drop one channel without the
+    /// others — clone or drop the entire `ActorRef` instead.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn drop_priority_sender_for_test(&mut self) {
+        self.priority_sender = None;
+    }
+
     /// Checks if the actor is still alive by verifying if its channels are open.
+    ///
+    /// The optional priority channel is intentionally **not** consulted: it is a
+    /// secondary channel, and the actor is considered alive as long as the regular
+    /// mailbox and the terminate channel remain open.
     #[inline]
     pub fn is_alive(&self) -> bool {
         // Both channels must be open for the actor to be considered alive
@@ -117,6 +150,7 @@ impl<T: Actor> ActorRef<T> {
         ActorWeak {
             id: this.id,
             sender: this.sender.downgrade(),
+            priority_sender: this.priority_sender.as_ref().map(|s| s.downgrade()),
             terminate_sender: this.terminate_sender.downgrade(),
             #[cfg(feature = "metrics")]
             metrics: this.metrics.clone(),
@@ -387,6 +421,282 @@ impl<T: Actor> ActorRef<T> {
         }
 
         result
+    }
+
+    /// Sends a message through the priority channel without awaiting a reply (fire-and-forget).
+    ///
+    /// The priority channel bypasses the regular mailbox queue: at every iteration of the
+    /// actor's runtime loop it is polled with higher priority than the regular mailbox,
+    /// but lower priority than the `kill()` (terminate) signal. This is intended for short,
+    /// infrequent control-plane messages such as health checks or pause/resume signals.
+    ///
+    /// `timeout` is **mandatory** and applies to the admission of the message into the
+    /// priority channel. The priority channel has a fixed capacity of 1, so a wedged
+    /// actor would otherwise block the sender indefinitely; the timeout makes that
+    /// failure mode visible.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::PriorityChannelNotEnabled`] if the actor was spawned without
+    ///   [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority).
+    ///   This is a configuration error and is **not** recorded as a dead letter.
+    /// - [`Error::Send`] if the actor has already stopped (recorded as a dead letter).
+    /// - [`Error::Timeout`] if admission did not complete within `timeout` (recorded as
+    ///   a dead letter).
+    #[cfg_attr(feature = "tracing", tracing::instrument(
+        level = "debug",
+        name = "actor_tell_priority",
+        fields(
+            actor_id = %self.identity(),
+            message_type = %std::any::type_name::<M>(),
+            timeout_ms = timeout.as_millis()
+        ),
+        skip(self, msg)
+    ))]
+    pub async fn tell_priority<M>(&self, msg: M, timeout: Duration) -> Result<()>
+    where
+        M: Send + 'static,
+        T: Message<M>,
+    {
+        let Some(priority_sender) = self.priority_sender.as_ref() else {
+            #[cfg(feature = "tracing")]
+            warn!("tell_priority called on actor without a priority channel");
+            return Err(Error::PriorityChannelNotEnabled {
+                identity: self.identity(),
+            });
+        };
+
+        let envelope = MailboxMessage::Envelope {
+            payload: Box::new(msg),
+            reply_channel: None,
+            actor_ref: self.clone(),
+        };
+
+        #[cfg(feature = "tracing")]
+        debug!(
+            timeout_ms = timeout.as_millis(),
+            "Sending priority tell message"
+        );
+
+        let send_fut = priority_sender.send(envelope);
+        let result = match tokio::time::timeout(timeout, send_fut).await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(_)) => {
+                crate::dead_letter::record::<M>(
+                    self.identity(),
+                    crate::dead_letter::DeadLetterReason::ActorStopped,
+                    "tell_priority",
+                );
+                Err(Error::Send {
+                    identity: self.identity(),
+                    details: "Priority channel closed".to_string(),
+                })
+            }
+            Err(_) => {
+                crate::dead_letter::record::<M>(
+                    self.identity(),
+                    crate::dead_letter::DeadLetterReason::Timeout,
+                    "tell_priority",
+                );
+                Err(Error::Timeout {
+                    identity: self.identity(),
+                    timeout,
+                    operation: "tell_priority".to_string(),
+                })
+            }
+        };
+
+        #[cfg(feature = "tracing")]
+        match &result {
+            Ok(_) => debug!("Priority tell message sent successfully"),
+            Err(e) => warn!(error = %e, "Priority tell failed"),
+        }
+
+        result
+    }
+
+    /// Sends a message through the priority channel and awaits a typed reply.
+    ///
+    /// `timeout` is **mandatory** and applies to the entire round-trip (admission into
+    /// the priority channel plus reply wait). The reply travels through a dedicated
+    /// `oneshot` channel separate from the priority slot, so a single in-flight priority
+    /// message does not block another `ask_priority` from issuing a fresh request as
+    /// soon as the actor pulls the previous one off the channel.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::PriorityChannelNotEnabled`] if the actor was spawned without the
+    ///   priority channel enabled (not recorded as a dead letter).
+    /// - [`Error::Send`] if the actor has already stopped (recorded as a dead letter).
+    /// - [`Error::Timeout`] if the round-trip did not complete within `timeout`
+    ///   (recorded as a dead letter).
+    /// - [`Error::Receive`] if the reply channel was dropped before a response arrived
+    ///   (recorded as a dead letter).
+    /// - [`Error::Downcast`] if the handler returned a value of an unexpected type.
+    #[cfg_attr(feature = "tracing", tracing::instrument(
+        level = "debug",
+        name = "actor_ask_priority",
+        fields(
+            actor_id = %self.identity(),
+            message_type = %std::any::type_name::<M>(),
+            reply_type = %std::any::type_name::<T::Reply>(),
+            timeout_ms = timeout.as_millis()
+        ),
+        skip(self, msg)
+    ))]
+    pub async fn ask_priority<M>(&self, msg: M, timeout: Duration) -> Result<T::Reply>
+    where
+        T: Message<M>,
+        M: Send + 'static,
+        T::Reply: Send + 'static,
+    {
+        let Some(priority_sender) = self.priority_sender.as_ref() else {
+            #[cfg(feature = "tracing")]
+            warn!("ask_priority called on actor without a priority channel");
+            return Err(Error::PriorityChannelNotEnabled {
+                identity: self.identity(),
+            });
+        };
+
+        let result = tokio::time::timeout(timeout, async {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let envelope = MailboxMessage::Envelope {
+                payload: Box::new(msg),
+                reply_channel: Some(reply_tx),
+                actor_ref: self.clone(),
+            };
+
+            if priority_sender.send(envelope).await.is_err() {
+                crate::dead_letter::record::<M>(
+                    self.identity(),
+                    crate::dead_letter::DeadLetterReason::ActorStopped,
+                    "ask_priority",
+                );
+                return Err(Error::Send {
+                    identity: self.identity(),
+                    details: "Priority channel closed".to_string(),
+                });
+            }
+
+            match reply_rx.await {
+                Ok(reply_any) => match reply_any.downcast::<T::Reply>() {
+                    Ok(reply) => Ok(*reply),
+                    Err(_) => Err(Error::Downcast {
+                        identity: self.identity(),
+                        expected_type: std::any::type_name::<T::Reply>().to_string(),
+                    }),
+                },
+                Err(_) => {
+                    crate::dead_letter::record::<M>(
+                        self.identity(),
+                        crate::dead_letter::DeadLetterReason::ReplyDropped,
+                        "ask_priority",
+                    );
+                    Err(Error::Receive {
+                        identity: self.identity(),
+                        details: "Reply channel closed unexpectedly".to_string(),
+                    })
+                }
+            }
+        })
+        .await;
+
+        match result {
+            Ok(inner) => inner,
+            Err(_) => {
+                crate::dead_letter::record::<M>(
+                    self.identity(),
+                    crate::dead_letter::DeadLetterReason::Timeout,
+                    "ask_priority",
+                );
+                Err(Error::Timeout {
+                    identity: self.identity(),
+                    timeout,
+                    operation: "ask_priority".to_string(),
+                })
+            }
+        }
+    }
+
+    /// Blocking equivalent of [`tell_priority`](Self::tell_priority). `timeout` is
+    /// mandatory for the same reason as the async version.
+    ///
+    /// Internally this spawns a short-lived single-thread Tokio runtime in a separate
+    /// thread, so it is safe to call from inside an existing runtime context as well as
+    /// from non-async threads.
+    pub fn blocking_tell_priority<M>(&self, msg: M, timeout: Duration) -> Result<()>
+    where
+        M: Send + 'static,
+        T: Message<M>,
+    {
+        if self.priority_sender.is_none() {
+            return Err(Error::PriorityChannelNotEnabled {
+                identity: self.identity(),
+            });
+        }
+
+        let self_clone = self.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build();
+
+            let result = match rt {
+                Ok(runtime) => runtime.block_on(self_clone.tell_priority(msg, timeout)),
+                Err(e) => Err(Error::Send {
+                    identity: self_clone.identity(),
+                    details: format!("Failed to create runtime: {}", e),
+                }),
+            };
+
+            let _ = tx.send(result);
+        });
+
+        rx.recv().map_err(|_| Error::Send {
+            identity: self.identity(),
+            details: "Priority blocking thread terminated unexpectedly".to_string(),
+        })?
+    }
+
+    /// Blocking equivalent of [`ask_priority`](Self::ask_priority). `timeout` is
+    /// mandatory for the same reason as the async version.
+    pub fn blocking_ask_priority<M>(&self, msg: M, timeout: Duration) -> Result<T::Reply>
+    where
+        T: Message<M>,
+        M: Send + 'static,
+        T::Reply: Send + 'static,
+    {
+        if self.priority_sender.is_none() {
+            return Err(Error::PriorityChannelNotEnabled {
+                identity: self.identity(),
+            });
+        }
+
+        let self_clone = self.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build();
+
+            let result = match rt {
+                Ok(runtime) => runtime.block_on(self_clone.ask_priority(msg, timeout)),
+                Err(e) => Err(Error::Send {
+                    identity: self_clone.identity(),
+                    details: format!("Failed to create runtime: {}", e),
+                }),
+            };
+
+            let _ = tx.send(result);
+        });
+
+        rx.recv().map_err(|_| Error::Send {
+            identity: self.identity(),
+            details: "Priority blocking thread terminated unexpectedly".to_string(),
+        })?
     }
 
     /// Sends an immediate termination signal to the actor.
@@ -972,6 +1282,30 @@ impl<T: Actor> ActorRef<T> {
         self.metrics.max_processing_time()
     }
 
+    /// Returns the total number of priority messages processed by this actor.
+    ///
+    /// Always `0` for actors spawned without
+    /// [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority).
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn priority_message_count(&self) -> u64 {
+        self.metrics.priority_message_count()
+    }
+
+    /// Returns the average priority message processing time.
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn avg_priority_processing_time(&self) -> std::time::Duration {
+        self.metrics.avg_priority_processing_time()
+    }
+
+    /// Returns the maximum priority message processing time observed.
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn max_priority_processing_time(&self) -> std::time::Duration {
+        self.metrics.max_priority_processing_time()
+    }
+
     /// Returns the total number of errors during message handling.
     #[cfg(feature = "metrics")]
     #[inline]
@@ -994,15 +1328,6 @@ impl<T: Actor> ActorRef<T> {
     pub fn last_activity(&self) -> Option<std::time::SystemTime> {
         self.metrics.last_activity()
     }
-
-    /// Returns a reference to the internal metrics collector.
-    ///
-    /// This is primarily for internal use by the message processing loop.
-    #[cfg(feature = "metrics")]
-    #[inline]
-    pub(crate) fn metrics_collector(&self) -> &MetricsCollector {
-        &self.metrics
-    }
 }
 
 impl<T: Actor> Clone for ActorRef<T> {
@@ -1011,6 +1336,7 @@ impl<T: Actor> Clone for ActorRef<T> {
         ActorRef {
             id: self.id,
             sender: self.sender.clone(),
+            priority_sender: self.priority_sender.clone(),
             terminate_sender: self.terminate_sender.clone(),
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
@@ -1051,6 +1377,8 @@ pub struct ActorWeak<T: Actor> {
     id: Identity,
     /// Weak reference to the actor's mailbox sender
     sender: tokio::sync::mpsc::WeakSender<MailboxMessage<T>>,
+    /// Weak reference to the actor's optional priority sender (None if priority disabled)
+    priority_sender: Option<tokio::sync::mpsc::WeakSender<MailboxMessage<T>>>,
     /// Weak reference to the actor's terminate signal sender
     terminate_sender: tokio::sync::mpsc::WeakSender<ControlSignal>,
     /// Strong reference to metrics (survives actor drop for post-mortem analysis)
@@ -1063,15 +1391,24 @@ impl<T: Actor> ActorWeak<T> {
     ///
     /// Returns `Some(ActorRef<T>)` if the actor is still alive, or `None` if the actor
     /// has been dropped.
+    ///
+    /// The priority channel is treated as a secondary channel: if the original actor was
+    /// spawned with priority enabled but every strong priority sender has been dropped,
+    /// `upgrade()` still succeeds. The resulting [`ActorRef`] has
+    /// [`has_priority_channel()`](ActorRef::has_priority_channel) returning `false`, and
+    /// priority calls will fail with
+    /// [`Error::PriorityChannelNotEnabled`](crate::Error::PriorityChannelNotEnabled).
     #[inline]
     pub fn upgrade(&self) -> Option<ActorRef<T>> {
         // Try to upgrade both the mailbox sender and terminate sender
         let sender = self.sender.upgrade()?;
         let terminate_sender = self.terminate_sender.upgrade()?;
+        let priority_sender = self.priority_sender.as_ref().and_then(|s| s.upgrade());
 
         Some(ActorRef {
             id: self.id,
             sender,
+            priority_sender,
             terminate_sender,
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
@@ -1106,6 +1443,7 @@ impl<T: Actor> Clone for ActorWeak<T> {
         ActorWeak {
             id: self.id,
             sender: self.sender.clone(),
+            priority_sender: self.priority_sender.clone(),
             terminate_sender: self.terminate_sender.clone(),
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,16 @@ pub enum Error {
         /// The original JoinError from tokio
         source: tokio::task::JoinError,
     },
+    /// Error when a priority channel operation is attempted on an actor that
+    /// did not enable the priority channel via [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority).
+    ///
+    /// This is a configuration error (not a delivery failure) and is therefore
+    /// not recorded as a dead letter. Callers can guard against this with
+    /// [`ActorRef::has_priority_channel`](crate::ActorRef::has_priority_channel).
+    PriorityChannelNotEnabled {
+        /// ID of the actor that does not have a priority channel.
+        identity: Identity,
+    },
 }
 
 /// Implementation of the Display trait for Error enum.
@@ -129,6 +139,13 @@ impl std::fmt::Display for Error {
                     "Failed to join spawned task from actor {}: {}",
                     identity.name(),
                     source
+                )
+            }
+            Error::PriorityChannelNotEnabled { identity } => {
+                write!(
+                    f,
+                    "Priority channel is not enabled for actor {}: enable it via SpawnOptions::with_priority()",
+                    identity.name()
                 )
             }
         }
@@ -261,6 +278,11 @@ impl Error {
                 "Use `ActorResult::is_join_failed()` to confirm this failure type",
                 "Check for unwrap(), expect(), or panic!() calls in actor code",
                 "Verify tokio runtime wasn't shut down while actor was running",
+            ],
+            Error::PriorityChannelNotEnabled { .. } => &[
+                "Spawn the actor with SpawnOptions::new().with_priority() via spawn_with_options()",
+                "Use ActorRef::has_priority_channel() to check before sending priority messages",
+                "If priority is not required, use the regular tell()/ask() methods instead",
             ],
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,15 @@
 //!   - [`ask_with_timeout`](actor_ref::ActorRef::ask_with_timeout): Send a message and await a reply, with a specified timeout.
 //!   - [`tell_blocking`](actor_ref::ActorRef::tell_blocking): Blocking version of `tell` for use in [`tokio::task::spawn_blocking`] tasks.
 //!   - [`ask_blocking`](actor_ref::ActorRef::ask_blocking): Blocking version of `ask` for use in [`tokio::task::spawn_blocking`] tasks.
+//! - **Priority Channel** (opt-in via [`SpawnOptions::with_priority`]):
+//!   A dedicated mpsc channel of fixed capacity 1 that the runtime polls with
+//!   higher priority than the regular mailbox but lower priority than the
+//!   `kill()` (terminate signal). Use it for short, infrequent control messages
+//!   such as health checks and pause/resume. Send via
+//!   [`tell_priority`](actor_ref::ActorRef::tell_priority) /
+//!   [`ask_priority`](actor_ref::ActorRef::ask_priority). The priority channel
+//!   is **off by default**; calls on a non-priority actor return
+//!   [`Error::PriorityChannelNotEnabled`].
 //! - **Straightforward Actor Lifecycle**: Actors have [`on_start`](Actor::on_start), [`on_run`](Actor::on_run),
 //!   and [`on_stop`](Actor::on_stop) lifecycle hooks that provide a clean and intuitive actor lifecycle management system.
 //!   The framework manages the execution flow while giving developers full control over actor behavior.
@@ -544,6 +553,14 @@ static CONFIGURED_DEFAULT_MAILBOX_CAPACITY: OnceLock<usize> = OnceLock::new();
 /// The default mailbox capacity for actors.
 pub const DEFAULT_MAILBOX_CAPACITY: usize = 32;
 
+/// The fixed capacity of the priority channel when it is enabled.
+///
+/// The priority channel is intentionally limited to a single in-flight slot. The slot is
+/// released as soon as the actor's runtime loop calls `recv()`, so admission resumes
+/// immediately after the actor reaches the next select! iteration. See
+/// [`SpawnOptions::with_priority`] for the rationale.
+pub(crate) const PRIORITY_CHANNEL_CAPACITY: usize = 1;
+
 /// Sets the global default buffer size for actor mailboxes.
 ///
 /// This function can only be called successfully once. Subsequent calls
@@ -563,6 +580,96 @@ pub fn set_default_mailbox_capacity(size: usize) -> Result<()> {
         })
 }
 
+/// Configuration options for spawning an actor.
+///
+/// `SpawnOptions` is a builder used by [`spawn_with_options`] to control aspects of the
+/// actor's runtime that are not part of the actor's own definition: mailbox capacity and
+/// optional activation of the priority channel.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use rsactor::{spawn_with_options, SpawnOptions, Actor, ActorRef, message_handlers};
+///
+/// #[derive(Actor)]
+/// struct MyActor;
+///
+/// struct Ping;
+///
+/// #[message_handlers]
+/// impl MyActor {
+///     #[handler]
+///     async fn handle_ping(&mut self, _: Ping, _: &ActorRef<Self>) -> () {}
+/// }
+///
+/// # fn main() {
+/// let opts = SpawnOptions::new().mailbox_capacity(64).with_priority();
+/// let (actor_ref, _join) = spawn_with_options::<MyActor>(MyActor, opts);
+/// assert!(actor_ref.has_priority_channel());
+/// # }
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    /// Capacity of the regular mailbox channel. Must be greater than 0.
+    /// Set via [`SpawnOptions::mailbox_capacity`].
+    pub(crate) mailbox_capacity: usize,
+    /// Whether to enable the priority channel. When `false` (default) no priority channel
+    /// is created and any call to [`tell_priority`](crate::ActorRef::tell_priority) etc.
+    /// returns [`Error::PriorityChannelNotEnabled`]. Toggled via
+    /// [`SpawnOptions::with_priority`].
+    pub(crate) priority_enabled: bool,
+}
+
+impl SpawnOptions {
+    /// Creates a new `SpawnOptions` with default mailbox capacity and the priority channel
+    /// disabled.
+    pub fn new() -> Self {
+        let capacity = CONFIGURED_DEFAULT_MAILBOX_CAPACITY
+            .get()
+            .copied()
+            .unwrap_or(DEFAULT_MAILBOX_CAPACITY);
+        Self {
+            mailbox_capacity: capacity,
+            priority_enabled: false,
+        }
+    }
+
+    /// Sets the mailbox capacity. Must be greater than 0.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n == 0`.
+    pub fn mailbox_capacity(mut self, n: usize) -> Self {
+        assert!(n > 0, "Mailbox capacity must be greater than 0");
+        self.mailbox_capacity = n;
+        self
+    }
+
+    /// Enables the priority channel for the spawned actor.
+    ///
+    /// When enabled, the actor gets a second mpsc channel of fixed capacity 1 that the
+    /// runtime polls with higher priority than the regular mailbox but lower than
+    /// `kill()`. Use it for short, infrequent control-plane messages such
+    /// as health checks or pause/resume signals.
+    ///
+    /// The capacity is fixed at 1 so the API enforces the intended semantics ("short and
+    /// rare"). The single slot is released the moment the actor calls `recv()` on the
+    /// channel, so admission resumes immediately at the next select! iteration. Callers
+    /// must always pass a [`Duration`](std::time::Duration) so a wedged actor can never
+    /// block a sender indefinitely.
+    pub fn with_priority(mut self) -> Self {
+        self.priority_enabled = true;
+        self
+    }
+}
+
+impl Default for SpawnOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Spawns a new actor and returns an `ActorRef<T>` to it, along with a `JoinHandle`.
 ///
 /// Takes initialization arguments that will be passed to the actor's [`on_start`](crate::Actor::on_start) method.
@@ -571,11 +678,7 @@ pub fn set_default_mailbox_capacity(size: usize) -> Result<()> {
 pub fn spawn<T: Actor + 'static>(
     args: T::Args,
 ) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
-    let capacity = CONFIGURED_DEFAULT_MAILBOX_CAPACITY
-        .get()
-        .copied()
-        .unwrap_or(DEFAULT_MAILBOX_CAPACITY);
-    spawn_with_mailbox_capacity(args, capacity)
+    spawn_with_options(args, SpawnOptions::new())
 }
 
 /// Spawns a new actor with a specified mailbox capacity and returns an `ActorRef<T>` to it, along with a `JoinHandle`.
@@ -588,8 +691,21 @@ pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
     args: T::Args,
     mailbox_capacity: usize,
 ) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
+    spawn_with_options(args, SpawnOptions::new().mailbox_capacity(mailbox_capacity))
+}
+
+/// Spawns a new actor with the given [`SpawnOptions`] and returns an `ActorRef<T>` along
+/// with a `JoinHandle`.
+///
+/// This is the most general spawn entry point. Use it when you need to enable the
+/// priority channel via [`SpawnOptions::with_priority`] or configure both mailbox
+/// capacity and priority in a single call.
+pub fn spawn_with_options<T: Actor + 'static>(
+    args: T::Args,
+    opts: SpawnOptions,
+) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
     assert!(
-        mailbox_capacity > 0,
+        opts.mailbox_capacity > 0,
         "Mailbox capacity must be greater than 0"
     );
 
@@ -600,8 +716,15 @@ pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
         std::any::type_name::<T>(),
     );
 
-    let (mailbox_tx, mailbox_rx) = mpsc::channel(mailbox_capacity);
+    let (mailbox_tx, mailbox_rx) = mpsc::channel(opts.mailbox_capacity);
     let (terminate_tx, terminate_rx) = mpsc::channel::<ControlSignal>(1);
+
+    let (priority_tx, priority_rx) = if opts.priority_enabled {
+        let (tx, rx) = mpsc::channel(PRIORITY_CHANNEL_CAPACITY);
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
 
     #[cfg(feature = "metrics")]
     let metrics = std::sync::Arc::new(metrics::MetricsCollector::new());
@@ -609,6 +732,7 @@ pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
     let actor_ref = ActorRef::new(
         actor_id,
         mailbox_tx,
+        priority_tx,
         terminate_tx,
         #[cfg(feature = "metrics")]
         metrics,
@@ -618,6 +742,7 @@ pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
         args,
         actor_ref.clone(),
         mailbox_rx,
+        priority_rx,
         terminate_rx,
     ));
 

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -24,14 +24,21 @@ use super::MetricsSnapshot;
 /// - Individual durations are capped at `u64::MAX` nanoseconds (~584 years)
 #[derive(Debug)]
 pub(crate) struct MetricsCollector {
-    /// Number of messages processed
+    /// Number of messages processed (regular mailbox only — priority messages are
+    /// counted separately so callers can detect priority-channel abuse).
     message_count: AtomicU64,
     /// Number of errors during message handling
     error_count: AtomicU64,
-    /// Cumulative processing time in nanoseconds (saturating)
+    /// Cumulative processing time for regular messages, in nanoseconds (saturating)
     total_processing_nanos: AtomicU64,
-    /// Maximum processing time observed in nanoseconds
+    /// Maximum regular message processing time observed in nanoseconds
     max_processing_nanos: AtomicU64,
+    /// Number of priority messages processed (regular + drained-on-stop).
+    priority_message_count: AtomicU64,
+    /// Cumulative processing time for priority messages, in nanoseconds (saturating)
+    total_priority_processing_nanos: AtomicU64,
+    /// Maximum priority message processing time observed in nanoseconds
+    max_priority_processing_nanos: AtomicU64,
     /// Last activity timestamp as milliseconds since UNIX_EPOCH
     last_activity_millis: AtomicU64,
     /// When the actor started (for uptime calculation)
@@ -46,6 +53,9 @@ impl MetricsCollector {
             error_count: AtomicU64::new(0),
             total_processing_nanos: AtomicU64::new(0),
             max_processing_nanos: AtomicU64::new(0),
+            priority_message_count: AtomicU64::new(0),
+            total_priority_processing_nanos: AtomicU64::new(0),
+            max_priority_processing_nanos: AtomicU64::new(0),
             last_activity_millis: AtomicU64::new(0),
             start_instant: Instant::now(),
         }
@@ -74,6 +84,29 @@ impl MetricsCollector {
 
         // Update max using atomic fetch_max
         self.max_processing_nanos
+            .fetch_max(nanos, Ordering::Relaxed);
+
+        self.update_last_activity();
+    }
+
+    /// Records a completed priority message processing with its duration.
+    ///
+    /// Priority messages are tracked in dedicated counters separate from regular
+    /// messages so callers can detect imbalance (e.g. starvation) by comparing the
+    /// two counts.
+    #[inline]
+    pub fn record_priority_message(&self, duration: Duration) {
+        self.priority_message_count.fetch_add(1, Ordering::Relaxed);
+
+        let nanos = duration.as_nanos().min(u64::MAX as u128) as u64;
+
+        let _ = self.total_priority_processing_nanos.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |current| Some(current.saturating_add(nanos)),
+        );
+
+        self.max_priority_processing_nanos
             .fetch_max(nanos, Ordering::Relaxed);
 
         self.update_last_activity();
@@ -116,6 +149,8 @@ impl MetricsCollector {
     pub fn snapshot(&self) -> MetricsSnapshot {
         let count = self.message_count.load(Ordering::Relaxed);
         let total_nanos = self.total_processing_nanos.load(Ordering::Relaxed);
+        let priority_count = self.priority_message_count.load(Ordering::Relaxed);
+        let total_priority_nanos = self.total_priority_processing_nanos.load(Ordering::Relaxed);
 
         MetricsSnapshot {
             message_count: count,
@@ -125,6 +160,14 @@ impl MetricsCollector {
                 .unwrap_or(Duration::ZERO),
             max_processing_time: Duration::from_nanos(
                 self.max_processing_nanos.load(Ordering::Relaxed),
+            ),
+            priority_message_count: priority_count,
+            avg_priority_processing_time: total_priority_nanos
+                .checked_div(priority_count)
+                .map(Duration::from_nanos)
+                .unwrap_or(Duration::ZERO),
+            max_priority_processing_time: Duration::from_nanos(
+                self.max_priority_processing_nanos.load(Ordering::Relaxed),
             ),
             error_count: self.error_count.load(Ordering::Relaxed),
             uptime: self.start_instant.elapsed(),
@@ -161,6 +204,29 @@ impl MetricsCollector {
     #[inline]
     pub fn max_processing_time(&self) -> Duration {
         Duration::from_nanos(self.max_processing_nanos.load(Ordering::Relaxed))
+    }
+
+    /// Returns the total number of priority messages processed.
+    #[inline]
+    pub fn priority_message_count(&self) -> u64 {
+        self.priority_message_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the average priority message processing time.
+    #[inline]
+    pub fn avg_priority_processing_time(&self) -> Duration {
+        let count = self.priority_message_count.load(Ordering::Relaxed);
+        let total_nanos = self.total_priority_processing_nanos.load(Ordering::Relaxed);
+        total_nanos
+            .checked_div(count)
+            .map(Duration::from_nanos)
+            .unwrap_or(Duration::ZERO)
+    }
+
+    /// Returns the maximum priority message processing time observed.
+    #[inline]
+    pub fn max_priority_processing_time(&self) -> Duration {
+        Duration::from_nanos(self.max_priority_processing_nanos.load(Ordering::Relaxed))
     }
 
     /// Returns the uptime since actor start.
@@ -214,6 +280,32 @@ impl Drop for MessageProcessingGuard<'_> {
     #[inline]
     fn drop(&mut self) {
         self.collector.record_message(self.start.elapsed());
+    }
+}
+
+/// RAII guard for measuring priority message processing time.
+///
+/// Mirrors [`MessageProcessingGuard`] but records into the priority counters so the two
+/// channels can be observed independently.
+pub(crate) struct PriorityMessageProcessingGuard<'a> {
+    collector: &'a MetricsCollector,
+    start: Instant,
+}
+
+impl<'a> PriorityMessageProcessingGuard<'a> {
+    #[inline]
+    pub fn new(collector: &'a MetricsCollector) -> Self {
+        Self {
+            collector,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for PriorityMessageProcessingGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.collector.record_priority_message(self.start.elapsed());
     }
 }
 

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -44,6 +44,20 @@ pub struct MetricsSnapshot {
     /// This is useful for identifying slow message handlers or potential bottlenecks.
     pub max_processing_time: Duration,
 
+    /// Total number of priority messages processed by this actor.
+    ///
+    /// Counts messages delivered through the priority channel (enabled via
+    /// [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority)). Comparing
+    /// this to `message_count` lets callers detect priority-channel abuse such as
+    /// starvation of regular messages.
+    pub priority_message_count: u64,
+
+    /// Average time spent processing each priority message.
+    pub avg_priority_processing_time: Duration,
+
+    /// Maximum time spent processing any single priority message.
+    pub max_priority_processing_time: Duration,
+
     /// Total number of errors that occurred during message handling.
     ///
     /// This counts errors returned by message handlers, not framework-level errors
@@ -67,6 +81,9 @@ impl Default for MetricsSnapshot {
             message_count: 0,
             avg_processing_time: Duration::ZERO,
             max_processing_time: Duration::ZERO,
+            priority_message_count: 0,
+            avg_priority_processing_time: Duration::ZERO,
+            max_priority_processing_time: Duration::ZERO,
             error_count: 0,
             uptime: Duration::ZERO,
             last_activity: None,
@@ -96,6 +113,9 @@ mod tests {
             message_count: 42,
             avg_processing_time: Duration::from_millis(100),
             max_processing_time: Duration::from_millis(500),
+            priority_message_count: 7,
+            avg_priority_processing_time: Duration::from_micros(80),
+            max_priority_processing_time: Duration::from_millis(2),
             error_count: 3,
             uptime: Duration::from_secs(60),
             last_activity: Some(SystemTime::now()),
@@ -106,6 +126,15 @@ mod tests {
         assert_eq!(cloned.message_count, 42);
         assert_eq!(cloned.avg_processing_time, Duration::from_millis(100));
         assert_eq!(cloned.max_processing_time, Duration::from_millis(500));
+        assert_eq!(cloned.priority_message_count, 7);
+        assert_eq!(
+            cloned.avg_priority_processing_time,
+            Duration::from_micros(80)
+        );
+        assert_eq!(
+            cloned.max_priority_processing_time,
+            Duration::from_millis(2)
+        );
         assert_eq!(cloned.error_count, 3);
         assert_eq!(cloned.uptime, Duration::from_secs(60));
         assert!(cloned.last_activity.is_some());

--- a/tests/priority_signal_tests.rs
+++ b/tests/priority_signal_tests.rs
@@ -1,0 +1,853 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the priority channel (`SpawnOptions::with_priority`).
+//!
+//! These tests cover:
+//! - Disabled-by-default behavior (calls return `PriorityChannelNotEnabled`,
+//!   no dead letters recorded).
+//! - Priority bypass over a saturated regular mailbox.
+//! - `kill()` overtaking pending priority messages.
+//! - `stop()` draining the priority queue before `on_stop` while refusing new sends.
+//! - Round-trip `ask_priority` with downcast.
+//! - `ActorWeak::upgrade()` succeeding even when every strong priority sender is gone.
+//! - Blocking variants (`blocking_tell_priority`, `blocking_ask_priority`).
+//! - Mandatory-`Duration` timeout behavior on a wedged actor.
+//! - `capacity = 1` admission serialization between concurrent senders.
+
+use rsactor::{
+    dead_letter_count, message_handlers, spawn, spawn_with_options, Actor, ActorRef, Error,
+    SpawnOptions,
+};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+
+// Tests that read the global dead-letter counter must not run concurrently
+// with each other within this test binary, otherwise their `before`/`after`
+// captures race. The mutex is held across `.await` points (the test body),
+// so it must be `tokio::sync::Mutex` rather than `std::sync::Mutex`
+// (clippy::await_holding_lock).
+fn dead_letter_serial_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Default priority operation timeout for tests where no waiting is expected.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+struct CounterActor {
+    normal_count: u32,
+    priority_count: u32,
+}
+
+#[derive(Debug)]
+struct NormalMsg;
+#[derive(Debug)]
+struct PriorityMsg;
+#[derive(Debug)]
+struct GetCounts;
+#[derive(Debug)]
+struct PriorityPing(u32);
+
+impl Actor for CounterActor {
+    type Args = ();
+    type Error = anyhow::Error;
+
+    async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
+        Ok(CounterActor {
+            normal_count: 0,
+            priority_count: 0,
+        })
+    }
+}
+
+#[message_handlers]
+impl CounterActor {
+    #[handler]
+    async fn handle_normal(&mut self, _: NormalMsg, _: &ActorRef<Self>) {
+        self.normal_count += 1;
+    }
+
+    #[handler]
+    async fn handle_priority(&mut self, _: PriorityMsg, _: &ActorRef<Self>) {
+        self.priority_count += 1;
+    }
+
+    #[handler]
+    async fn handle_get_counts(&mut self, _: GetCounts, _: &ActorRef<Self>) -> (u32, u32) {
+        (self.normal_count, self.priority_count)
+    }
+
+    #[handler]
+    async fn handle_priority_ping(&mut self, msg: PriorityPing, _: &ActorRef<Self>) -> u32 {
+        self.priority_count += 1;
+        msg.0 + 1
+    }
+}
+
+// Actor that blocks the regular mailbox on demand. Used to test that priority
+// messages bypass a saturated mailbox and that timeouts fire on wedge.
+#[derive(Debug)]
+struct BlockingActor {
+    started: Arc<AtomicU32>,
+    release: Arc<Notify>,
+    priority_count: u32,
+}
+
+#[derive(Debug)]
+struct BlockMe;
+#[derive(Debug)]
+struct PingPriority;
+#[derive(Debug)]
+struct GetPriorityCount;
+
+impl Actor for BlockingActor {
+    type Args = (Arc<AtomicU32>, Arc<Notify>);
+    type Error = anyhow::Error;
+
+    async fn on_start(
+        (started, release): Self::Args,
+        _: &ActorRef<Self>,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(BlockingActor {
+            started,
+            release,
+            priority_count: 0,
+        })
+    }
+}
+
+#[message_handlers]
+impl BlockingActor {
+    #[handler]
+    async fn handle_block(&mut self, _: BlockMe, _: &ActorRef<Self>) {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        self.release.notified().await;
+    }
+
+    #[handler]
+    async fn handle_ping(&mut self, _: PingPriority, _: &ActorRef<Self>) -> u32 {
+        self.priority_count += 1;
+        self.priority_count
+    }
+
+    #[handler]
+    async fn handle_get_priority_count(&mut self, _: GetPriorityCount, _: &ActorRef<Self>) -> u32 {
+        self.priority_count
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Disabled-by-default behavior
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn default_spawn_has_no_priority_channel() {
+    let (actor_ref, _handle) = spawn::<CounterActor>(());
+    assert!(
+        !actor_ref.has_priority_channel(),
+        "spawn() must not enable the priority channel"
+    );
+    let _ = actor_ref.stop().await;
+}
+
+#[tokio::test]
+async fn tell_priority_on_disabled_actor_returns_not_enabled_error() {
+    let _serial = dead_letter_serial_lock().lock().await;
+
+    let (actor_ref, _handle) = spawn::<CounterActor>(());
+    let before = dead_letter_count();
+
+    let err = actor_ref
+        .tell_priority(PriorityMsg, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_err();
+
+    match err {
+        Error::PriorityChannelNotEnabled { .. } => {}
+        other => panic!("expected PriorityChannelNotEnabled, got {other:?}"),
+    }
+
+    // Configuration error must NOT be recorded as a dead letter.
+    assert_eq!(
+        dead_letter_count(),
+        before,
+        "PriorityChannelNotEnabled must not increment the dead letter counter"
+    );
+
+    let _ = actor_ref.stop().await;
+}
+
+#[tokio::test]
+async fn ask_priority_on_disabled_actor_returns_not_enabled_error() {
+    let _serial = dead_letter_serial_lock().lock().await;
+
+    let (actor_ref, _handle) = spawn::<CounterActor>(());
+    let before = dead_letter_count();
+
+    let err = actor_ref
+        .ask_priority(PriorityPing(1), DEFAULT_TIMEOUT)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
+    assert_eq!(dead_letter_count(), before);
+
+    let _ = actor_ref.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// Priority bypass and ask_priority round-trip
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn priority_bypasses_saturated_regular_mailbox() {
+    let started = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+
+    // Mailbox capacity 1: a single in-flight BlockMe message will occupy the
+    // actor while a second BlockMe sits in the channel slot. Any further
+    // regular send would block on admission.
+    let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+    let (actor_ref, _handle) =
+        spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+    // 1) Saturate the regular mailbox: the first BlockMe is being processed,
+    //    the second occupies the channel slot.
+    actor_ref.tell(BlockMe).await.unwrap();
+
+    // Wait until the actor actually entered the first handler.
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    actor_ref.tell(BlockMe).await.unwrap();
+
+    // Confirm the regular mailbox would now block — try_send equivalent via a
+    // short timeout. We use tell_with_timeout to avoid hanging the test if our
+    // assumption is wrong.
+    let saturated = tokio::time::timeout(
+        Duration::from_millis(100),
+        actor_ref.tell_with_timeout(BlockMe, Duration::from_millis(50)),
+    )
+    .await
+    .expect("tell_with_timeout should return")
+    .unwrap_err();
+    assert!(
+        matches!(saturated, Error::Timeout { .. }),
+        "regular mailbox should be saturated, got {saturated:?}"
+    );
+
+    // 2) Priority should still go through and be processed before the queued
+    //    regular messages. We need to release the in-flight handler so that
+    //    the actor reaches the next select! iteration to pick up priority.
+    release.notify_one();
+
+    let n = actor_ref
+        .ask_priority(PingPriority, DEFAULT_TIMEOUT)
+        .await
+        .unwrap();
+    assert_eq!(n, 1, "priority handler should have run exactly once");
+
+    // Drain the rest gracefully.
+    release.notify_one();
+    release.notify_one();
+    let _ = actor_ref.stop().await;
+}
+
+#[tokio::test]
+async fn ask_priority_returns_typed_reply() {
+    let opts = SpawnOptions::new().with_priority();
+    let (actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+
+    let reply: u32 = actor_ref
+        .ask_priority(PriorityPing(41), DEFAULT_TIMEOUT)
+        .await
+        .unwrap();
+    assert_eq!(reply, 42);
+
+    let _ = actor_ref.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// kill() overtakes the priority queue
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn kill_overtakes_pending_priority_messages() {
+    let started = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+
+    let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+    let (actor_ref, handle) =
+        spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+    // Make the actor busy on a regular handler that won't return until we
+    // release it. While it's busy, queue a priority message that will sit in
+    // the priority slot.
+    actor_ref.tell(BlockMe).await.unwrap();
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    actor_ref
+        .tell_priority(PingPriority, DEFAULT_TIMEOUT)
+        .await
+        .unwrap();
+
+    // Kill the actor. Per §5.A-1, kill MUST overtake pending priority messages
+    // and the queued PingPriority MUST NOT be processed.
+    actor_ref.kill().unwrap();
+    release.notify_one(); // unblock the in-flight handler so the loop progresses
+
+    let result = handle.await.unwrap();
+    let actor = result.actor().expect("actor should be returned on kill");
+    assert_eq!(
+        actor.priority_count, 0,
+        "kill must not drain pending priority messages"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stop() processes pending priority messages before on_stop, then refuses
+// new priority sends. The drain code path is also stress-tested below.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn priority_message_pending_at_stop_is_processed_before_on_stop() {
+    // Note: in this happy-path scenario the priority message is consumed by
+    // the normal priority `select!` arm (priority > regular bias), NOT by the
+    // close-then-drain code in the StopGracefully branch. The drain itself
+    // is exercised by `stop_drain_loop_processes_racing_priority_send` below.
+
+    let started = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+
+    let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+    let (actor_ref, handle) =
+        spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+    actor_ref.tell(BlockMe).await.unwrap();
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    actor_ref
+        .tell_priority(PingPriority, DEFAULT_TIMEOUT)
+        .await
+        .unwrap();
+    actor_ref.stop().await.unwrap();
+    release.notify_one();
+
+    let result = handle.await.unwrap();
+    let actor = result.actor().expect("actor returned on graceful stop");
+    assert_eq!(
+        actor.priority_count, 1,
+        "priority message pending at stop must be processed before on_stop"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stop_drain_loop_processes_racing_priority_send() {
+    // Genuinely exercises the close-then-drain code in the StopGracefully arm.
+    //
+    // The drain only fires for messages that land in the priority slot AFTER
+    // the actor has already moved past the priority `select!` arm and entered
+    // the regular-mailbox StopGracefully arm. That window only exists on a
+    // multi-threaded runtime where the sender and the actor can race.
+    //
+    // Strategy: race many iterations. For each iteration spawn an actor, hold
+    // it on a regular handler, queue stop(), release, then immediately spawn
+    // a sender that hammers tell_priority. Across iterations the drain MUST
+    // sometimes fire (priority message arrives while actor is already in
+    // graceful-stop arm) and the contract holds in every case:
+    //   - tell_priority either succeeds (consumed by normal priority arm OR
+    //     by drain) or fails with Send (priority channel closed by drain).
+    //   - The actor terminates cleanly with priority_count counting all
+    //     accepted messages.
+    //
+    // We additionally assert that across iterations at least one tell_priority
+    // observed Send (i.e. drain ran close() while a sender was racing). This
+    // confirms the drain branch is reachable, not dead code.
+    //
+    // Caveats:
+    // - Requires multi-threaded runtime (worker_threads >= 2). On a true
+    //   single-CPU host the workers serialize and the race window collapses;
+    //   the assertion below could fail. Modern CI runners are multi-CPU so
+    //   this is not currently a concern.
+    // - ITERS = 200 keeps the assertion robust across scheduling jitter while
+    //   still completing in well under a second on a typical laptop.
+
+    const ITERS: usize = 200;
+    let mut saw_post_close_send = false;
+
+    for _ in 0..ITERS {
+        let started = Arc::new(AtomicU32::new(0));
+        let release = Arc::new(Notify::new());
+        let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+        let (actor_ref, handle) =
+            spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+        actor_ref.tell(BlockMe).await.unwrap();
+        while started.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        actor_ref.stop().await.unwrap();
+
+        // Race: spawn a few priority senders concurrently with releasing the
+        // blocker. Some sends will be accepted, some will be rejected after
+        // close().
+        let sender = actor_ref.clone();
+        let race = tokio::spawn(async move {
+            let mut send_errors = 0u32;
+            let mut accepted = 0u32;
+            for _ in 0..8 {
+                match sender
+                    .tell_priority(PingPriority, Duration::from_millis(50))
+                    .await
+                {
+                    Ok(()) => accepted += 1,
+                    Err(Error::Send { .. }) => send_errors += 1,
+                    Err(Error::Timeout { .. }) => {
+                        // capacity-1 contention — fine, skip
+                    }
+                    Err(other) => panic!("unexpected error from racing send: {other:?}"),
+                }
+            }
+            (accepted, send_errors)
+        });
+
+        release.notify_one();
+
+        let (_accepted, send_errors) = race.await.unwrap();
+        if send_errors > 0 {
+            saw_post_close_send = true;
+        }
+
+        // Actor must terminate cleanly regardless of the race outcome.
+        let result = handle.await.unwrap();
+        result.actor().expect("clean termination");
+    }
+
+    assert!(
+        saw_post_close_send,
+        "across {ITERS} iterations of racing tell_priority vs stop(), at least one \
+         send should have observed the priority channel closed by the drain branch — \
+         this is what proves the drain code is reachable in production"
+    );
+}
+
+#[tokio::test]
+async fn priority_send_after_stop_drain_records_dead_letter() {
+    let _serial = dead_letter_serial_lock().lock().await;
+
+    let opts = SpawnOptions::new().with_priority();
+    let (actor_ref, handle) = spawn_with_options::<CounterActor>((), opts);
+    actor_ref.stop().await.unwrap();
+    handle.await.unwrap();
+
+    let before = dead_letter_count();
+
+    // Actor has fully stopped; both regular and priority channels are closed.
+    let err = actor_ref
+        .tell_priority(PriorityMsg, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::Send { .. }));
+    assert!(
+        dead_letter_count() > before,
+        "Send failure on closed priority channel must be recorded as a dead letter"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Timeout on a wedged actor
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tell_priority_timeout_on_wedged_actor_records_dead_letter() {
+    let _serial = dead_letter_serial_lock().lock().await;
+
+    let started = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+
+    let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+    let (actor_ref, handle) =
+        spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+    // Block the actor in a handler so it never reaches the next select.
+    actor_ref.tell(BlockMe).await.unwrap();
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // First priority message fills the capacity-1 slot.
+    actor_ref
+        .tell_priority(PingPriority, Duration::from_millis(500))
+        .await
+        .unwrap();
+
+    let before = dead_letter_count();
+    // Second priority message must time out: the slot is full and the actor
+    // is wedged so it won't be drained.
+    let err = actor_ref
+        .tell_priority(PingPriority, Duration::from_millis(100))
+        .await
+        .unwrap_err();
+    match err {
+        Error::Timeout { operation, .. } => assert_eq!(operation, "tell_priority"),
+        other => panic!("expected Timeout, got {other:?}"),
+    }
+    assert!(
+        dead_letter_count() > before,
+        "Timeout on tell_priority must be recorded as a dead letter"
+    );
+
+    // Cleanup: release the wedge and shut down.
+    release.notify_one();
+    actor_ref.kill().unwrap();
+    let _ = handle.await;
+}
+
+// ---------------------------------------------------------------------------
+// ActorWeak upgrade policy
+// ---------------------------------------------------------------------------
+
+/// Wait until the lifecycle task has progressed past `on_start` and dropped
+/// its own clone of `actor_ref`. Without this, the lifecycle clone keeps the
+/// strong sender count at >= 1 even after the test drops its own priority
+/// sender, masking the upgrade-policy under test. A round-trip ask is the
+/// most reliable signal: receiving a reply implies the actor has reached the
+/// main loop, which means the lifecycle has executed its early `drop(actor_ref)`.
+async fn wait_for_lifecycle_settled<A>(actor_ref: &ActorRef<A>)
+where
+    A: Actor + rsactor::Message<GetCounts, Reply = (u32, u32)> + 'static,
+{
+    let _ = actor_ref.ask(GetCounts).await.unwrap();
+}
+
+#[tokio::test]
+async fn actor_weak_upgrade_succeeds_when_only_priority_strong_dropped() {
+    let opts = SpawnOptions::new().with_priority();
+    let (mut actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+
+    // Wait until the lifecycle's internal actor_ref clone is gone before we
+    // sample upgrade behavior. Otherwise we observe its strong sender too.
+    wait_for_lifecycle_settled(&actor_ref).await;
+
+    let weak = ActorRef::downgrade(&actor_ref);
+    assert!(
+        actor_ref.has_priority_channel(),
+        "spawned with priority enabled"
+    );
+
+    // Drop ONLY the priority sender on this single ActorRef. The regular
+    // mailbox and terminate channels stay strong, so the actor remains alive.
+    actor_ref.drop_priority_sender_for_test();
+    assert!(
+        !actor_ref.has_priority_channel(),
+        "priority sender removed from this ActorRef"
+    );
+
+    // Upgrade must still succeed — priority is a secondary channel and only
+    // the mailbox + terminate channels gate liveness.
+    let upgraded = weak.upgrade().expect("actor should still be alive");
+
+    // The upgraded ref should also have priority disabled, because no strong
+    // priority sender exists anywhere to upgrade from.
+    assert!(
+        !upgraded.has_priority_channel(),
+        "upgrade() returns priority-disabled ActorRef when every strong priority sender is gone"
+    );
+
+    // And calling tell_priority on the upgraded ref must surface the config error.
+    let err = upgraded
+        .tell_priority(PriorityMsg, DEFAULT_TIMEOUT)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
+
+    let _ = upgraded.stop().await;
+}
+
+#[tokio::test]
+async fn actor_weak_upgrade_preserves_priority_when_other_strong_alive() {
+    let opts = SpawnOptions::new().with_priority();
+    let (mut actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+    wait_for_lifecycle_settled(&actor_ref).await;
+
+    let weak = ActorRef::downgrade(&actor_ref);
+
+    // Hold a SEPARATE clone with the priority sender intact, then drop priority
+    // on the original. Upgrade should still see priority alive.
+    let other_strong = actor_ref.clone();
+    actor_ref.drop_priority_sender_for_test();
+
+    let upgraded = weak.upgrade().expect("alive");
+    assert!(
+        upgraded.has_priority_channel(),
+        "priority sender survives in upgrade because another strong clone holds it"
+    );
+
+    drop(other_strong);
+    let _ = upgraded.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// Blocking variants
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_tell_priority_succeeds_when_enabled() {
+    let opts = SpawnOptions::new().with_priority();
+    let (actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+
+    let actor_ref_clone = actor_ref.clone();
+    let join = tokio::task::spawn_blocking(move || {
+        actor_ref_clone.blocking_tell_priority(PriorityMsg, DEFAULT_TIMEOUT)
+    });
+    join.await.unwrap().unwrap();
+
+    let (_normal, priority) = actor_ref.ask(GetCounts).await.unwrap();
+    assert_eq!(priority, 1);
+
+    let _ = actor_ref.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_ask_priority_returns_reply() {
+    let opts = SpawnOptions::new().with_priority();
+    let (actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+
+    let actor_ref_clone = actor_ref.clone();
+    let reply: u32 = tokio::task::spawn_blocking(move || {
+        actor_ref_clone.blocking_ask_priority(PriorityPing(99), DEFAULT_TIMEOUT)
+    })
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(reply, 100);
+
+    let _ = actor_ref.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_priority_on_disabled_actor_returns_not_enabled() {
+    let (actor_ref, _handle) = spawn::<CounterActor>(());
+    let actor_ref_clone = actor_ref.clone();
+    let err = tokio::task::spawn_blocking(move || {
+        actor_ref_clone.blocking_tell_priority(PriorityMsg, DEFAULT_TIMEOUT)
+    })
+    .await
+    .unwrap()
+    .unwrap_err();
+    assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
+    let _ = actor_ref.stop().await;
+}
+
+// ---------------------------------------------------------------------------
+// capacity = 1 admission serialization
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn capacity_one_serializes_concurrent_priority_admission() {
+    let started = Arc::new(AtomicU32::new(0));
+    let release = Arc::new(Notify::new());
+
+    let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
+    let (actor_ref, _handle) =
+        spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
+
+    actor_ref.tell(BlockMe).await.unwrap();
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // Two concurrent priority sends. With capacity = 1 and a wedged actor,
+    // at most one can be admitted; the other must time out.
+    let r1 = actor_ref.clone();
+    let r2 = actor_ref.clone();
+    let task1 = tokio::spawn(async move {
+        r1.tell_priority(PingPriority, Duration::from_millis(200))
+            .await
+    });
+    let task2 = tokio::spawn(async move {
+        r2.tell_priority(PingPriority, Duration::from_millis(200))
+            .await
+    });
+
+    let res1 = task1.await.unwrap();
+    let res2 = task2.await.unwrap();
+    let oks = [&res1, &res2].iter().filter(|r| r.is_ok()).count();
+    let timeouts = [&res1, &res2]
+        .iter()
+        .filter(|r| matches!(r, Err(Error::Timeout { .. })))
+        .count();
+    assert_eq!(
+        oks, 1,
+        "exactly one priority send should succeed, results: {res1:?} {res2:?}"
+    );
+    assert_eq!(
+        timeouts, 1,
+        "exactly one priority send should time out, results: {res1:?} {res2:?}"
+    );
+
+    release.notify_one();
+    actor_ref.kill().unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Processing order: priority handler runs before queued regular messages
+// ---------------------------------------------------------------------------
+//
+// `priority_bypasses_saturated_regular_mailbox` proves a priority message can
+// still be admitted when the regular mailbox is saturated. This test proves
+// the stronger ordering claim: once a regular handler in flight finishes, the
+// queued priority message is processed BEFORE the next regular message in
+// line, even if regulars were enqueued first.
+
+#[derive(Debug)]
+struct OrderActor {
+    log: Arc<std::sync::Mutex<Vec<&'static str>>>,
+    r1_started: Arc<Notify>,
+    r1_release: Arc<Notify>,
+}
+
+#[derive(Debug)]
+struct SlowRegular(&'static str);
+#[derive(Debug)]
+struct PriorityTag(&'static str);
+
+impl Actor for OrderActor {
+    type Args = (
+        Arc<std::sync::Mutex<Vec<&'static str>>>,
+        Arc<Notify>,
+        Arc<Notify>,
+    );
+    type Error = anyhow::Error;
+    async fn on_start(
+        (log, r1_started, r1_release): Self::Args,
+        _: &ActorRef<Self>,
+    ) -> std::result::Result<Self, Self::Error> {
+        Ok(OrderActor {
+            log,
+            r1_started,
+            r1_release,
+        })
+    }
+}
+
+#[message_handlers]
+impl OrderActor {
+    #[handler]
+    async fn handle_slow(&mut self, msg: SlowRegular, _: &ActorRef<Self>) {
+        // R1 specifically signals when it has entered the handler and waits
+        // for the test to release it. R2/R3 fall through immediately so they
+        // back-fill behind R1 in FIFO order.
+        if msg.0 == "R1" {
+            self.r1_started.notify_one();
+            self.r1_release.notified().await;
+        }
+        self.log.lock().unwrap().push(msg.0);
+    }
+
+    #[handler]
+    async fn handle_priority_tag(&mut self, msg: PriorityTag, _: &ActorRef<Self>) {
+        self.log.lock().unwrap().push(msg.0);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn priority_handler_runs_before_queued_regular_messages() {
+    let log = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+    let r1_started = Arc::new(Notify::new());
+    let r1_release = Arc::new(Notify::new());
+    let opts = SpawnOptions::new().mailbox_capacity(8).with_priority();
+    let (actor_ref, handle) = spawn_with_options::<OrderActor>(
+        (log.clone(), r1_started.clone(), r1_release.clone()),
+        opts,
+    );
+
+    actor_ref.tell(SlowRegular("R1")).await.unwrap();
+    actor_ref.tell(SlowRegular("R2")).await.unwrap();
+    actor_ref.tell(SlowRegular("R3")).await.unwrap();
+
+    // Wait deterministically until R1 is actually inside its handler. Without
+    // this barrier the priority send below could race ahead of R1 (especially
+    // under CI load) and the observed order would become ["P", "R1", "R2", "R3"].
+    r1_started.notified().await;
+
+    // R1 is mid-handler; enqueue the priority message.
+    actor_ref
+        .tell_priority(PriorityTag("P"), DEFAULT_TIMEOUT)
+        .await
+        .unwrap();
+
+    // Release R1 and let everything drain.
+    r1_release.notify_one();
+    actor_ref.stop().await.unwrap();
+    handle.await.unwrap();
+
+    let order = log.lock().unwrap().clone();
+    // Contract: R1 finishes first (already in flight when P arrived); then the
+    // biased priority branch beats the regular mailbox so P runs before R2/R3.
+    assert_eq!(
+        order,
+        vec!["R1", "P", "R2", "R3"],
+        "priority handler must run between R1 (in-flight) and R2/R3 (queued)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Metrics separation: priority counters are distinct from regular counters
+// ---------------------------------------------------------------------------
+//
+// Compiled only when the `metrics` feature is enabled. This is the headline
+// observability story for priority-channel abuse detection per the FAQ.
+
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn priority_metrics_counters_are_distinct_from_regular() {
+    let opts = SpawnOptions::new().with_priority();
+    let (actor_ref, _handle) = spawn_with_options::<CounterActor>((), opts);
+
+    // 5 regular sends.
+    for _ in 0..5 {
+        actor_ref.tell(NormalMsg).await.unwrap();
+    }
+    // 3 priority sends. Use ask_priority to ensure each is processed before
+    // the next is admitted (synchronous, no race on observation).
+    for n in 0..3u32 {
+        let _: u32 = actor_ref
+            .ask_priority(PriorityPing(n), DEFAULT_TIMEOUT)
+            .await
+            .unwrap();
+    }
+
+    // Round-trip a final ask through the regular mailbox to be sure all
+    // earlier regulars have been processed (handlers are sequential).
+    let _ = actor_ref.ask(GetCounts).await.unwrap();
+
+    let snap = actor_ref.metrics();
+    // 5 regular tells + 1 ask = 6 regular messages.
+    assert_eq!(
+        snap.message_count, 6,
+        "regular counter must include only mailbox-channel messages, got snapshot {snap:?}"
+    );
+    assert_eq!(
+        snap.priority_message_count, 3,
+        "priority counter must include only priority-channel messages, got snapshot {snap:?}"
+    );
+
+    // Convenience accessors mirror the snapshot.
+    assert_eq!(actor_ref.priority_message_count(), 3);
+    assert_eq!(actor_ref.message_count(), 6);
+
+    let _ = actor_ref.stop().await;
+}


### PR DESCRIPTION
## Summary

- Add an **opt-in priority channel**: a second mpsc of fixed capacity 1, polled with biased `select!` above the regular mailbox but below `kill()` (terminate). For short, infrequent control messages — health checks, pause/resume, config reload.
- Pure additive surface. Existing `spawn()` / `spawn_with_mailbox_capacity()` / `Message<T>` / `#[handler]` / `ActorControl` unchanged. Channel is enabled only via `SpawnOptions::new().with_priority()` + new `spawn_with_options()`.
- API: `tell_priority(msg, Duration)` / `ask_priority(msg, Duration)` + blocking pair (mandatory `Duration` is the capacity-1 wedge defense), `has_priority_channel()`, new `Error::PriorityChannelNotEnabled` (config error — **not** a dead letter).
- Lifecycle: `stop()` performs close-then-drain so a priority message sent immediately before `stop()` is not lost; `kill()` does not drain. Priority branch becomes inert when all strong priority senders are dropped (avoids busy-loop on closed receiver).
- Metrics (`metrics` feature): `priority_message_count` / `avg_priority_processing_time` / `max_priority_processing_time` separated from regular counters so abuse (starvation) is detectable.
- Refactored envelope-processing into a `process_envelope!` macro shared across the regular, priority, and drain paths; metrics path Arc-clones the collector instead of the entire `ActorRef` (4 atomic increments → 1).
- Example: [`examples/priority_signal.rs`](examples/priority_signal.rs) — health check + pause/resume demo.
- Docs: README table, FAQ decision-tree entry, lib.rs module docs, CHANGELOG `[Unreleased]` entry.

Design notes are in [`plan/01-priority-channel.md`](plan/01-priority-channel.md) (not included in this PR).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo doc --no-deps --all-features` — clean (zero warnings)
- [x] `cargo test --all-features` — 24 binaries, 409 tests, 0 failures
  - New `priority_signal_tests` (18 tests, requires `test-utils` and `metrics`):
    - Disabled-by-default behavior (3 tests, dead-letter counter assertions serialized)
    - Priority bypass over saturated regular mailbox
    - `ask_priority` round-trip with downcast
    - `kill()` overtakes pending priority messages
    - `stop()` drain — including a multi-thread stress test (200 iterations) that proves the drain code is reachable in production
    - `ActorWeak::upgrade()` policy with priority-only-drop hook
    - Blocking variants
    - Wedge timeout (records dead letter)
    - Capacity-1 admission serialization
    - Processing order (priority handler runs between in-flight regular and queued regulars)
    - Metrics counter separation
- [x] `cargo run --example priority_signal` — health snapshot lands mid-flight; pause/resume signals overtake queued jobs