### PR TITLE
feat(actor)!: replace on_run with stream-based on_idle handler

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -56,7 +56,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -163,7 +162,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -194,7 +192,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -99,7 +98,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -159,7 +157,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -243,7 +240,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -275,7 +271,6 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "rand",
  "rsactor-derive",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]
@@ -305,6 +306,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["actor", "rust", "framework"]
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-stream = { version = "0.1", features = ["time"] }
 anyhow = "1.0"
 futures = "0.3"
 rand = "0.9"
@@ -56,6 +57,7 @@ futures = "0.3"
 anyhow.workspace = true
 futures.workspace = true
 rand.workspace = true
+tokio-stream.workspace = true
 tracing-subscriber.workspace = true
 
 [[test]]

--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -17,6 +17,7 @@ struct RequesterActor {
 impl Actor for RequesterActor {
     type Args = ActorRef<WorkerActor>;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(
         args: Self::Args,
@@ -96,6 +97,7 @@ struct WorkerActor;
 impl Actor for WorkerActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(
         _args: Self::Args,

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -59,6 +59,7 @@ struct SyncDataProcessorActor {
 impl Actor for SyncDataProcessorActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!(

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -9,8 +9,10 @@
 //! 3. Send data from the background task back to the actor using actor messages
 
 use anyhow::Result;
+use futures::stream::StreamExt;
 use rsactor::{message_handlers, Actor, ActorRef, ActorWeak};
 use std::time::Duration;
+use tokio_stream::wrappers::IntervalStream;
 use tracing::{debug, info};
 
 // Define message types for our actor
@@ -36,7 +38,15 @@ enum TaskCommand {
 /// Message to send a command to the background task
 struct SendTaskCommand(TaskCommand);
 
-/// Define our actor that will use await_next_event/on_event pattern
+/// Idle events delivered by the periodic stream subscribed in `on_start`.
+#[derive(Debug, Clone, Copy)]
+struct GenerateData;
+
+/// Define our actor — driven by a subscribed `IntervalStream` rather than by
+/// open-coded timer state inside `on_run`. The interval can be reconfigured at
+/// runtime via [`SendTaskCommand`]; the previous stream is replaced by simply
+/// subscribing a new one and letting the old one complete (here it never
+/// completes, so both keep firing — see the handler comment).
 struct DataProcessorActor {
     /// Current processing factor (multiplier for incoming values)
     factor: f64,
@@ -44,15 +54,12 @@ struct DataProcessorActor {
     latest_value: Option<f64>,
     /// Latest timestamp when data was received
     latest_timestamp: Option<std::time::Instant>,
-    /// Interval for generating data
-    interval: tokio::time::Interval,
-    /// Whether the actor is running
-    running: bool,
 }
 
 impl Actor for DataProcessorActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = GenerateData;
 
     async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!(
@@ -60,38 +67,33 @@ impl Actor for DataProcessorActor {
             actor_ref.identity()
         );
 
-        let mut actor = Self {
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_millis(500)))
+                .map(|_| GenerateData),
+        )?;
+
+        info!("DataProcessorActor started with event-based processing");
+        Ok(Self {
             factor: 1.0,
             latest_value: None,
             latest_timestamp: None,
-            interval: tokio::time::interval(Duration::from_millis(500)),
-            running: true,
-        };
-
-        // Reset the interval to ensure it starts ticking from now
-        actor.interval = tokio::time::interval(Duration::from_millis(500));
-        actor.running = true;
-
-        info!("DataProcessorActor started with event-based processing");
-        Ok(actor)
+        })
     }
 
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        self.interval.tick().await;
-
+    async fn on_idle(
+        &mut self,
+        _event: GenerateData,
+        _actor_ref: &ActorWeak<Self>,
+    ) -> Result<(), Self::Error> {
         // Generate a random value (simulating sensor data or similar)
         let raw_value = rand::random::<f64>() * 100.0;
-
-        // Process the data directly (no need to send to self via message)
         let processed_value = raw_value * self.factor;
 
-        // Update our state
         self.latest_value = Some(processed_value);
         self.latest_timestamp = Some(std::time::Instant::now());
 
         debug!("Generated data: original={raw_value:.2}, processed={processed_value:.2}");
-
-        Ok(true) // Continue calling on_run
+        Ok(())
     }
 }
 
@@ -139,13 +141,25 @@ impl DataProcessorActor {
     async fn handle_send_task_command(
         &mut self,
         msg: SendTaskCommand,
-        _actor_ref: &ActorRef<Self>,
+        actor_ref: &ActorRef<Self>,
     ) -> bool {
         match msg.0 {
             TaskCommand::ChangeInterval(new_interval) => {
-                self.interval = tokio::time::interval(new_interval);
-                info!("Successfully changed interval");
-                true
+                // Subscribe an additional IntervalStream at the new cadence.
+                // The original 500ms stream continues to fire — this is the
+                // intentional contract of `subscribe_idle` (additive, not
+                // replacement). Use a per-stream cancellation token, a finite
+                // `take_until`, or a fused-stream pattern if you need
+                // replacement semantics.
+                let result = actor_ref.subscribe_idle(
+                    IntervalStream::new(tokio::time::interval(new_interval)).map(|_| GenerateData),
+                );
+                if result.is_ok() {
+                    info!("Subscribed additional generator at {:?}", new_interval);
+                    true
+                } else {
+                    false
+                }
             }
         }
     }

--- a/examples/actor_with_timeout.rs
+++ b/examples/actor_with_timeout.rs
@@ -18,6 +18,7 @@ struct TimeoutDemoActor {
 impl Actor for TimeoutDemoActor {
     type Args = String;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!("{} actor (id: {}) started", args, actor_ref.identity());

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,49 +2,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use futures::stream::StreamExt;
 use rsactor::{message_handlers, Actor, ActorRef, ActorWeak};
 use tokio::time::{interval, Duration};
+use tokio_stream::wrappers::IntervalStream;
 use tracing::info;
 
 // Message types
 struct Increment; // Message to increment the actor's counter
 struct Decrement; // Message to decrement the actor's counter
 
+/// Periodic idle events delivered by the streams subscribed in `on_start`.
+#[derive(Debug, Clone, Copy)]
+enum Tick {
+    Fast, // every 300ms
+    Slow, // every 1s
+}
+
 // Define the actor struct
 struct MyActor {
-    count: u32,                        // Internal state of the actor
-    start_up: std::time::Instant,      // Optional field to track the start time
-    tick_300ms: tokio::time::Interval, // Interval for 300ms ticks
-    tick_1s: tokio::time::Interval,    // Interval for 1s ticks
+    count: u32,                   // Internal state of the actor
+    start_up: std::time::Instant, // Optional field to track the start time
 }
 
 // Implement the Actor trait for MyActor
 impl Actor for MyActor {
-    type Args = Self;
-    type Error = anyhow::Error; // Define the error type for actor operations
+    type Args = u32; // initial count
+    type Error = anyhow::Error;
+    type IdleEvent = Tick;
 
-    // Called when the actor is started
-    async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        info!("MyActor started. Initial count: {}.", args.count);
-        Ok(args)
+    // Called when the actor is started. Subscribes the two periodic streams that
+    // drive the actor's idle work. Stream state (the next-tick instant) lives in
+    // the runtime's `SelectAll`, so ticks are never cancelled by message arrivals.
+    async fn on_start(
+        initial: Self::Args,
+        actor_ref: &ActorRef<Self>,
+    ) -> Result<Self, Self::Error> {
+        info!("MyActor started. Initial count: {}.", initial);
+
+        actor_ref.subscribe_idle(
+            IntervalStream::new(interval(Duration::from_millis(300))).map(|_| Tick::Fast),
+        )?;
+        actor_ref.subscribe_idle(
+            IntervalStream::new(interval(Duration::from_secs(1))).map(|_| Tick::Slow),
+        )?;
+
+        Ok(MyActor {
+            count: initial,
+            start_up: std::time::Instant::now(),
+        })
     }
 
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Use the tokio::select! macro to handle the first completed asynchronous operation among several.
-        tokio::select! {
-            // Executes when the 300ms interval timer ticks.
-            _ = self.tick_300ms.tick() => {
-                println!("300ms tick. Elapsed: {:?}",
-                    self.start_up.elapsed()); // Print the current count
-            }
-            // Executes when the 1s interval timer ticks. (Currently no specific action)
-            _ = self.tick_1s.tick() => {
-                println!("1s tick. Elapsed: {:?} ",
-                    self.start_up.elapsed()); // Print the current count
-            }
+    async fn on_idle(&mut self, event: Tick, _: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        match event {
+            Tick::Fast => println!("300ms tick. Elapsed: {:?}", self.start_up.elapsed()),
+            Tick::Slow => println!("1s tick. Elapsed: {:?}", self.start_up.elapsed()),
         }
-
-        Ok(true) // Continue calling on_run
+        Ok(())
     }
 }
 
@@ -84,16 +98,11 @@ async fn main() -> Result<()> {
 
     println!("Spawning MyActor...");
 
-    let my_actor = MyActor {
-        count: 100,
-        start_up: std::time::Instant::now(),
-        tick_300ms: interval(Duration::from_millis(300)),
-        tick_1s: interval(Duration::from_secs(1)),
-    };
-
     // Spawn the actor. This returns an ActorRef for sending messages
-    // and a JoinHandle to await the actor's completion.
-    let (actor_ref, join_handle) = rsactor::spawn::<MyActor>(my_actor); // MODIFIED: use system.spawn and await
+    // and a JoinHandle to await the actor's completion. The initial counter
+    // value is passed via `Args`; the actor's idle streams are subscribed
+    // inside `on_start` so they outlive `select!` cancellation.
+    let (actor_ref, join_handle) = rsactor::spawn::<MyActor>(100);
 
     tokio::time::sleep(Duration::from_millis(700)).await;
 

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -66,6 +66,7 @@ struct Philosopher {
 impl Actor for Philosopher {
     type Args = (usize, String, ActorRef<Table>);
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         let (id, name, table_ref) = args;
@@ -338,6 +339,7 @@ struct Table {
 impl Actor for Table {
     type Args = usize;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         println!("Table actor is ready with {args} forks.");

--- a/examples/kill_demo.rs
+++ b/examples/kill_demo.rs
@@ -16,6 +16,7 @@ struct DemoActor {
 impl Actor for DemoActor {
     type Args = String;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(
         args: Self::Args,

--- a/examples/priority_signal.rs
+++ b/examples/priority_signal.rs
@@ -50,6 +50,7 @@ struct ResumeProcessing;
 impl Actor for WorkerActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self> {
         Ok(WorkerActor {

--- a/examples/unified_macro_demo.rs
+++ b/examples/unified_macro_demo.rs
@@ -8,6 +8,7 @@ struct SimpleActor {
 
 impl Actor for SimpleActor {
     type Error = String;
+    type IdleEvent = ();
     type Args = i32;
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
@@ -41,6 +42,7 @@ struct GenericActor<T: Send + std::fmt::Debug + Clone + 'static> {
 
 impl<T: Send + std::fmt::Debug + Clone + 'static> Actor for GenericActor<T> {
     type Error = String;
+    type IdleEvent = ();
     type Args = ();
 
     async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {

--- a/examples/weak_reference_demo.rs
+++ b/examples/weak_reference_demo.rs
@@ -25,6 +25,7 @@ struct PingActor {
 impl Actor for PingActor {
     type Args = String;
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(
         args: Self::Args,

--- a/rsactor-derive/src/lib.rs
+++ b/rsactor-derive/src/lib.rs
@@ -53,6 +53,7 @@
 //! impl Actor for MyActor {
 //!     type Args = Self;
 //!     type Error = Infallible;
+//!     type IdleEvent = ();
 //!
 //!     async fn on_start(
 //!         args: Self::Args,
@@ -164,6 +165,7 @@ use syn::{
 /// impl rsactor::Actor for MyActor {
 ///     type Args = Self;
 ///     type Error = std::convert::Infallible;
+///     type IdleEvent = ();
 ///
 ///     async fn on_start(
 ///         args: Self::Args,
@@ -204,6 +206,7 @@ fn derive_actor_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
                 impl #impl_generics rsactor::Actor for #name #ty_generics #where_clause {
                     type Args = Self;
                     type Error = std::convert::Infallible;
+                    type IdleEvent = ();
 
                     async fn on_start(
                         args: Self::Args,

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -3,9 +3,14 @@
 
 use crate::actor_ref::ActorRef;
 use crate::{ActorResult, ActorWeak, ControlSignal, FailurePhase, MailboxMessage};
+use futures::stream::{BoxStream, SelectAll, StreamExt};
 use std::{fmt::Debug, future::Future};
 use tokio::sync::mpsc;
 use tracing::{debug, error, Instrument};
+
+/// Boxed, dynamically-typed stream of idle events delivered to an actor's [`Actor::on_idle`]
+/// handler. Subscriptions are added via [`ActorRef::subscribe_idle`].
+pub(crate) type IdleEventStream<T> = BoxStream<'static, <T as Actor>::IdleEvent>;
 
 /// Wrap a future with CURRENT_ACTOR scope and await it.
 /// Used for on_start, message handler, on_stop.
@@ -18,21 +23,6 @@ macro_rules! run_with_actor_scope {
         #[cfg(not(feature = "deadlock-detection"))]
         {
             $fut.await
-        }
-    }};
-}
-
-/// Wrap a future with CURRENT_ACTOR scope without awaiting.
-/// Used for tokio::select! branch expressions (on_run).
-macro_rules! with_actor_scope {
-    ($actor_id:expr, $fut:expr) => {{
-        #[cfg(feature = "deadlock-detection")]
-        {
-            crate::CURRENT_ACTOR.scope($actor_id, $fut)
-        }
-        #[cfg(not(feature = "deadlock-detection"))]
-        {
-            $fut
         }
     }};
 }
@@ -93,16 +83,16 @@ macro_rules! process_envelope {
 ///
 /// # Error Handling
 ///
-/// Actor lifecycle methods ([`on_start`](Actor::on_start), [`on_run`](Actor::on_run), [`on_stop`](Actor::on_stop)) can return errors. How these errors
+/// Actor lifecycle methods ([`on_start`](Actor::on_start), [`on_idle`](Actor::on_idle), [`on_stop`](Actor::on_stop)) can return errors. How these errors
 /// are handled depends on when they occur:
 ///
 /// 1. Errors in [`on_start`](Actor::on_start): The actor fails to initialize. The error is captured in
 ///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
 ///    [`FailurePhase::OnStart`](crate::FailurePhase::OnStart) and `actor` set to `None`.
 ///
-/// 2. Errors in [`on_run`](Actor::on_run): The actor terminates during runtime. The error is captured in
+/// 2. Errors in [`on_idle`](Actor::on_idle): The actor terminates during runtime. The error is captured in
 ///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
-///    [`FailurePhase::OnRun`](crate::FailurePhase::OnRun) and `actor` contains the actor instance.
+///    [`FailurePhase::OnIdle`](crate::FailurePhase::OnIdle) and `actor` contains the actor instance.
 ///
 /// 3. Errors in [`on_stop`](Actor::on_stop): The actor fails during cleanup. The error is captured in
 ///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
@@ -124,9 +114,26 @@ pub trait Actor: Sized + Send + 'static {
     /// Type for arguments passed to [`on_start`](Actor::on_start) for actor initialization.
     /// This type provides the necessary data to create an instance of the actor.
     type Args: Send;
-    /// The error type that can be returned by the actor\'s lifecycle methods.
-    /// Used in [`on_start`](Actor::on_start), [`on_run`](Actor::on_run), and [`on_stop`](Actor::on_stop).
+    /// The error type that can be returned by the actor's lifecycle methods.
+    /// Used in [`on_start`](Actor::on_start), [`on_idle`](Actor::on_idle), and [`on_stop`](Actor::on_stop).
     type Error: Send + Debug;
+    /// Event type carried by streams subscribed via
+    /// [`ActorRef::subscribe_idle`](crate::actor_ref::ActorRef::subscribe_idle) and dispatched
+    /// to [`on_idle`](Actor::on_idle).
+    ///
+    /// Actors that never subscribe an idle stream should set this to `()`. The
+    /// `#[derive(Actor)]` macro fills this in automatically. When implementing
+    /// [`Actor`] manually, declare it explicitly:
+    ///
+    /// ```rust,ignore
+    /// impl Actor for MyActor {
+    ///     type Args = ();
+    ///     type Error = anyhow::Error;
+    ///     type IdleEvent = ();
+    ///     // ...
+    /// }
+    /// ```
+    type IdleEvent: Send + 'static;
 
     /// Called when the actor is started. This is required for actor creation.
     ///
@@ -177,6 +184,7 @@ pub trait Actor: Sized + Send + 'static {
     /// impl Actor for SimpleActor {
     ///     type Args = String; // Name parameter
     ///     type Error = anyhow::Error;
+    ///     type IdleEvent = ();
     ///
     ///     async fn on_start(name: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
     ///         // Create and return the actor instance
@@ -216,106 +224,87 @@ pub trait Actor: Sized + Send + 'static {
         actor_ref: &ActorRef<Self>,
     ) -> impl Future<Output = std::result::Result<Self, Self::Error>> + Send;
 
-    /// The idle handler for the actor, similar to `on_idle` in traditional event loops.
+    /// Handler invoked for each event yielded by streams subscribed via
+    /// [`ActorRef::subscribe_idle`](crate::actor_ref::ActorRef::subscribe_idle).
     ///
-    /// This method is called when the actor's message queue is empty, allowing the actor to
-    /// perform background processing or periodic tasks. The return value controls whether
-    /// `on_run` continues to be called:
+    /// The runtime owns a [`SelectAll`](futures::stream::SelectAll) of every subscribed
+    /// stream and polls it as one branch of its `select!` loop. When any stream yields an
+    /// event, `on_idle` is called with `&mut self` and full mutable access to actor state —
+    /// no concurrent borrow with message handlers, no surprise cancellation of work in
+    /// progress. A returned `Err` terminates the actor with
+    /// [`FailurePhase::OnIdle`](crate::FailurePhase::OnIdle).
     ///
-    /// - `Ok(true)`: Continue calling `on_run` (equivalent to `G_SOURCE_CONTINUE` in GTK+)
-    /// - `Ok(false)`: Stop calling `on_run`, only process messages (equivalent to `G_SOURCE_REMOVE`)
-    /// - `Err(e)`: Terminate the actor with an error
+    /// # Why a stream — not a free-form async block
     ///
-    /// # Key characteristics:
+    /// In rsActor 0.15 and earlier, idle work was expressed via `on_run`, an async method the
+    /// runtime called repeatedly inside `select!`. Each iteration produced a *new* future, so
+    /// any timing or async state created inside `on_run` (e.g. a raw `tokio::time::sleep`)
+    /// was dropped whenever a message arrived — a 1-second sleep that races with frequent
+    /// messages may never fire.
     ///
-    /// - **Idle Processing**: `on_run` is only called when the message queue is empty,
-    ///   thanks to the `biased` selection in the runtime loop. Messages always have
-    ///   higher priority than idle processing.
+    /// Subscription-based idle events move the timing/event state out of the cancellable
+    /// future and into a [`Stream`](futures::Stream) owned by the runtime. Stream
+    /// implementations like [`IntervalStream`](https://docs.rs/tokio-stream) are
+    /// cancel-safe by construction: even when the surrounding `select!` arm is cancelled,
+    /// the stream's internal schedule survives across iterations.
     ///
-    /// - **Dynamic Control**: The return value allows dynamic control over idle processing.
-    ///   Return `Ok(true)` to continue, or `Ok(false)` when idle processing is no longer needed.
+    /// # Priority relative to messages
     ///
-    /// - **State Persistence Across Invocations**: Because `on_run` can be invoked multiple
-    ///   times by the runtime (each time generating a new `Future`), any state intended
-    ///   to persist across these distinct invocations *must* be stored as fields within
-    ///   the actor's struct (`self`). Local variables declared inside `on_run` are ephemeral
-    ///   and will not be preserved if `on_run` completes and is subsequently re-invoked.
+    /// The runtime's `select!` is `biased` with this order: terminate signal, priority
+    /// mailbox, new subscriptions, regular mailbox, idle events. Idle events therefore
+    /// have *lower* priority than messages — high message throughput can starve idle
+    /// processing. This mirrors the previous `on_run` semantics. If you need strict
+    /// fairness, send self-tells from a separate task instead.
     ///
-    /// - **Full State Access**: `on_run` has full mutable access to the actor's state (`self`).
-    ///   Modifications to `self` within `on_run` are visible to subsequent message handlers
-    ///   and future `on_run` invocations.
+    /// # Common patterns
     ///
-    /// - **Essential Await Points**: The `Future` returned by `on_run` must yield control
-    ///   to the Tokio runtime via `.await` points, especially within any internal loops.
-    ///   Lacking these, the `on_run` task could block the actor's ability to process messages
-    ///   or perform other concurrent activities.
+    /// **Periodic tick:** subscribe an [`IntervalStream`](https://docs.rs/tokio-stream)
+    /// in `on_start` and react in `on_idle`.
     ///
-    /// # Common patterns:
+    /// ```rust,no_run
+    /// # use rsactor::{Actor, ActorRef, ActorWeak};
+    /// # use anyhow::Result;
+    /// # use std::time::Duration;
+    /// # use futures::stream::StreamExt;
+    /// # struct MyActor { ticks: u32 }
+    /// # impl Actor for MyActor {
+    /// # type Args = ();
+    /// # type Error = anyhow::Error;
+    /// # type IdleEvent = ();
+    /// # async fn on_start(_: (), actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+    /// #     // pseudo-code: wrap a tokio::time::Interval as a stream and subscribe
+    /// #     // actor_ref.subscribe_idle(IntervalStream::new(...).map(|_| ()))?;
+    /// #     Ok(MyActor { ticks: 0 })
+    /// # }
+    /// async fn on_idle(&mut self, _: (), actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+    ///     self.ticks += 1;
+    ///     println!("tick {} on actor {}", self.ticks, actor_weak.identity());
+    ///     Ok(())
+    /// }
+    /// # }
+    /// ```
     ///
-    /// 1. **Periodic tasks**: For executing work at regular intervals.
-    ///    ```rust,no_run
-    ///    # use rsactor::{Actor, ActorRef, ActorWeak, Message, spawn};
-    ///    # use anyhow::Result;
-    ///    # use std::time::Duration;
-    ///    # use tokio::time::{Interval, MissedTickBehavior};
-    ///    # struct MyActor {
-    ///    #     interval: Interval,
-    ///    #     ticks_done: u32,
-    ///    # }
-    ///    # impl Actor for MyActor {
-    ///    # type Args = Duration;
-    ///    # type Error = anyhow::Error;
-    ///    # async fn on_start(duration: Self::Args, _actor_ref: &ActorRef<MyActor>) -> std::result::Result<Self, Self::Error> {
-    ///    #     let mut interval = tokio::time::interval(duration);
-    ///    #     interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    ///    #     Ok(MyActor { interval, ticks_done: 0 })
-    ///    # }
-    ///    async fn on_run(&mut self, actor_weak: &ActorWeak<MyActor>) -> std::result::Result<bool, Self::Error> {
-    ///        self.interval.tick().await;
-    ///        println!("Periodic task executed by actor {}", actor_weak.identity());
-    ///        self.ticks_done += 1;
+    /// **Dynamic subscription:** add a new idle source from a message handler.
     ///
-    ///        // Stop idle processing after 10 ticks, but actor continues processing messages
-    ///        if self.ticks_done >= 10 {
-    ///            return Ok(false);
-    ///        }
+    /// ```rust,ignore
+    /// async fn handle_start_sensor(&mut self, _: StartSensor, actor_ref: &ActorRef<Self>) {
+    ///     actor_ref
+    ///         .subscribe_idle(self.sensor.events().map(MyEvent::SensorTick))
+    ///         .ok();
+    /// }
+    /// ```
     ///
-    ///        Ok(true)  // Continue calling on_run
-    ///    }
-    ///    # }
-    ///    ```
+    /// # Default implementation
     ///
-    /// 2. **One-time initialization then message-only**: Perform setup work, then only handle messages.
-    ///    ```rust,no_run
-    ///    # use rsactor::{Actor, ActorRef, ActorWeak};
-    ///    # struct MyActor { initialized: bool }
-    ///    # impl Actor for MyActor {
-    ///    # type Args = ();
-    ///    # type Error = anyhow::Error;
-    ///    # async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> { Ok(MyActor { initialized: false }) }
-    ///    async fn on_run(&mut self, _: &ActorWeak<Self>) -> std::result::Result<bool, Self::Error> {
-    ///        if !self.initialized {
-    ///            // Perform one-time initialization
-    ///            self.initialized = true;
-    ///        }
-    ///        Ok(false)  // No more idle processing needed
-    ///    }
-    ///    # }
-    ///    ```
-    ///
-    /// # Default Implementation
-    ///
-    /// The default implementation returns `Ok(false)`, meaning `on_run` is called once
-    /// and then disabled. Actors that don't override `on_run` will only process messages.
+    /// The default returns `Ok(())` immediately. Actors that never subscribe an idle stream
+    /// can leave this unimplemented and set `type IdleEvent = ();`.
     #[allow(unused_variables)]
-    fn on_run(
+    fn on_idle(
         &mut self,
+        event: Self::IdleEvent,
         actor_weak: &ActorWeak<Self>,
-    ) -> impl Future<Output = std::result::Result<bool, Self::Error>> + Send {
-        // Default implementation returns Ok(false) to indicate no idle processing needed.
-        // The actor will only process messages without calling on_run again.
-        // Override this method and return Ok(true) to have on_run called repeatedly.
-        async { Ok(false) }
+    ) -> impl Future<Output = std::result::Result<(), Self::Error>> + Send {
+        async { Ok(()) }
     }
 
     /// Called when the actor is about to stop. This allows the actor to perform cleanup tasks.
@@ -323,7 +312,7 @@ pub trait Actor: Sized + Send + 'static {
     /// This method is called when the actor is stopping, including:
     /// - Explicit stop via [`ActorRef::stop`](crate::actor_ref::ActorRef::stop) (graceful termination)
     /// - Explicit kill via [`ActorRef::kill`](crate::actor_ref::ActorRef::kill) (immediate termination)
-    /// - Cleanup after an [`on_run`](Actor::on_run) error
+    /// - Cleanup after an [`on_idle`](Actor::on_idle) error
     ///
     /// It is **not** called if the actor fails during message processing (handler panic/error).
     /// The result of this method affects the final [`ActorResult`](crate::ActorResult) returned when awaiting the join handle.
@@ -343,6 +332,7 @@ pub trait Actor: Sized + Send + 'static {
     /// # impl Actor for MyActor {
     /// #     type Args = ();
     /// #     type Error = anyhow::Error;
+    /// #     type IdleEvent = ();
     /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
     /// #         Ok(MyActor { /* ... */ })
     /// #     }
@@ -489,7 +479,7 @@ pub trait Message<T: Send + 'static>: Actor {
 ///                    ┌─────────────┐
 ///                    │ Message     │
 ///                    │ Processing  │
-///                    │ + on_run    │
+///                    │ + on_idle   │
 ///                    └─────────────┘
 /// ```
 #[cfg_attr(feature = "tracing", tracing::instrument(
@@ -507,7 +497,13 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     mut receiver: mpsc::Receiver<MailboxMessage<T>>,
     mut priority_receiver: Option<mpsc::Receiver<MailboxMessage<T>>>,
     mut terminate_receiver: mpsc::Receiver<ControlSignal>,
+    idle_subscribe_receiver: mpsc::Receiver<IdleEventStream<T>>,
 ) -> ActorResult<T> {
+    // Track the subscribe channel as Option to mirror the priority-channel
+    // close-detection pattern: when all strong senders drop and `recv()`
+    // returns None, replace with `None` so the select arm becomes pending and
+    // does not busy-loop. We still allow normal shutdown via the mailbox arm.
+    let mut idle_subscribe_receiver = Some(idle_subscribe_receiver);
     let actor_id = actor_ref.identity();
 
     #[cfg(feature = "tracing")]
@@ -540,17 +536,34 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     drop(actor_ref); // Drop the strong reference to allow graceful shutdown detection
 
     let mut killed = false;
-    let mut idle_enabled = true;
 
-    // Main actor processing loop - handles three concurrent operations:
-    // 1. Termination signals (highest priority via biased select)
-    // 2. Incoming messages from the mailbox
-    // 3. Actor's on_run lifecycle method execution
+    // Aggregates every stream registered via `ActorRef::subscribe_idle`. New
+    // streams arrive on `idle_subscribe_receiver`; completed streams are removed
+    // automatically by `SelectAll`. The branch below is guarded so the runtime
+    // does not poll the empty set forever — `futures::stream::SelectAll::next()`
+    // on an empty set returns `Poll::Ready(None)` immediately, which would
+    // busy-loop without the guard.
+    let mut idle_streams: SelectAll<IdleEventStream<T>> = SelectAll::new();
+
+    // Drain any subscriptions queued during `on_start`. The subscribe arm in
+    // the main loop would install them one per select! iteration; doing this
+    // synchronously up front means the very first iteration can already
+    // service idle events and avoids N round-trips through the select! when
+    // `on_start` calls `subscribe_idle` N times.
+    if let Some(rx) = idle_subscribe_receiver.as_mut() {
+        while let Ok(stream) = rx.try_recv() {
+            idle_streams.push(stream);
+        }
+    }
+
+    // Main actor processing loop. The `tokio::select!` is `biased` with this
+    // priority order: termination signals → priority mailbox → new idle
+    // subscriptions → regular mailbox → idle events.
     loop {
         #[cfg(feature = "tracing")]
-        let on_run_span = tracing::debug_span!("actor_on_run");
+        let on_idle_span = tracing::debug_span!("actor_on_idle");
         #[cfg(not(feature = "tracing"))]
-        let on_run_span = tracing::Span::none();
+        let on_idle_span = tracing::Span::none();
 
         tokio::select! {
             // Handle termination signals with highest priority using biased selection
@@ -638,6 +651,31 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 }
             }
 
+            // Install newly subscribed idle streams as soon as they arrive.
+            // Subscriptions are typically pushed from `on_start` (before this
+            // loop runs the first time) or from a message handler that just
+            // completed. Polling this branch ahead of the regular mailbox
+            // ensures freshly-added streams are active before the next message
+            // is processed. When the channel closes (all `ActorRef`/`ActorWeak`
+            // strong senders dropped) we set the option to None so the branch
+            // becomes pending — graceful termination then propagates via the
+            // mailbox arm below.
+            maybe_subscription = async {
+                match idle_subscribe_receiver.as_mut() {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending::<Option<IdleEventStream<T>>>().await,
+                }
+            } => {
+                match maybe_subscription {
+                    Some(stream) => {
+                        idle_streams.push(stream);
+                    }
+                    None => {
+                        idle_subscribe_receiver = None;
+                    }
+                }
+            }
+
             // Process incoming messages from the actor's mailbox
             // Messages can be: regular message envelopes or graceful stop signals
             maybe_message = receiver.recv() => {
@@ -715,50 +753,48 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 }
             }
 
-            // Execute the actor's on_run method (idle handler) when enabled.
-            // This branch is disabled when on_run returns Ok(false).
-            maybe_result = with_actor_scope!(
-                actor_id,
-                actor.on_run(&actor_weak).instrument(on_run_span)
-            ), if idle_enabled => {
-                match maybe_result {
-                    Ok(true) => {
-                        // on_run completed successfully, continue calling on_run
-                    }
-                    Ok(false) => {
-                        // on_run indicated no more idle processing needed
-                        idle_enabled = false;
-                    }
-                    Err(e) => {
-                        // on_run returned an error - terminate the actor with failure status
-                        let error_msg = format!("Actor {actor_id} on_run error: {e:?}");
-                        error!("{error_msg}");
+            // Dispatch one event from the merged set of subscribed idle streams
+            // to the actor's `on_idle` handler. The `if !idle_streams.is_empty()`
+            // guard is essential: `SelectAll::next()` on an empty set resolves
+            // to `Poll::Ready(None)` immediately and would busy-loop.
+            //
+            // Each underlying stream is responsible for its own cancel-safety.
+            // Streams that complete (return None) are removed from the set
+            // automatically by `SelectAll`.
+            Some(event) = idle_streams.next(), if !idle_streams.is_empty() => {
+                let result = run_with_actor_scope!(
+                    actor_id,
+                    actor.on_idle(event, &actor_weak).instrument(on_idle_span)
+                );
 
-                        // Call on_stop for cleanup even after on_run failure
-                        #[cfg(feature = "tracing")]
-                        let on_stop_span = tracing::debug_span!("actor_on_stop", killed = false);
-                        #[cfg(not(feature = "tracing"))]
-                        let on_stop_span = tracing::Span::none();
+                if let Err(e) = result {
+                    let error_msg = format!("Actor {actor_id} on_idle error: {e:?}");
+                    error!("{error_msg}");
 
-                        let phase = if let Err(stop_err) = run_with_actor_scope!(
-                            actor_id,
-                            actor.on_stop(&actor_weak, false).instrument(on_stop_span)
-                        ) {
-                            error!(
-                                "Actor {actor_id} on_stop failed during on_run error cleanup: {stop_err:?}"
-                            );
-                            FailurePhase::OnRunThenOnStop
-                        } else {
-                            FailurePhase::OnRun
-                        };
+                    // Call on_stop for cleanup even after on_idle failure
+                    #[cfg(feature = "tracing")]
+                    let on_stop_span = tracing::debug_span!("actor_on_stop", killed = false);
+                    #[cfg(not(feature = "tracing"))]
+                    let on_stop_span = tracing::Span::none();
 
-                        return ActorResult::Failed {
-                            actor: Some(actor),
-                            error: e,
-                            phase,
-                            killed,
-                        };
-                    }
+                    let phase = if let Err(stop_err) = run_with_actor_scope!(
+                        actor_id,
+                        actor.on_stop(&actor_weak, false).instrument(on_stop_span)
+                    ) {
+                        error!(
+                            "Actor {actor_id} on_stop failed during on_idle error cleanup: {stop_err:?}"
+                        );
+                        FailurePhase::OnIdleThenOnStop
+                    } else {
+                        FailurePhase::OnIdle
+                    };
+
+                    return ActorResult::Failed {
+                        actor: Some(actor),
+                        error: e,
+                        phase,
+                        killed,
+                    };
                 }
             }
         }
@@ -769,6 +805,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     terminate_receiver.close(); // Close the termination signal channel
     if let Some(rx) = priority_receiver.as_mut() {
         rx.close(); // Close the optional priority channel
+    }
+    if let Some(rx) = idle_subscribe_receiver.as_mut() {
+        rx.close(); // Close the idle subscribe channel
     }
 
     debug!("Actor {actor_id} lifecycle completed - exiting runtime loop.");

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -172,7 +172,7 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// Streams are owned by the runtime — their internal state (timer schedules,
     /// channel buffers, etc.) survives across runtime-loop iterations, so a
-    /// stream like [`tokio_stream::wrappers::IntervalStream`] fires reliably even
+    /// stream like [`IntervalStream`](https://docs.rs/tokio-stream) fires reliably even
     /// when the surrounding `select!` arm is cancelled by a higher-priority
     /// branch. This is the chief reason to prefer subscriptions over open-coded
     /// idle loops.

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -1,9 +1,11 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::actor::IdleEventStream;
 use crate::error::{Error, Result};
 use crate::Identity;
 use crate::{Actor, ControlSignal, MailboxMessage, MailboxSender, Message};
+use futures::stream::{Stream, StreamExt};
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
@@ -76,6 +78,10 @@ pub struct ActorRef<T: Actor> {
     pub(crate) priority_sender: Option<MailboxSender<T>>,
     /// Channel for sending control signals (e.g., terminate) to the actor
     pub(crate) terminate_sender: mpsc::Sender<ControlSignal>,
+    /// Channel for registering new idle-event streams with the actor's runtime.
+    /// Each subscribed stream is merged into the runtime's `SelectAll` and its
+    /// events drive [`Actor::on_idle`](crate::Actor::on_idle).
+    pub(crate) idle_subscribe_sender: mpsc::Sender<IdleEventStream<T>>,
     /// Per-actor metrics collector (when metrics feature is enabled)
     #[cfg(feature = "metrics")]
     pub(crate) metrics: Arc<MetricsCollector>,
@@ -88,6 +94,7 @@ impl<T: Actor> ActorRef<T> {
         sender: MailboxSender<T>,
         priority_sender: Option<MailboxSender<T>>,
         terminate_sender: mpsc::Sender<ControlSignal>,
+        idle_subscribe_sender: mpsc::Sender<IdleEventStream<T>>,
         #[cfg(feature = "metrics")] metrics: Arc<MetricsCollector>,
     ) -> Self {
         ActorRef {
@@ -95,6 +102,7 @@ impl<T: Actor> ActorRef<T> {
             sender,
             priority_sender,
             terminate_sender,
+            idle_subscribe_sender,
             #[cfg(feature = "metrics")]
             metrics,
         }
@@ -152,9 +160,77 @@ impl<T: Actor> ActorRef<T> {
             sender: this.sender.downgrade(),
             priority_sender: this.priority_sender.as_ref().map(|s| s.downgrade()),
             terminate_sender: this.terminate_sender.downgrade(),
+            idle_subscribe_sender: this.idle_subscribe_sender.downgrade(),
             #[cfg(feature = "metrics")]
             metrics: this.metrics.clone(),
         }
+    }
+
+    /// Registers a [`Stream`] of idle events to be merged into the actor's
+    /// runtime. Each event yielded by the stream is dispatched to
+    /// [`Actor::on_idle`](crate::Actor::on_idle).
+    ///
+    /// Streams are owned by the runtime — their internal state (timer schedules,
+    /// channel buffers, etc.) survives across runtime-loop iterations, so a
+    /// stream like [`tokio_stream::wrappers::IntervalStream`] fires reliably even
+    /// when the surrounding `select!` arm is cancelled by a higher-priority
+    /// branch. This is the chief reason to prefer subscriptions over open-coded
+    /// idle loops.
+    ///
+    /// Subscription can be called any number of times, from any context with
+    /// access to an [`ActorRef`] — typically from [`Actor::on_start`] for the
+    /// initial sources, and from message handlers to attach additional sources
+    /// dynamically.
+    ///
+    /// This method is synchronous and never awaits. It uses [`try_send`] under
+    /// the hood so that subscriptions inside `on_start` cannot deadlock the
+    /// runtime: at that moment the lifecycle is still awaiting `on_start`, so
+    /// the subscribe channel's receiver is not yet being polled and any
+    /// `.await` would block forever. The bounded buffer (capacity
+    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY))
+    /// absorbs bursts; an explicit `Err` is returned if it is exceeded.
+    ///
+    /// [`try_send`]: tokio::sync::mpsc::Sender::try_send
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Send`] when:
+    /// - The actor is no longer alive (channel closed); or
+    /// - The subscribe buffer is full. In that case, batch your subscriptions
+    ///   across separate handler invocations or raise
+    ///   [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Inside `on_start`:
+    /// actor_ref.subscribe_idle(
+    ///     tokio_stream::wrappers::IntervalStream::new(
+    ///         tokio::time::interval(std::time::Duration::from_secs(1))
+    ///     ).map(|_| Tick)
+    /// )?;
+    /// ```
+    pub fn subscribe_idle<S>(&self, stream: S) -> Result<()>
+    where
+        S: Stream<Item = T::IdleEvent> + Send + 'static,
+    {
+        let boxed: IdleEventStream<T> = stream.boxed();
+        self.idle_subscribe_sender
+            .try_send(boxed)
+            .map_err(|e| match e {
+                mpsc::error::TrySendError::Full(_) => Error::Send {
+                    identity: self.identity(),
+                    details: format!(
+                        "Idle subscribe channel full (capacity {}); batch subscriptions across \
+                         handler invocations or raise IDLE_SUBSCRIBE_CHANNEL_CAPACITY",
+                        crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY
+                    ),
+                },
+                mpsc::error::TrySendError::Closed(_) => Error::Send {
+                    identity: self.identity(),
+                    details: "Idle subscribe channel closed (actor is no longer alive)".to_string(),
+                },
+            })
     }
 
     /// Sends a message to the actor without awaiting a reply (fire-and-forget).
@@ -1338,6 +1414,7 @@ impl<T: Actor> Clone for ActorRef<T> {
             sender: self.sender.clone(),
             priority_sender: self.priority_sender.clone(),
             terminate_sender: self.terminate_sender.clone(),
+            idle_subscribe_sender: self.idle_subscribe_sender.clone(),
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
         }
@@ -1381,6 +1458,8 @@ pub struct ActorWeak<T: Actor> {
     priority_sender: Option<tokio::sync::mpsc::WeakSender<MailboxMessage<T>>>,
     /// Weak reference to the actor's terminate signal sender
     terminate_sender: tokio::sync::mpsc::WeakSender<ControlSignal>,
+    /// Weak reference to the actor's idle-subscribe channel sender
+    idle_subscribe_sender: tokio::sync::mpsc::WeakSender<IdleEventStream<T>>,
     /// Strong reference to metrics (survives actor drop for post-mortem analysis)
     #[cfg(feature = "metrics")]
     metrics: Arc<MetricsCollector>,
@@ -1398,18 +1477,26 @@ impl<T: Actor> ActorWeak<T> {
     /// [`has_priority_channel()`](ActorRef::has_priority_channel) returning `false`, and
     /// priority calls will fail with
     /// [`Error::PriorityChannelNotEnabled`](crate::Error::PriorityChannelNotEnabled).
+    ///
+    /// The mailbox, terminate, and idle-subscribe channels are all *primary* channels and
+    /// must all upgrade for `upgrade()` to succeed. In practice their strong-sender counts
+    /// move in lockstep — every [`ActorRef`] clone owns one of each — so they live and die
+    /// together; the joint check is defensive rather than restrictive.
     #[inline]
     pub fn upgrade(&self) -> Option<ActorRef<T>> {
-        // Try to upgrade both the mailbox sender and terminate sender
+        // Try to upgrade the three primary channel senders (mailbox, terminate,
+        // idle-subscribe). The priority channel, when present, is best-effort.
         let sender = self.sender.upgrade()?;
         let terminate_sender = self.terminate_sender.upgrade()?;
         let priority_sender = self.priority_sender.as_ref().and_then(|s| s.upgrade());
+        let idle_subscribe_sender = self.idle_subscribe_sender.upgrade()?;
 
         Some(ActorRef {
             id: self.id,
             sender,
             priority_sender,
             terminate_sender,
+            idle_subscribe_sender,
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
         })
@@ -1445,6 +1532,7 @@ impl<T: Actor> Clone for ActorWeak<T> {
             sender: self.sender.clone(),
             priority_sender: self.priority_sender.clone(),
             terminate_sender: self.terminate_sender.clone(),
+            idle_subscribe_sender: self.idle_subscribe_sender.clone(),
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
         }

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -13,14 +13,14 @@ use std::fmt::Debug;
 pub enum FailurePhase {
     /// Actor failed during the [`on_start`](crate::Actor::on_start) lifecycle hook.
     OnStart,
-    /// Actor failed during execution in the [`on_run`](crate::Actor::on_run) lifecycle hook.
-    OnRun,
+    /// Actor failed during execution in the [`on_idle`](crate::Actor::on_idle) lifecycle hook.
+    OnIdle,
     /// Actor failed during the [`on_stop`](crate::Actor::on_stop) lifecycle hook.
     OnStop,
-    /// Actor failed during [`on_run`](crate::Actor::on_run), and then
+    /// Actor failed during [`on_idle`](crate::Actor::on_idle), and then
     /// [`on_stop`](crate::Actor::on_stop) also failed during cleanup.
-    /// The primary error is from `on_run`; the `on_stop` error is logged.
-    OnRunThenOnStop,
+    /// The primary error is from `on_idle`; the `on_stop` error is logged.
+    OnIdleThenOnStop,
 }
 
 /// Implements Display for FailurePhase to provide human-readable error messages.
@@ -31,9 +31,9 @@ impl std::fmt::Display for FailurePhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             FailurePhase::OnStart => write!(f, "OnStart"),
-            FailurePhase::OnRun => write!(f, "OnRun"),
+            FailurePhase::OnIdle => write!(f, "OnIdle"),
             FailurePhase::OnStop => write!(f, "OnStop"),
-            FailurePhase::OnRunThenOnStop => write!(f, "OnRunThenOnStop"),
+            FailurePhase::OnIdleThenOnStop => write!(f, "OnIdleThenOnStop"),
         }
     }
 }
@@ -61,6 +61,7 @@ impl std::fmt::Display for FailurePhase {
 /// # impl Actor for MyActor {
 /// #     type Args = ();
 /// #     type Error = anyhow::Error;
+/// #     type IdleEvent = ();
 /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self> { Ok(MyActor) }
 /// # }
 /// # async fn example() -> Result<()> {
@@ -88,6 +89,7 @@ impl std::fmt::Display for FailurePhase {
 /// # impl Actor for MyActor {
 /// #     type Args = ();
 /// #     type Error = anyhow::Error;
+/// #     type IdleEvent = ();
 /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self> { Ok(MyActor) }
 /// # }
 /// # async fn restart_actor() -> Result<(ActorRef<MyActor>, tokio::task::JoinHandle<ActorResult<MyActor>>)> {
@@ -225,27 +227,27 @@ impl<T: Actor> ActorResult<T> {
     /// Returns `true` if the actor failed during runtime.
     ///
     /// This indicates that the actor started successfully but encountered an error
-    /// during its normal operation in the [`on_run`](crate::Actor::on_run) lifecycle phase.
+    /// during its normal operation in the [`on_idle`](crate::Actor::on_idle) lifecycle phase.
     /// Also returns `true` when `on_stop` additionally failed during cleanup
-    /// ([`FailurePhase::OnRunThenOnStop`]).
+    /// ([`FailurePhase::OnIdleThenOnStop`]).
     pub fn is_runtime_failed(&self) -> bool {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnRun | FailurePhase::OnRunThenOnStop,
+                phase: FailurePhase::OnIdle | FailurePhase::OnIdleThenOnStop,
                 ..
             }
         )
     }
 
-    /// Returns `true` if `on_stop` also failed after an `on_run` error.
+    /// Returns `true` if `on_stop` also failed after an `on_idle` error.
     ///
-    /// The primary error is from `on_run`; the `on_stop` error is logged separately.
+    /// The primary error is from `on_idle`; the `on_stop` error is logged separately.
     pub fn is_cleanup_failed(&self) -> bool {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnRunThenOnStop,
+                phase: FailurePhase::OnIdleThenOnStop,
                 ..
             }
         )
@@ -281,6 +283,7 @@ impl<T: Actor> ActorResult<T> {
     /// # impl Actor for MyActor {
     /// #     type Args = ();
     /// #     type Error = anyhow::Error;
+    /// #     type IdleEvent = ();
     /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> { Ok(MyActor) }
     /// # }
     /// # fn example(result: ActorResult<MyActor>) {
@@ -312,6 +315,7 @@ impl<T: Actor> ActorResult<T> {
     /// # impl Actor for MyActor {
     /// #     type Args = ();
     /// #     type Error = anyhow::Error;
+    /// #     type IdleEvent = ();
     /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
     /// #         Ok(MyActor { state: "ready".to_string() })
     /// #     }
@@ -382,6 +386,7 @@ impl<T: Actor> ActorResult<T> {
     /// # impl Actor for MyActor {
     /// #     type Args = ();
     /// #     type Error = anyhow::Error;
+    /// #     type IdleEvent = ();
     /// #     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> { Ok(MyActor) }
     /// # }
     /// # fn example(result: ActorResult<MyActor>) -> Result<MyActor, anyhow::Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -261,9 +261,9 @@ impl Error {
                 "This usually indicates a bug in handler implementation",
             ],
             Error::Runtime { .. } => &[
-                "Check if on_start() or on_run() returned an error",
+                "Check if on_start() or on_idle() returned an error",
                 "Look for panic messages in the error details field",
-                "Use `ActorResult::is_start_failed()` or `is_run_failed()` to identify failure phase",
+                "Use `ActorResult::is_startup_failed()` or `is_runtime_failed()` to identify failure phase",
                 "Call `ActorResult::error()` to get the underlying error details",
                 "Initialize tracing-subscriber and set RUST_LOG=debug for lifecycle diagnostics",
             ],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,10 @@
 //!   [`ask_priority`](actor_ref::ActorRef::ask_priority). The priority channel
 //!   is **off by default**; calls on a non-priority actor return
 //!   [`Error::PriorityChannelNotEnabled`].
-//! - **Straightforward Actor Lifecycle**: Actors have [`on_start`](Actor::on_start), [`on_run`](Actor::on_run),
-//!   and [`on_stop`](Actor::on_stop) lifecycle hooks that provide a clean and intuitive actor lifecycle management system.
-//!   The framework manages the execution flow while giving developers full control over actor behavior.
+//! - **Straightforward Actor Lifecycle**: Actors have [`on_start`](Actor::on_start), [`on_idle`](Actor::on_idle),
+//!   and [`on_stop`](Actor::on_stop) lifecycle hooks. Idle work is driven by streams subscribed via
+//!   [`ActorRef::subscribe_idle`](actor_ref::ActorRef::subscribe_idle) — each yielded event is dispatched to
+//!   `on_idle` with `&mut self`, so timer / channel state never gets cancelled by a competing `select!` arm.
 //! - **Graceful Shutdown & Kill**: Actors can be stopped gracefully or killed immediately.
 //! - **Typed Messages**: Messages are strongly typed, and replies are also typed.
 //! - **Macro for Message Handling**:
@@ -51,7 +52,7 @@
 //!
 //! ## Core Concepts
 //!
-//! - **[`Actor`]**: Trait defining actor behavior and lifecycle hooks ([`on_start`](Actor::on_start) required, [`on_run`](Actor::on_run) optional).
+//! - **[`Actor`]**: Trait defining actor behavior and lifecycle hooks ([`on_start`](Actor::on_start) required, [`on_idle`](Actor::on_idle) optional).
 //! - **[`Message<M>`](actor::Message)**: Trait for handling a message type `M` and defining its reply type.
 //! - **[`ActorRef`]**: Handle for sending messages to an actor.
 //! - **[`spawn`]**: Function to create and start an actor, returning an [`ActorRef`] and a `JoinHandle`.
@@ -138,9 +139,10 @@
 //! impl Actor for MyActor {
 //!     type Args = String;
 //!     type Error = anyhow::Error;
+//!     type IdleEvent = ();
 //!
 //!     // on_start is required and must be implemented.
-//!     // on_run and on_stop are optional and have default implementations.
+//!     // on_idle and on_stop are optional and have default implementations.
 //!     async fn on_start(initial_data: Self::Args, actor_ref: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
 //!         println!("MyActor (id: {}) started with data: '{}'", actor_ref.identity(), initial_data);
 //!         Ok(MyActor {
@@ -561,6 +563,24 @@ pub const DEFAULT_MAILBOX_CAPACITY: usize = 32;
 /// [`SpawnOptions::with_priority`] for the rationale.
 pub(crate) const PRIORITY_CHANNEL_CAPACITY: usize = 1;
 
+/// Capacity of the idle-subscribe channel used by
+/// [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle).
+///
+/// Subscriptions are rare events (typically a handful per actor, established
+/// during `on_start` or in response to occasional control messages), and the
+/// runtime drains the channel on every loop iteration. The buffer absorbs
+/// bursts that occur **before the runtime enters its select! loop** —
+/// specifically, every subscription made inside `on_start` is queued here
+/// because the receiver is not polled until `on_start` returns. A capacity of
+/// 32 leaves comfortable headroom for fan-out patterns (e.g. one subscription
+/// per item in a small config list) without resorting to an unbounded channel.
+///
+/// `subscribe_idle` uses `try_send` and returns [`Error::Send`] when the
+/// buffer is full, so the failure mode is a loud, actionable error rather
+/// than a silent hang — callers can batch or raise this constant if it is
+/// ever hit in practice.
+pub const IDLE_SUBSCRIBE_CHANNEL_CAPACITY: usize = 32;
+
 /// Sets the global default buffer size for actor mailboxes.
 ///
 /// This function can only be called successfully once. Subsequent calls
@@ -718,6 +738,7 @@ pub fn spawn_with_options<T: Actor + 'static>(
 
     let (mailbox_tx, mailbox_rx) = mpsc::channel(opts.mailbox_capacity);
     let (terminate_tx, terminate_rx) = mpsc::channel::<ControlSignal>(1);
+    let (idle_subscribe_tx, idle_subscribe_rx) = mpsc::channel(IDLE_SUBSCRIBE_CHANNEL_CAPACITY);
 
     let (priority_tx, priority_rx) = if opts.priority_enabled {
         let (tx, rx) = mpsc::channel(PRIORITY_CHANNEL_CAPACITY);
@@ -734,6 +755,7 @@ pub fn spawn_with_options<T: Actor + 'static>(
         mailbox_tx,
         priority_tx,
         terminate_tx,
+        idle_subscribe_tx,
         #[cfg(feature = "metrics")]
         metrics,
     );
@@ -744,6 +766,7 @@ pub fn spawn_with_options<T: Actor + 'static>(
         mailbox_rx,
         priority_rx,
         terminate_rx,
+        idle_subscribe_rx,
     ));
 
     (actor_ref, join_handle)

--- a/tests/actor_ref_drop_tests.rs
+++ b/tests/actor_ref_drop_tests.rs
@@ -30,6 +30,7 @@ struct DropTestArgs {
 impl Actor for DropTestActor {
     type Args = DropTestArgs;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         debug!("DropTestActor (id: {}) started.", actor_ref.identity());

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::stream::StreamExt;
 use rsactor::{spawn, Actor, ActorRef, ActorResult, ActorWeak, FailurePhase, Message};
+use tokio_stream::wrappers::IntervalStream;
 
 // Dummy message for test actors
 #[derive(Debug)]
@@ -17,16 +19,11 @@ struct TestActor {
 impl Actor for TestActor {
     type Args = (String, i32);
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         let (id, value) = args;
         Ok(TestActor { id, value })
-    }
-
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Simple idle handler that continues running
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        Ok(true)
     }
 }
 
@@ -52,24 +49,29 @@ struct FailureTestArgs {
 impl Actor for FailureTestActor {
     type Args = FailureTestArgs;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
-    async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+    async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         if args.fail_on_start {
             return Err(anyhow::anyhow!("Test failure in on_start"));
         }
+        // Subscribe a fast IntervalStream so `on_idle` fires repeatedly and we
+        // can simulate runtime failures via the actor's `id` flag below.
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(std::time::Duration::from_millis(50)))
+                .map(|_| ()),
+        )?;
         Ok(FailureTestActor {
             id: args.id,
             value: args.value,
         })
     }
 
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+    async fn on_idle(&mut self, _: (), _actor_ref: &ActorWeak<Self>) -> Result<(), Self::Error> {
         if self.id.contains("fail_on_run") {
-            return Err(anyhow::anyhow!("Test failure in on_run"));
+            return Err(anyhow::anyhow!("Test failure in on_idle"));
         }
-        // Simple idle handler that continues running
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        Ok(true)
+        Ok(())
     }
 
     async fn on_stop(
@@ -275,7 +277,7 @@ async fn test_actor_result_failed_on_run() {
     // Test error access
     assert!(result.error().is_some(), "Should have error");
     if let Some(error) = result.error() {
-        assert!(error.to_string().contains("Test failure in on_run"));
+        assert!(error.to_string().contains("Test failure in on_idle"));
     }
 }
 
@@ -368,18 +370,18 @@ async fn test_actor_result_failed_on_stop_killed() {
 #[tokio::test]
 async fn test_failure_phase_display() {
     assert_eq!(FailurePhase::OnStart.to_string(), "OnStart");
-    assert_eq!(FailurePhase::OnRun.to_string(), "OnRun");
+    assert_eq!(FailurePhase::OnIdle.to_string(), "OnIdle");
     assert_eq!(FailurePhase::OnStop.to_string(), "OnStop");
 }
 
 #[tokio::test]
 async fn test_failure_phase_equality() {
     assert_eq!(FailurePhase::OnStart, FailurePhase::OnStart);
-    assert_eq!(FailurePhase::OnRun, FailurePhase::OnRun);
+    assert_eq!(FailurePhase::OnIdle, FailurePhase::OnIdle);
     assert_eq!(FailurePhase::OnStop, FailurePhase::OnStop);
 
-    assert_ne!(FailurePhase::OnStart, FailurePhase::OnRun);
-    assert_ne!(FailurePhase::OnRun, FailurePhase::OnStop);
+    assert_ne!(FailurePhase::OnStart, FailurePhase::OnIdle);
+    assert_ne!(FailurePhase::OnIdle, FailurePhase::OnStop);
     assert_ne!(FailurePhase::OnStart, FailurePhase::OnStop);
 }
 
@@ -414,7 +416,7 @@ async fn test_actor_result_from_failed_with_actor() {
             value: 456,
         }),
         error: anyhow::anyhow!("test error"),
-        phase: FailurePhase::OnRun,
+        phase: FailurePhase::OnIdle,
         killed: false,
     };
 
@@ -559,7 +561,7 @@ async fn test_all_boolean_combinations() {
             value: 4,
         }),
         error: anyhow::anyhow!("error4"),
-        phase: FailurePhase::OnRun,
+        phase: FailurePhase::OnIdle,
         killed: false,
     };
     assert!(!result4.is_completed() && !result4.was_killed() && result4.is_runtime_failed());

--- a/tests/blocking_without_runtime_tests.rs
+++ b/tests/blocking_without_runtime_tests.rs
@@ -17,6 +17,7 @@ struct RuntimelessTestActor {
 impl Actor for RuntimelessTestActor {
     type Args = i32;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(Self { counter: args })

--- a/tests/comprehensive_alternatives_test.rs
+++ b/tests/comprehensive_alternatives_test.rs
@@ -12,6 +12,7 @@ struct AlternativesTestActor {
 impl Actor for AlternativesTestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(AlternativesTestActor { counter: 0 })

--- a/tests/coverage_improvement_tests.rs
+++ b/tests/coverage_improvement_tests.rs
@@ -1,8 +1,10 @@
 // Tests specifically designed to improve code coverage
 // These tests target uncovered code paths identified by llvm-cov
 
+use futures::stream::StreamExt;
 use rsactor::{spawn, Actor, ActorRef, ActorWeak, Identity};
 use std::time::Duration;
+use tokio_stream::wrappers::IntervalStream;
 
 /// Initialize tracing subscriber for tests
 /// This enables coverage of tracing-related code paths
@@ -316,22 +318,31 @@ mod on_run_error_tests {
     impl Actor for FailingOnRunActor {
         type Args = u32; // Number of times to succeed before failing
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(
             args: Self::Args,
-            _actor_ref: &ActorRef<Self>,
+            actor_ref: &ActorRef<Self>,
         ) -> Result<Self, Self::Error> {
+            actor_ref
+                .subscribe_idle(
+                    IntervalStream::new(tokio::time::interval(Duration::from_millis(10)))
+                        .map(|_| ()),
+                )
+                .map_err(|e| e.to_string())?;
             Ok(Self { fail_count: args })
         }
 
-        async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+        async fn on_idle(
+            &mut self,
+            _: (),
+            _actor_weak: &ActorWeak<Self>,
+        ) -> Result<(), Self::Error> {
             if self.fail_count > 0 {
                 self.fail_count -= 1;
-                // Use a short sleep to yield control
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                Ok(true)
+                Ok(())
             } else {
-                Err("Intentional on_run failure".to_string())
+                Err("Intentional on_idle failure".to_string())
             }
         }
     }
@@ -350,13 +361,13 @@ mod on_run_error_tests {
 
         // Verify the error message
         let error = result.error().unwrap();
-        assert_eq!(error, "Intentional on_run failure");
+        assert_eq!(error, "Intentional on_idle failure");
 
         // The actor_ref should no longer be alive
         assert!(!actor_ref.is_alive());
     }
 
-    // Actor that fails in both on_run and on_stop
+    // Actor that fails in both on_idle and on_stop
     struct FailingOnRunAndOnStopActor {
         fail_count: u32,
     }
@@ -364,21 +375,31 @@ mod on_run_error_tests {
     impl Actor for FailingOnRunAndOnStopActor {
         type Args = u32;
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(
             args: Self::Args,
-            _actor_ref: &ActorRef<Self>,
+            actor_ref: &ActorRef<Self>,
         ) -> Result<Self, Self::Error> {
+            actor_ref
+                .subscribe_idle(
+                    IntervalStream::new(tokio::time::interval(Duration::from_millis(10)))
+                        .map(|_| ()),
+                )
+                .map_err(|e| e.to_string())?;
             Ok(Self { fail_count: args })
         }
 
-        async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+        async fn on_idle(
+            &mut self,
+            _: (),
+            _actor_weak: &ActorWeak<Self>,
+        ) -> Result<(), Self::Error> {
             if self.fail_count > 0 {
                 self.fail_count -= 1;
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                Ok(true)
+                Ok(())
             } else {
-                Err("Intentional on_run failure".to_string())
+                Err("Intentional on_idle failure".to_string())
             }
         }
 
@@ -387,8 +408,8 @@ mod on_run_error_tests {
             _actor_weak: &ActorWeak<Self>,
             _killed: bool,
         ) -> Result<(), Self::Error> {
-            // This error is logged but not propagated (on_run error takes precedence)
-            Err("Intentional on_stop failure during on_run cleanup".to_string())
+            // This error is logged but not propagated (on_idle error takes precedence)
+            Err("Intentional on_stop failure during on_idle cleanup".to_string())
         }
     }
 
@@ -404,14 +425,14 @@ mod on_run_error_tests {
         assert!(result.is_failed());
         assert!(result.is_runtime_failed());
 
-        // The error should be from on_run (on_stop error is only logged)
+        // The error should be from on_idle (on_stop error is only logged)
         let error = result.error().unwrap();
-        assert_eq!(error, "Intentional on_run failure");
+        assert_eq!(error, "Intentional on_idle failure");
 
-        // Phase should be OnRunThenOnStop since both on_run and on_stop failed
+        // Phase should be OnIdleThenOnStop since both on_idle and on_stop failed
         match &result {
             rsactor::ActorResult::Failed { phase, .. } => {
-                assert_eq!(*phase, rsactor::FailurePhase::OnRunThenOnStop);
+                assert_eq!(*phase, rsactor::FailurePhase::OnIdleThenOnStop);
             }
             _ => panic!("Expected Failed result"),
         }
@@ -435,6 +456,7 @@ mod on_stop_error_tests {
     impl Actor for FailingOnStopActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self)
@@ -506,6 +528,7 @@ mod on_start_error_tests {
     impl Actor for FailingOnStartActor {
         type Args = bool; // true = succeed, false = fail
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(succeed: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             if succeed {
@@ -701,6 +724,7 @@ mod actor_result_from_tests {
         impl Actor for FailOnStopActor {
             type Args = i32;
             type Error = String;
+            type IdleEvent = ();
 
             async fn on_start(args: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
                 Ok(Self { value: args })
@@ -735,6 +759,7 @@ mod actor_result_from_tests {
         impl Actor for FailOnStartActor {
             type Args = ();
             type Error = String;
+            type IdleEvent = ();
 
             async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
                 Err("on_start error".to_string())
@@ -1085,6 +1110,7 @@ mod actor_result_methods_tests {
         impl Actor for FailActor {
             type Args = ();
             type Error = String;
+            type IdleEvent = ();
 
             async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, String> {
                 Err("failed".to_string())
@@ -1121,6 +1147,7 @@ mod actor_result_methods_tests {
         impl Actor for FailActorForError {
             type Args = ();
             type Error = String;
+            type IdleEvent = ();
 
             async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, String> {
                 Err("into_error_test".to_string())
@@ -1326,7 +1353,7 @@ mod failure_phase_tests {
     #[test]
     fn test_failure_phase_display_all_variants() {
         assert_eq!(format!("{}", FailurePhase::OnStart), "OnStart");
-        assert_eq!(format!("{}", FailurePhase::OnRun), "OnRun");
+        assert_eq!(format!("{}", FailurePhase::OnIdle), "OnIdle");
         assert_eq!(format!("{}", FailurePhase::OnStop), "OnStop");
     }
 
@@ -1336,8 +1363,8 @@ mod failure_phase_tests {
         let debug_str = format!("{:?}", FailurePhase::OnStart);
         assert!(debug_str.contains("OnStart"));
 
-        let debug_str = format!("{:?}", FailurePhase::OnRun);
-        assert!(debug_str.contains("OnRun"));
+        let debug_str = format!("{:?}", FailurePhase::OnIdle);
+        assert!(debug_str.contains("OnIdle"));
 
         let debug_str = format!("{:?}", FailurePhase::OnStop);
         assert!(debug_str.contains("OnStop"));
@@ -1345,7 +1372,7 @@ mod failure_phase_tests {
 
     #[test]
     fn test_failure_phase_clone_copy() {
-        let phase = FailurePhase::OnRun;
+        let phase = FailurePhase::OnIdle;
         let cloned = phase;
         let copied = phase;
 
@@ -1388,6 +1415,7 @@ mod actor_result_debug_tests {
         impl Actor for FailDebugActor {
             type Args = ();
             type Error = String;
+            type IdleEvent = ();
 
             async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, String> {
                 Err("debug test failure".to_string())
@@ -1824,11 +1852,16 @@ mod stop_edge_cases_tests {
 }
 
 // ============================================================================
-// Tests for on_run returning Ok(false) (actor.rs)
+// Tests for a finite idle stream (drives `on_idle` once, then completes).
+// This replaces the old `on_run` returning `Ok(false)` semantics: in B-1 the
+// stream itself controls how many events are produced, so a single-shot
+// stream produces a single `on_idle` call and then is automatically removed
+// from the runtime's `SelectAll`.
 // ============================================================================
 
 mod on_run_disable_tests {
     use super::*;
+    use futures::stream;
 
     struct OnRunDisableActor {
         run_count: u32,
@@ -1837,15 +1870,19 @@ mod on_run_disable_tests {
     impl Actor for OnRunDisableActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
-        async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        async fn on_start(_: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+            // One-shot stream: yields a single `()` and then ends.
+            actor_ref
+                .subscribe_idle(stream::once(async {}))
+                .map_err(|e| e.to_string())?;
             Ok(Self { run_count: 0 })
         }
 
-        async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+        async fn on_idle(&mut self, _: (), _: &ActorWeak<Self>) -> Result<(), Self::Error> {
             self.run_count += 1;
-            // Return false after first run to disable further on_run calls
-            Ok(false)
+            Ok(())
         }
     }
 
@@ -1860,23 +1897,23 @@ mod on_run_disable_tests {
     }
 
     #[tokio::test]
-    async fn test_on_run_returns_false_disables_idle_processing() {
+    async fn test_finite_idle_stream_dispatches_once() {
         init_test_logger();
         let (actor_ref, handle) = spawn::<OnRunDisableActor>(());
 
-        // Wait for on_run to execute once
+        // Wait for the one-shot stream to fire.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // Check run count - should be 1 (on_run was called once, returned false)
         let run_count: u32 = actor_ref.ask(GetRunCount).await.unwrap();
-        assert_eq!(run_count, 1, "on_run should have been called exactly once");
+        assert_eq!(run_count, 1, "on_idle should have been called exactly once");
 
-        // Wait more and check again - should still be 1
+        // Wait more and check again - the stream completed, so SelectAll
+        // removed it; on_idle does not fire again.
         tokio::time::sleep(Duration::from_millis(100)).await;
         let run_count: u32 = actor_ref.ask(GetRunCount).await.unwrap();
         assert_eq!(
             run_count, 1,
-            "on_run should not have been called again after returning false"
+            "on_idle should not be called again after the stream completed"
         );
 
         actor_ref.stop().await.unwrap();
@@ -1898,6 +1935,7 @@ mod message_trait_tests {
     impl Actor for MessageTraitActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self {
@@ -2043,6 +2081,7 @@ mod actual_timeout_tests {
     impl Actor for TimeoutTestActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self)
@@ -2123,17 +2162,25 @@ mod lifecycle_phase_tests {
     impl Actor for LifecyclePhaseActor {
         type Args = std::sync::Arc<AtomicU32>;
         type Error = String;
+        type IdleEvent = ();
 
-        async fn on_start(tracker: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        async fn on_start(
+            tracker: Self::Args,
+            actor_ref: &ActorRef<Self>,
+        ) -> Result<Self, Self::Error> {
             tracker.fetch_add(1, Ordering::SeqCst); // 1
+                                                    // One-shot idle stream to drive on_idle exactly once.
+            actor_ref
+                .subscribe_idle(futures::stream::once(async {}))
+                .map_err(|e| e.to_string())?;
             Ok(Self {
                 phase_tracker: tracker,
             })
         }
 
-        async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+        async fn on_idle(&mut self, _: (), _: &ActorWeak<Self>) -> Result<(), Self::Error> {
             self.phase_tracker.fetch_add(10, Ordering::SeqCst); // 11
-            Ok(false) // Don't continue
+            Ok(())
         }
 
         async fn on_stop(&mut self, _: &ActorWeak<Self>, _killed: bool) -> Result<(), Self::Error> {
@@ -2149,10 +2196,10 @@ mod lifecycle_phase_tests {
 
         let (actor_ref, handle) = spawn::<LifecyclePhaseActor>(tracker.clone());
 
-        // Wait for on_run to execute
+        // Wait for on_idle to execute
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        // After on_start and on_run, should be 11
+        // After on_start and on_idle, should be 11
         let value = tracker.load(Ordering::SeqCst);
         assert!(value >= 11, "Expected at least 11, got {}", value);
 
@@ -2182,6 +2229,7 @@ mod metrics_api_tests {
     impl Actor for MetricsTestActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self)
@@ -2373,6 +2421,7 @@ mod tell_with_timeout_tests {
     impl Actor for SlowTellActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self)
@@ -2426,6 +2475,7 @@ mod blocking_timeout_expiry_tests {
     impl Actor for BlockingTimeoutActor {
         type Args = ();
         type Error = String;
+        type IdleEvent = ();
 
         async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
             Ok(Self)

--- a/tests/deadlock_detection_tests.rs
+++ b/tests/deadlock_detection_tests.rs
@@ -25,6 +25,7 @@ struct SequentialPing(ActorRef<WorkerActor>, ActorRef<WorkerActor>);
 impl Actor for WorkerActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(WorkerActor)
@@ -70,6 +71,7 @@ struct TriggerSelfAsk;
 impl Actor for SelfAskActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(SelfAskActor)
@@ -123,6 +125,7 @@ struct CyclePong;
 impl Actor for CycleActorA {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(CycleActorA)
@@ -132,6 +135,7 @@ impl Actor for CycleActorA {
 impl Actor for CycleActorB {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(CycleActorB)
@@ -220,6 +224,7 @@ struct ChainPong;
 impl Actor for ChainActorA {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(ChainActorA)
@@ -229,6 +234,7 @@ impl Actor for ChainActorA {
 impl Actor for ChainActorB {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(ChainActorB)
@@ -238,6 +244,7 @@ impl Actor for ChainActorB {
 impl Actor for ChainActorC {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(ChainActorC)

--- a/tests/function_message_types_tests.rs
+++ b/tests/function_message_types_tests.rs
@@ -17,6 +17,7 @@ struct FunctionHandlerTestActor {
 impl Actor for FunctionHandlerTestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(
         _args: Self::Args,

--- a/tests/generic_closure_types_test.rs
+++ b/tests/generic_closure_types_test.rs
@@ -12,6 +12,7 @@ struct GenericClosureTestActor {
 impl Actor for GenericClosureTestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(GenericClosureTestActor {

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -15,6 +15,7 @@ struct GenericActor<T: Send + Debug + Clone + 'static> {
 // ---- Actor Trait Implementation ----
 impl<T: Send + Debug + Clone + 'static> Actor for GenericActor<T> {
     type Args = Option<T>; // Initial value for data
+    type IdleEvent = ();
     type Error = anyhow::Error;
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
@@ -325,6 +326,7 @@ struct BiGenericActor<K: Send + Debug + Clone + 'static, V: Send + Debug + Clone
 impl<K: Send + Debug + Clone + 'static, V: Send + Debug + Clone + 'static> Actor
     for BiGenericActor<K, V>
 {
+    type IdleEvent = ();
     type Args = (Option<K>, Option<V>);
     type Error = anyhow::Error;
 
@@ -413,6 +415,7 @@ where
 {
     type Args = (U, W);
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(TriGenericActor {
@@ -565,6 +568,7 @@ struct SerializableActor<T: Serializable> {
 impl<T: Serializable> Actor for SerializableActor<T> {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(SerializableActor { data: None })

--- a/tests/message_handlers_macro_tests.rs
+++ b/tests/message_handlers_macro_tests.rs
@@ -17,6 +17,7 @@ struct MessageHandlerTestActor {
 impl Actor for MessageHandlerTestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(
         _args: Self::Args,

--- a/tests/panic_handling_tests.rs
+++ b/tests/panic_handling_tests.rs
@@ -10,11 +10,13 @@
 //! - Tests for supervision patterns
 
 use anyhow::Result;
+use futures::stream::StreamExt;
 use rsactor::{spawn, Actor, ActorRef, ActorResult, ActorWeak, Message};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
+use tokio_stream::wrappers::IntervalStream;
 use tracing::info;
 
 // Test messages
@@ -38,26 +40,28 @@ struct PanicTestActor {
 }
 
 impl Actor for PanicTestActor {
-    type Args = Option<u32>; // Optional panic threshold for on_run
+    type Args = Option<u32>; // Optional panic threshold for on_idle
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!("PanicTestActor started with ID: {}", actor_ref.identity());
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_millis(10))).map(|_| ()),
+        )?;
         Ok(PanicTestActor {
             counter: 0,
             panic_threshold: args,
         })
     }
 
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+    async fn on_idle(&mut self, _: (), _actor_ref: &ActorWeak<Self>) -> Result<(), Self::Error> {
         if let Some(threshold) = self.panic_threshold {
             if self.counter >= threshold {
-                panic!("Counter reached threshold {threshold} - intentional panic in on_run!");
+                panic!("Counter reached threshold {threshold} - intentional panic in on_idle!");
             }
         }
-
-        sleep(Duration::from_millis(10)).await;
-        Ok(true)
+        Ok(())
     }
 
     async fn on_stop(
@@ -393,6 +397,7 @@ mod advanced_tests {
     impl Actor for StartupPanicActor {
         type Args = bool; // true to panic during on_start
         type Error = anyhow::Error;
+        type IdleEvent = ();
 
         async fn on_start(
             should_panic: Self::Args,
@@ -439,6 +444,7 @@ mod advanced_tests {
     impl Actor for StopPanicActor {
         type Args = bool; // true to panic during on_stop
         type Error = anyhow::Error;
+        type IdleEvent = ();
 
         async fn on_start(
             panic_on_stop: Self::Args,
@@ -496,6 +502,7 @@ mod advanced_tests {
     impl Actor for KillTestActor {
         type Args = bool;
         type Error = anyhow::Error;
+        type IdleEvent = ();
 
         async fn on_start(
             should_panic_on_stop: Self::Args,
@@ -703,6 +710,7 @@ mod integration_tests {
         impl Actor for ServiceActor {
             type Args = ();
             type Error = anyhow::Error;
+            type IdleEvent = ();
 
             async fn on_start(
                 _args: Self::Args,
@@ -782,6 +790,7 @@ mod integration_tests {
         impl Actor for SimpleActor {
             type Args = u32;
             type Error = anyhow::Error;
+            type IdleEvent = ();
 
             async fn on_start(
                 id: Self::Args,

--- a/tests/priority_signal_tests.rs
+++ b/tests/priority_signal_tests.rs
@@ -59,6 +59,7 @@ struct PriorityPing(u32);
 impl Actor for CounterActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(CounterActor {
@@ -111,6 +112,7 @@ struct GetPriorityCount;
 impl Actor for BlockingActor {
     type Args = (Arc<AtomicU32>, Arc<Notify>);
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(
         (started, release): Self::Args,
@@ -731,6 +733,7 @@ impl Actor for OrderActor {
         Arc<Notify>,
     );
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(
         (log, r1_started, r1_release): Self::Args,
         _: &ActorRef<Self>,

--- a/tests/simple_function_types_test.rs
+++ b/tests/simple_function_types_test.rs
@@ -13,6 +13,7 @@ struct TestActor {
 impl Actor for TestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(TestActor { count: 0 })

--- a/tests/tell_error_logging_tests.rs
+++ b/tests/tell_error_logging_tests.rs
@@ -24,6 +24,7 @@ struct AutoDetectActor;
 impl Actor for AutoDetectActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(
         _args: Self::Args,
@@ -75,6 +76,7 @@ struct TellErrActor;
 impl Actor for TellErrActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(TellErrActor)
     }
@@ -108,6 +110,7 @@ struct TellOkActor;
 impl Actor for TellOkActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(TellOkActor)
     }
@@ -140,6 +143,7 @@ struct AskNoInvokeActor;
 impl Actor for AskNoInvokeActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(AskNoInvokeActor)
     }
@@ -168,6 +172,7 @@ struct NoLogActor;
 impl Actor for NoLogActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(NoLogActor)
     }
@@ -197,6 +202,7 @@ struct ForceResultActor;
 impl Actor for ForceResultActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
     async fn on_start(_: (), _: &ActorRef<Self>) -> std::result::Result<Self, Self::Error> {
         Ok(ForceResultActor)
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,10 @@
 // Copyright 2022 Jeff Kim <hiking90@gmail.com>
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::stream::StreamExt;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio_stream::wrappers::IntervalStream;
 use tracing::debug;
 
 use rsactor::{
@@ -27,6 +29,7 @@ struct TestArgs {
 impl Actor for TestActor {
     type Args = TestArgs;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         debug!("TestActor (id: {}) started.", actor_ref.identity());
@@ -306,6 +309,7 @@ struct LifecycleErrorActor {
 impl Actor for LifecycleErrorActor {
     type Args = LifecycleErrorArgs;
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         let _id = actor_ref.identity();
@@ -313,6 +317,10 @@ impl Actor for LifecycleErrorActor {
         if args.fail_on_start {
             Err(anyhow::anyhow!("simulated on_start failure"))
         } else {
+            actor_ref.subscribe_idle(
+                IntervalStream::new(tokio::time::interval(std::time::Duration::from_millis(50)))
+                    .map(|_| ()),
+            )?;
             Ok(LifecycleErrorActor {
                 _id,
                 fail_on_run: args.fail_on_run,
@@ -324,14 +332,12 @@ impl Actor for LifecycleErrorActor {
         }
     }
 
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+    async fn on_idle(&mut self, _: (), _actor_ref: &ActorWeak<Self>) -> Result<(), Self::Error> {
         *self.on_run_attempted.lock().await = true;
         if self.fail_on_run {
-            Err(anyhow::anyhow!("simulated on_run failure"))
+            Err(anyhow::anyhow!("simulated on_idle failure"))
         } else {
-            // Continue idle processing
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-            Ok(true)
+            Ok(())
         }
     }
 
@@ -411,7 +417,7 @@ async fn test_actor_fail_on_run() {
 
     match result {
         rsactor::ActorResult::Failed { actor, error, .. } => {
-            assert!(error.to_string().contains("simulated on_run failure"));
+            assert!(error.to_string().contains("simulated on_idle failure"));
             if let Some(actor) = actor {
                 assert!(*actor.on_start_attempted.lock().await);
                 assert!(*actor.on_run_attempted.lock().await);
@@ -473,6 +479,7 @@ struct PanicActor {}
 impl Actor for PanicActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(PanicActor {})
@@ -496,6 +503,7 @@ struct StringErrorActor {
 impl Actor for StringErrorActor {
     type Args = Arc<Mutex<bool>>;
     type Error = String; // Using String as the error type
+    type IdleEvent = ();
 
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         let on_start_called = args;
@@ -605,6 +613,7 @@ struct DummyActor;
 impl Actor for DummyActor {
     type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = ();
 
     async fn on_start(_args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(DummyActor)
@@ -1086,7 +1095,7 @@ async fn test_actor_fail_on_stop_after_on_run_failure() {
         } => {
             assert_eq!(
                 phase,
-                rsactor::FailurePhase::OnRunThenOnStop,
+                rsactor::FailurePhase::OnIdleThenOnStop,
                 "Should fail in OnRunThenOnStop phase when both on_run and on_stop fail"
             );
             assert!(
@@ -1094,7 +1103,7 @@ async fn test_actor_fail_on_stop_after_on_run_failure() {
                 "Should not be marked as killed for on_run failure scenario"
             );
             // The error should be from on_run, not on_stop
-            assert!(error.to_string().contains("simulated on_run failure"));
+            assert!(error.to_string().contains("simulated on_idle failure"));
 
             if let Some(actor) = actor {
                 assert!(
@@ -1150,14 +1159,14 @@ async fn test_actor_on_stop_success_after_on_run_failure() {
         } => {
             assert_eq!(
                 phase,
-                rsactor::FailurePhase::OnRun,
+                rsactor::FailurePhase::OnIdle,
                 "Should fail in OnRun phase"
             );
             assert!(
                 !killed,
                 "Should not be marked as killed for on_run failure scenario"
             );
-            assert!(error.to_string().contains("simulated on_run failure"));
+            assert!(error.to_string().contains("simulated on_idle failure"));
 
             if let Some(actor) = actor {
                 assert!(

--- a/tests/trait_object_without_box_test.rs
+++ b/tests/trait_object_without_box_test.rs
@@ -12,6 +12,7 @@ struct TraitObjectTestActor {
 impl Actor for TraitObjectTestActor {
     type Args = ();
     type Error = AnyError;
+    type IdleEvent = ();
 
     async fn on_start(_: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
         Ok(TraitObjectTestActor { counter: 0 })


### PR DESCRIPTION
## Summary
- Replace `Actor::on_run` with `Actor::on_idle`. Idle work is now driven by streams subscribed via `ActorRef::subscribe_idle`; each yielded event is dispatched to `on_idle(&mut self, event, actor_weak)`. Stream state lives in the runtime's `SelectAll` and survives `select!` cancellation, so periodic work fires reliably even under message pressure.
- New required associated type `Actor::IdleEvent: Send + 'static`. `#[derive(Actor)]` auto-fills it as `()`. Manual `impl Actor` adds one line.
- Rename `FailurePhase::OnRun` → `OnIdle`, `OnRunThenOnStop` → `OnIdleThenOnStop`.
- `subscribe_idle` is synchronous and uses `try_send` (capacity 32) so subscriptions from `on_start` cannot deadlock the runtime while the lifecycle is awaiting `on_start` and the receiver is not yet being polled. A pre-loop drain installs all `on_start` subscriptions before the first `select!` iteration.

## Motivation
`on_run` was created fresh inside the runtime's `select!` each iteration. Any timer or await state created inside it (e.g. `tokio::time::sleep`) was dropped whenever a competing branch (message arrival, priority signal) won. A 1-second sleep racing with sub-second messages would never fire — a frequent footgun. Subscriptions move that timing/event state into runtime-owned streams that are inherently cancel-safe.

## Breaking changes
- `Actor::on_run` is removed. Implement `Actor::on_idle` instead.
- `Actor::IdleEvent` associated type is now required (default unstable; `#[derive(Actor)]` auto-fills as `()`).
- `FailurePhase::OnRun` / `OnRunThenOnStop` renamed to `OnIdle` / `OnIdleThenOnStop`. `is_runtime_failed()` / `is_cleanup_failed()` semantics are preserved.

### Migration (manual `impl Actor`)
```rust
// Before
impl Actor for MyActor {
    type Args = ();
    type Error = anyhow::Error;
    // ... open-coded interval state in self ...
    async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
        self.interval.tick().await;
        self.do_work();
        Ok(true)
    }
}

// After
impl Actor for MyActor {
    type Args = ();
    type Error = anyhow::Error;
    type IdleEvent = ();

    async fn on_start(_: (), actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
        actor_ref.subscribe_idle(
            IntervalStream::new(tokio::time::interval(Duration::from_secs(1))).map(|_| ()),
        )?;
        Ok(MyActor { /* ... */ })
    }

    async fn on_idle(&mut self, _: (), _: &ActorWeak<Self>) -> Result<(), Self::Error> {
        self.do_work();
        Ok(())
    }
}
```

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 24 test binaries, 388 unit/integration + 15 doctests, all passing
- [x] All 10 existing examples build and run
- [x] `examples/basic.rs` verified: 1s and 300ms ticks fire on schedule even with interleaved messages
- [x] `examples/actor_task.rs` verified: dynamic re-subscription from a message handler works

🤖 Generated with [Claude Code](https://claude.com/claude-code)