### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-03
+
 ### Added
 
 - **Priority channel** (opt-in, off by default): a second mpsc channel of fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "rsactor"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "rsactor-derive"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "rsactor-derive"]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.75.0"
 authors = ["Jeff Kim <hiking90@gmail.com>"]
@@ -48,7 +48,7 @@ deadlock-detection = []  # Runtime deadlock detection for ask cycles (panics on 
 
 [dependencies]
 tokio.workspace = true
-rsactor-derive = { version = "0.14", path = "rsactor-derive" }
+rsactor-derive = { version = "0.15", path = "rsactor-derive" }
 tracing.workspace = true  # Now REQUIRED (was optional) - provides logging infrastructure
 futures = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Unlike broader frameworks like Actix, rsActor specializes exclusively in **local
 
 ```toml
 [dependencies]
-rsactor = "0.14" # Check crates.io for the latest version
+rsactor = "0.15" # Check crates.io for the latest version
 
 # Optional: Enable tracing support for detailed observability
-# rsactor = { version = "0.14", features = ["tracing"] }
+# rsactor = { version = "0.15", features = ["tracing"] }
 ```
 
 For using the derive macros, you'll also need the `message_handlers` attribute macro which is included by default.
@@ -241,7 +241,7 @@ To enable tracing support, add the `tracing` feature to your dependencies:
 
 ```toml
 [dependencies]
-rsactor = { version = "0.14", features = ["tracing"] }
+rsactor = { version = "0.15", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -281,7 +281,7 @@ Actor B handler: actor_ref_a.ask(msg).await  ← waiting for A's reply
 
 ```toml
 [dependencies]
-rsactor = { version = "0.14", features = ["deadlock-detection"] }
+rsactor = { version = "0.15", features = ["deadlock-detection"] }
 ```
 
 Detected scenarios include self-ask, 2-actor cycles (A → B → A), and indirect chains (A → B → C → A). When a cycle is found, the framework panics with a descriptive message showing the full cycle path, because deadlocks are design errors that should be fixed during development.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rsactor = { version = "0.13", features = ["tracing"] }
+//! rsactor = { version = "0.15", features = ["tracing"] }
 //! tracing = "0.1"
 //! tracing-subscriber = "0.3"
 //! ```


### PR DESCRIPTION
## Summary

Release commit for the priority-channel feature merged in #86.

The priority-channel work landed in main via rebase merge (`cb66859..4c0e8d9`) but the version-bump commit (`b0af6a7` on the original PR branch) was pushed after the merge and didn't make it in. This PR carries that bump as a single isolated commit.

- `Cargo.toml` workspace.package version: `0.14.1` → `0.15.0`
- `Cargo.toml` `rsactor-derive` dep version: `0.14` → `0.15`
- `Cargo.lock`: regenerated for new versions
- `README.md` / `src/lib.rs`: dependency snippets bumped to `0.15` (`lib.rs` example was still on the older `0.13`)
- `CHANGELOG.md`: convert `[Unreleased]` to `[0.15.0] - 2026-05-03`

## Test plan

- [x] `cargo check --all-features` — clean
- [x] No source code changes (version bump only)
- [ ] Wait for CI green before tagging/publishing