### PR TITLE
feat!: stream-based on_idle handler + lifecycle/blocking refactors

### DIFF
--- a/examples/actor_async_worker.rs
+++ b/examples/actor_async_worker.rs
@@ -178,8 +178,8 @@ async fn main() -> Result<()> {
     }
 
     // Gracefully stop the actors
-    requester_ref.stop().await?;
-    worker_ref.stop().await?;
+    requester_ref.stop().await;
+    worker_ref.stop().await;
 
     // Wait for actors to complete
     let _requester_result = requester_handle.await?;

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -286,6 +286,7 @@ async fn main() -> Result<()> {
             error,
             phase,
             killed,
+            ..
         } => {
             println!("Actor stop failed: {error}. Phase: {phase}, Killed: {killed}");
             if let Some(actor) = actor {

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -267,7 +267,7 @@ async fn main() -> Result<()> {
 
     // Stop the actor gracefully
     println!("Stopping actor...");
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
 
     // Wait for the actor to finish (this will also wait for the background task)
     let result = join_handle.await?;

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -242,6 +242,7 @@ async fn main() -> Result<()> {
             error,
             killed,
             phase,
+            ..
         } => {
             println!("Actor stop failed: {error}. Phase: {phase}, Killed: {killed}");
             if let Some(actor) = actor {

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -224,7 +224,7 @@ async fn main() -> Result<()> {
 
     // Stop the actor gracefully
     println!("Stopping actor...");
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
 
     // Wait for the actor to finish (this will also wait for the background task)
     let result = join_handle.await?;

--- a/examples/actor_with_timeout.rs
+++ b/examples/actor_with_timeout.rs
@@ -222,7 +222,7 @@ async fn main() -> Result<()> {
 
     // Stop the actor gracefully and wait for it to terminate
     info!("\n=== Stopping actor ===");
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     let result = join_handle.await?;
 
     match result {

--- a/examples/advanced_derive_demo.rs
+++ b/examples/advanced_derive_demo.rs
@@ -176,9 +176,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Total tasks completed: {total_tasks}");
 
     // Cleanup
-    simple_ref.stop().await?;
-    counter_ref.stop().await?;
-    worker_ref.stop().await?;
+    simple_ref.stop().await;
+    counter_ref.stop().await;
+    worker_ref.stop().await;
 
     println!("\n✨ All actors stopped successfully!");
 

--- a/examples/ask_join_demo.rs
+++ b/examples/ask_join_demo.rs
@@ -280,7 +280,7 @@ async fn main() -> Result<()> {
 
     // Gracefully stop the actor
     println!("\nStopping actor...");
-    worker_ref.stop().await?;
+    worker_ref.stop().await;
 
     // Wait for actor to complete
     let _result = worker_handle.await?;

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -147,6 +147,7 @@ async fn main() -> Result<()> {
             error,
             phase,
             killed,
+            ..
         } => {
             println!(
                 "Actor stop failed: {}. Phase: {}, Killed: {}. Final count: {}",

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
     // Signal the actor to stop gracefully.
     // The actor will process any remaining messages in its mailbox before stopping.
     println!("Sending StopGracefully message to actor.",);
-    actor_ref.stop().await?; // Corrected method name
+    actor_ref.stop().await; // Corrected method name
 
     // Wait for the actor's task to complete.
     // `join_handle.await` returns a Result containing a tuple:

--- a/examples/derive_macro_demo.rs
+++ b/examples/derive_macro_demo.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Final count: {final_count}");
 
     // Stop the actor
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
 
     Ok(())
 }

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -484,9 +484,7 @@ async fn main() -> Result<()> {
     // Shutdown actors gracefully
     println!("\nShutting down philosophers...");
     for p_ref in philosopher_refs.iter() {
-        p_ref.stop().await.unwrap_or_else(|e| {
-            eprintln!("Error stopping philosopher: {e:?}");
-        });
+        p_ref.stop().await;
     }
 
     // Wait for actors to terminate
@@ -494,9 +492,7 @@ async fn main() -> Result<()> {
     let results = futures::future::join_all(philosopher_join_handles).await;
 
     println!("\nShutting down table...");
-    if let Err(e) = table_ref.stop().await {
-        eprintln!("Error stopping table: {e:?}");
-    }
+    table_ref.stop().await;
 
     println!("\nWaiting for table to terminate...");
     match table_join_handle.await {

--- a/examples/handler_demo.rs
+++ b/examples/handler_demo.rs
@@ -305,8 +305,8 @@ async fn main() -> Result<()> {
     println!("\n--- Cleanup ---\n");
 
     // Stop all actors
-    counter_actor.stop().await?;
-    logger_actor.stop().await?;
+    counter_actor.stop().await;
+    logger_actor.stop().await;
 
     // Wait for completion
     let counter_result = counter_handle.await?;

--- a/examples/kill_demo.rs
+++ b/examples/kill_demo.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
     println!("Calling kill() on the actor...");
 
     // Kill the actor (this should trigger the kill scenario)
-    actor_ref.kill()?;
+    actor_ref.kill();
 
     // Wait for the actor to complete
     println!("Waiting for actor to terminate...");

--- a/examples/kill_demo.rs
+++ b/examples/kill_demo.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<()> {
             error,
             phase,
             killed,
+            ..
         } => {
             println!(
                 "Actor failed: {}. Phase: {:?}, Killed: {}, Final name: {}",

--- a/examples/message_macro_demo.rs
+++ b/examples/message_macro_demo.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
 
     println!("📊 Final count: {}", actor_ref.ask(GetCount).await?);
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     let result = join_handle.await?;
 
     match result {

--- a/examples/metrics_demo.rs
+++ b/examples/metrics_demo.rs
@@ -113,7 +113,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("  Message count: {}", metrics.message_count);
         println!("  Avg processing time: {:?}", metrics.avg_processing_time);
         println!("  Max processing time: {:?}", metrics.max_processing_time);
-        println!("  Error count: {}", metrics.error_count);
         println!("  Uptime: {:?}", metrics.uptime);
         println!("  Last activity: {:?}", metrics.last_activity);
 
@@ -134,7 +133,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Message count after ask: {}", actor_ref.message_count());
 
     // Graceful shutdown
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     let result = handle.await?;
 
     println!("\nActor completed: {:?}", result.is_completed());

--- a/examples/priority_signal.rs
+++ b/examples/priority_signal.rs
@@ -149,7 +149,7 @@ async fn main() -> Result<()> {
         .tell_priority(ResumeProcessing, Duration::from_secs(1))
         .await?;
 
-    actor.stop().await?;
+    actor.stop().await;
     let result = join.await?;
     if let Some(final_state) = result.actor() {
         println!(

--- a/examples/tracing_demo.rs
+++ b/examples/tracing_demo.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Final counter value: {final_counter}\n");
 
     println!("10. Gracefully stopping actor...");
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     println!("Actor stopped successfully");
 
     #[cfg(feature = "tracing")]

--- a/examples/unified_macro_demo.rs
+++ b/examples/unified_macro_demo.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let count: i32 = simple_ref.ask(GetCount).await?;
     println!("Final count: {count}");
 
-    simple_ref.stop().await?;
+    simple_ref.stop().await;
 
     // Test generic actor with String
     println!("\n--- Testing Generic Actor<String> ---");
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let string_value: Option<String> = string_ref.ask(GetValue).await?;
     println!("String value: {string_value:?}");
 
-    string_ref.stop().await?;
+    string_ref.stop().await;
 
     // Test generic actor with i32
     println!("\n--- Testing Generic Actor<i32> ---");
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let int_value: Option<i32> = int_ref.ask(GetValue).await?;
     println!("Integer value: {int_value:?}");
 
-    int_ref.stop().await?;
+    int_ref.stop().await;
 
     println!("\n✅ Unified macro works for both generic and non-generic actors!");
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -199,7 +199,7 @@ pub trait Actor: Sized + Send + 'static {
     ///     let (actor_ref, join_handle) = spawn::<SimpleActor>("MyActor".to_string());
     ///
     ///     // Gracefully stop the actor using [`stop`](crate::actor_ref::ActorRef::stop)
-    ///     actor_ref.stop().await?;
+    ///     actor_ref.stop().await;
     ///
     ///     // Wait for the actor to complete and get its final state
     ///     // The JoinHandle returns an [`ActorResult`](crate::ActorResult) enum
@@ -312,6 +312,8 @@ pub trait Actor: Sized + Send + 'static {
     /// This method is called when the actor is stopping, including:
     /// - Explicit stop via [`ActorRef::stop`](crate::actor_ref::ActorRef::stop) (graceful termination)
     /// - Explicit kill via [`ActorRef::kill`](crate::actor_ref::ActorRef::kill) (immediate termination)
+    /// - Implicit shutdown when every strong [`ActorRef`](crate::actor_ref::ActorRef) has been
+    ///   dropped (treated as graceful termination, so `killed = false`)
     /// - Cleanup after an [`on_idle`](Actor::on_idle) error
     ///
     /// It is **not** called if the actor fails during message processing (handler panic/error).
@@ -451,15 +453,21 @@ pub trait Message<T: Send + 'static>: Actor {
 /// initialization through message processing to termination. It orchestrates:
 ///
 /// 1. **Initialization**: Calls `on_start` to create the actor instance
-/// 2. **Runtime Loop**: Concurrently handles messages and executes `on_run`
+/// 2. **Runtime Loop**: Concurrently handles messages and dispatches idle events to `on_idle`
 /// 3. **Termination**: Manages graceful/forceful shutdown and calls `on_stop`
 ///
 /// # Arguments
 ///
 /// * `args` - Initialization arguments passed to the actor's `on_start` method
 /// * `actor_ref` - Strong reference to the actor (dropped after initialization)
-/// * `receiver` - Channel receiver for incoming messages
+/// * `receiver` - Channel receiver for the regular mailbox
+/// * `priority_receiver` - Optional channel receiver for the priority mailbox.
+///   `None` when the actor was spawned without
+///   [`SpawnOptions::with_priority`](crate::SpawnOptions::with_priority).
 /// * `terminate_receiver` - Channel receiver for termination signals
+/// * `idle_subscribe_receiver` - Channel receiver for new idle-event stream
+///   subscriptions registered via
+///   [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle)
 ///
 /// # Returns
 ///

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -532,6 +532,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             return ActorResult::Failed {
                 actor: None,
                 error: e,
+                secondary_error: None,
                 phase: FailurePhase::OnStart,
                 killed: false,
             };
@@ -568,11 +569,6 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     // priority order: termination signals → priority mailbox → new idle
     // subscriptions → regular mailbox → idle events.
     loop {
-        #[cfg(feature = "tracing")]
-        let on_idle_span = tracing::debug_span!("actor_on_idle");
-        #[cfg(not(feature = "tracing"))]
-        let on_idle_span = tracing::Span::none();
-
         tokio::select! {
             // Handle termination signals with highest priority using biased selection
             // This ensures that termination requests are processed immediately when available
@@ -608,6 +604,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     return ActorResult::Failed {
                         actor: Some(actor),
                         error: e,
+                        secondary_error: None,
                         phase: FailurePhase::OnStop,
                         killed,
                     };
@@ -699,9 +696,12 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             guard = MessageProcessingGuard,
                         );
                     }
-                    Some(MailboxMessage::StopGracefully(_)) | None => {
+                    msg @ (Some(MailboxMessage::StopGracefully(_)) | None) => {
                         #[cfg(feature = "tracing")]
-                        debug!("Actor termination due to graceful stop");
+                        match &msg {
+                            Some(_) => debug!("Actor termination: explicit graceful stop"),
+                            None => debug!("Actor termination: all strong refs dropped"),
+                        }
 
                         // Drain any priority messages already enqueued before stopping.
                         // close() refuses new priority sends (they get Closed errors and
@@ -751,6 +751,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             return ActorResult::Failed {
                                 actor: Some(actor),
                                 error: e,
+                                secondary_error: None,
                                 phase: FailurePhase::OnStop,
                                 killed: false,
                             };
@@ -770,14 +771,18 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             // Streams that complete (return None) are removed from the set
             // automatically by `SelectAll`.
             Some(event) = idle_streams.next(), if !idle_streams.is_empty() => {
+                #[cfg(feature = "tracing")]
+                let on_idle_span = tracing::debug_span!("actor_on_idle");
+                #[cfg(not(feature = "tracing"))]
+                let on_idle_span = tracing::Span::none();
+
                 let result = run_with_actor_scope!(
                     actor_id,
                     actor.on_idle(event, &actor_weak).instrument(on_idle_span)
                 );
 
                 if let Err(e) = result {
-                    let error_msg = format!("Actor {actor_id} on_idle error: {e:?}");
-                    error!("{error_msg}");
+                    error!("Actor {actor_id} on_idle error: {e:?}");
 
                     // Call on_stop for cleanup even after on_idle failure
                     #[cfg(feature = "tracing")]
@@ -785,21 +790,23 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     #[cfg(not(feature = "tracing"))]
                     let on_stop_span = tracing::Span::none();
 
-                    let phase = if let Err(stop_err) = run_with_actor_scope!(
+                    let (phase, secondary_error) = match run_with_actor_scope!(
                         actor_id,
                         actor.on_stop(&actor_weak, false).instrument(on_stop_span)
                     ) {
-                        error!(
-                            "Actor {actor_id} on_stop failed during on_idle error cleanup: {stop_err:?}"
-                        );
-                        FailurePhase::OnIdleThenOnStop
-                    } else {
-                        FailurePhase::OnIdle
+                        Err(stop_err) => {
+                            error!(
+                                "Actor {actor_id} on_stop failed during on_idle error cleanup: {stop_err:?}"
+                            );
+                            (FailurePhase::OnIdleThenOnStop, Some(stop_err))
+                        }
+                        Ok(()) => (FailurePhase::OnIdle, None),
                     };
 
                     return ActorResult::Failed {
                         actor: Some(actor),
                         error: e,
+                        secondary_error,
                         phase,
                         killed,
                     };

--- a/src/actor_control.rs
+++ b/src/actor_control.rs
@@ -31,11 +31,11 @@
 //!
 //! // Stop all actors gracefully
 //! for control in &controls {
-//!     control.stop().await?;
+//!     control.stop().await;
 //! }
 //! ```
 
-use crate::{Actor, ActorRef, ActorWeak, BoxFuture, Identity, Result};
+use crate::{Actor, ActorRef, ActorWeak, BoxFuture, Identity};
 use futures::FutureExt;
 use std::fmt;
 
@@ -59,7 +59,7 @@ use std::fmt;
 ///
 /// // Stop all actors
 /// for control in &controls {
-///     control.stop().await?;
+///     control.stop().await;
 /// }
 /// ```
 pub trait ActorControl: Send + Sync {
@@ -72,12 +72,15 @@ pub trait ActorControl: Send + Sync {
     /// Gracefully stops the actor.
     ///
     /// The actor will process all remaining messages in its mailbox before stopping.
-    fn stop(&self) -> BoxFuture<'_, Result<()>>;
+    /// Idempotent: a closed mailbox is treated as "stop already in flight".
+    fn stop(&self) -> BoxFuture<'_, ()>;
 
     /// Immediately terminates the actor.
     ///
     /// The actor will stop without processing remaining messages.
-    fn kill(&self) -> Result<()>;
+    /// Idempotent: a closed or full terminate channel is treated as
+    /// "termination already in flight".
+    fn kill(&self);
 
     /// Downgrades to a weak control reference.
     fn downgrade(&self) -> Box<dyn WeakActorControl>;
@@ -109,7 +112,7 @@ pub trait ActorControl: Send + Sync {
 ///
 /// for control in &weak_controls {
 ///     if let Some(strong) = control.upgrade() {
-///         strong.stop().await?;
+///         strong.stop().await;
 ///     }
 /// }
 /// ```
@@ -172,11 +175,11 @@ impl<T: Actor + 'static> ActorControl for ActorRef<T> {
         ActorRef::is_alive(self)
     }
 
-    fn stop(&self) -> BoxFuture<'_, Result<()>> {
+    fn stop(&self) -> BoxFuture<'_, ()> {
         ActorRef::stop(self).boxed()
     }
 
-    fn kill(&self) -> Result<()> {
+    fn kill(&self) {
         ActorRef::kill(self)
     }
 

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -27,6 +27,40 @@ fn current_multi_thread_handle() -> Option<Handle> {
     (handle.runtime_flavor() == RuntimeFlavor::MultiThread).then_some(handle)
 }
 
+/// Slow-path helper shared by `blocking_*` APIs: spawns a dedicated thread,
+/// builds a single-thread Tokio runtime on it, and runs `fut` to completion.
+///
+/// Used only when the caller is *not* inside a multi-thread runtime (i.e. when
+/// the fast `block_in_place` path is unavailable). Centralizes the
+/// thread/runtime/join boilerplate so all four slow paths report errors
+/// identically.
+///
+/// `panic_msg` describes the failure surfaced when the spawned thread itself
+/// panics (the `join.join()` returns `Err`); it is wrapped in `Error::Send`.
+fn run_blocking_with_runtime<F, R>(identity: Identity, panic_msg: &'static str, fut: F) -> Result<R>
+where
+    F: std::future::Future<Output = Result<R>> + Send + 'static,
+    R: Send + 'static,
+{
+    let join = std::thread::spawn(move || -> Result<R> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .map_err(|e| Error::Send {
+                identity,
+                details: format!("Failed to create runtime: {}", e),
+            })?;
+        runtime.block_on(fut)
+    });
+
+    join.join().unwrap_or_else(|_| {
+        Err(Error::Send {
+            identity,
+            details: panic_msg.to_string(),
+        })
+    })
+}
+
 #[cfg(feature = "tracing")]
 use tracing::{debug, info};
 
@@ -377,7 +411,9 @@ impl<T: Actor> ActorRef<T> {
             let caller = crate::CURRENT_ACTOR.try_with(|id| *id).ok();
             if let Some(caller) = caller {
                 let callee = self.identity();
-                let mut graph = crate::wait_for_graph().lock().unwrap();
+                let mut graph = crate::wait_for_graph()
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
                 if caller.id == callee.id || crate::has_path(&graph, callee.id, caller.id) {
                     let cycle = crate::format_cycle_path(&graph, caller, callee);
                     drop(graph);
@@ -772,16 +808,10 @@ impl<T: Actor> ActorRef<T> {
         let identity = self.identity();
         let priority_sender = priority_sender.clone();
 
-        let join = std::thread::spawn(move || -> Result<()> {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_time()
-                .build()
-                .map_err(|e| Error::Send {
-                    identity,
-                    details: format!("Failed to create runtime: {}", e),
-                })?;
-
-            runtime.block_on(async {
+        run_blocking_with_runtime(
+            identity,
+            "Priority blocking thread terminated unexpectedly",
+            async move {
                 match tokio::time::timeout(timeout, priority_sender.send(envelope)).await {
                     Ok(Ok(())) => Ok(()),
                     Ok(Err(_)) => {
@@ -808,15 +838,8 @@ impl<T: Actor> ActorRef<T> {
                         })
                     }
                 }
-            })
-        });
-
-        join.join().unwrap_or_else(|_| {
-            Err(Error::Send {
-                identity: self.identity(),
-                details: "Priority blocking thread terminated unexpectedly".to_string(),
-            })
-        })
+            },
+        )
     }
 
     /// Blocking equivalent of [`ask_priority`](Self::ask_priority). `timeout` is
@@ -859,25 +882,11 @@ impl<T: Actor> ActorRef<T> {
         }
 
         let self_clone = self.clone();
-
-        let join = std::thread::spawn(move || -> Result<T::Reply> {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_time()
-                .build()
-                .map_err(|e| Error::Send {
-                    identity: self_clone.identity(),
-                    details: format!("Failed to create runtime: {}", e),
-                })?;
-
-            runtime.block_on(self_clone.ask_priority(msg, timeout))
-        });
-
-        join.join().unwrap_or_else(|_| {
-            Err(Error::Send {
-                identity: self.identity(),
-                details: "Priority blocking thread terminated unexpectedly".to_string(),
-            })
-        })
+        run_blocking_with_runtime(
+            self.identity(),
+            "Priority blocking thread terminated unexpectedly",
+            async move { self_clone.ask_priority(msg, timeout).await },
+        )
     }
 
     /// Sends an immediate termination signal to the actor.
@@ -1085,16 +1094,10 @@ impl<T: Actor> ActorRef<T> {
         let identity = self.identity();
         let sender = self.sender.clone();
 
-        let join = std::thread::spawn(move || -> Result<()> {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_time()
-                .build()
-                .map_err(|e| Error::Send {
-                    identity,
-                    details: format!("Failed to create runtime: {}", e),
-                })?;
-
-            runtime.block_on(async {
+        run_blocking_with_runtime(
+            identity,
+            "Timeout thread terminated unexpectedly",
+            async move {
                 match tokio::time::timeout(timeout, sender.send(envelope)).await {
                     Ok(Ok(())) => Ok(()),
                     Ok(Err(_)) => {
@@ -1121,15 +1124,8 @@ impl<T: Actor> ActorRef<T> {
                         })
                     }
                 }
-            })
-        });
-
-        join.join().unwrap_or_else(|_| {
-            Err(Error::Send {
-                identity: self.identity(),
-                details: "Timeout thread terminated unexpectedly".to_string(),
-            })
-        })
+            },
+        )
     }
 
     /// Synchronous version of [`ActorRef::ask`] that blocks until the reply is received.
@@ -1285,40 +1281,28 @@ impl<T: Actor> ActorRef<T> {
         T::Reply: Send + 'static,
     {
         let self_clone = self.clone();
+        let identity = self.identity();
 
-        let join = std::thread::spawn(move || -> Result<T::Reply> {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_time()
-                .build()
-                .map_err(|e| Error::Send {
-                    identity: self_clone.identity(),
-                    details: format!("Failed to create runtime: {}", e),
-                })?;
-
-            runtime.block_on(async {
+        run_blocking_with_runtime(
+            identity,
+            "Timeout thread terminated unexpectedly",
+            async move {
                 tokio::time::timeout(timeout, self_clone.ask(msg))
                     .await
                     .map_err(|_| {
                         crate::dead_letter::record::<M>(
-                            self_clone.identity(),
+                            identity,
                             crate::dead_letter::DeadLetterReason::Timeout,
                             "blocking_ask",
                         );
                         Error::Timeout {
-                            identity: self_clone.identity(),
+                            identity,
                             timeout,
                             operation: "blocking_ask".to_string(),
                         }
                     })?
-            })
-        });
-
-        join.join().unwrap_or_else(|_| {
-            Err(Error::Send {
-                identity: self.identity(),
-                details: "Timeout thread terminated unexpectedly".to_string(),
-            })
-        })
+            },
+        )
     }
 
     /// Synchronous version of [`ActorRef::tell`] that blocks until the message is sent.

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -211,11 +211,11 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Send`] when:
-    /// - The actor is no longer alive (channel closed); or
-    /// - The subscribe buffer is full. In that case, batch your subscriptions
+    /// - [`Error::ChannelFull`] when the bounded subscribe buffer is at capacity. This is
+    ///   transient ([`Error::is_retryable`] returns `true`) — batch your subscriptions
     ///   across separate handler invocations or raise
     ///   [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY).
+    /// - [`Error::Send`] when the actor is no longer alive (channel closed) — terminal.
     ///
     /// # Example
     ///
@@ -235,13 +235,9 @@ impl<T: Actor> ActorRef<T> {
         self.idle_subscribe_sender
             .try_send(boxed)
             .map_err(|e| match e {
-                mpsc::error::TrySendError::Full(_) => Error::Send {
+                mpsc::error::TrySendError::Full(_) => Error::ChannelFull {
                     identity: self.identity(),
-                    details: format!(
-                        "Idle subscribe channel full (capacity {}); batch subscriptions across \
-                         handler invocations or raise IDLE_SUBSCRIBE_CHANNEL_CAPACITY",
-                        crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY
-                    ),
+                    channel: "idle_subscribe",
                 },
                 mpsc::error::TrySendError::Closed(_) => Error::Send {
                     identity: self.identity(),
@@ -888,34 +884,31 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// The actor will stop processing messages and shut down as soon as possible.
     /// The actor's final result will indicate it was killed.
+    ///
+    /// This method is idempotent: a `Full` or `Closed` terminate channel is treated as
+    /// "termination already in flight" — the desired terminal state is met either way.
+    /// Both conditions are logged via `tracing::warn!` for diagnostics.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(level = "info", name = "actor_kill", skip(self))
     )]
-    pub fn kill(&self) -> Result<()> {
+    pub fn kill(&self) {
         #[cfg(feature = "tracing")]
         info!(actor_id = %self.identity(), "Killing actor");
 
         // Use the dedicated terminate_sender with try_send
         match self.terminate_sender.try_send(ControlSignal::Terminate) {
             Ok(_) => {
-                // Successfully sent the terminate message.
                 #[cfg(feature = "tracing")]
                 info!("Kill signal sent successfully");
-                Ok(())
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
-                // The channel is full. Since it has a capacity of 1,
-                // this means a Terminate message is already in the queue.
+                // The channel has capacity 1, so Full means a Terminate is already queued.
                 warn!("Failed to send Terminate to actor {}: terminate mailbox is full. Actor is likely already being terminated.", self.identity());
-                // Considered Ok as the desired state (stopping/killed) is effectively met.
-                Ok(())
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                // The channel is closed, which implies the actor is already stopped or has finished processing.
+                // The channel is closed; the actor is already stopped or has finished.
                 warn!("Failed to send Terminate to actor {}: terminate mailbox closed. Actor might already be stopped.", self.identity());
-                // Considered Ok as the desired state (stopped) is met.
-                Ok(())
             }
         }
     }
@@ -925,11 +918,15 @@ impl<T: Actor> ActorRef<T> {
     /// The actor will process all messages currently in its mailbox and then stop.
     /// New messages sent after this call might be ignored or fail.
     /// The actor's final result will indicate normal completion.
+    ///
+    /// This method is idempotent: a closed mailbox channel is treated as "stop already
+    /// in flight" — the desired terminal state is met either way. The condition is
+    /// logged via `tracing::warn!` for diagnostics.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(level = "info", name = "actor_stop", skip(self))
     )]
-    pub async fn stop(&self) -> Result<()> {
+    pub async fn stop(&self) {
         match self
             .sender
             .send(MailboxMessage::StopGracefully(self.clone()))
@@ -938,14 +935,10 @@ impl<T: Actor> ActorRef<T> {
             Ok(_) => {
                 #[cfg(feature = "tracing")]
                 info!(actor_id = %self.identity(), "Actor stop signal sent successfully");
-                Ok(())
             }
             Err(_) => {
-                // This error means the actor's mailbox channel is closed,
-                // which implies the actor is already stopping or has stopped.
+                // Mailbox channel is closed; the actor is already stopping or has stopped.
                 warn!("Failed to send StopGracefully to actor {}: mailbox closed. Actor might already be stopped or stopping.", self.identity());
-                // Considered Ok as the desired state (stopped/stopping) is met.
-                Ok(())
             }
         }
     }
@@ -1563,13 +1556,6 @@ impl<T: Actor> ActorRef<T> {
         self.metrics.max_priority_processing_time()
     }
 
-    /// Returns the total number of errors during message handling.
-    #[cfg(feature = "metrics")]
-    #[inline]
-    pub fn error_count(&self) -> u64 {
-        self.metrics.error_count()
-    }
-
     /// Returns the time elapsed since the actor started.
     #[cfg(feature = "metrics")]
     #[inline]
@@ -1700,8 +1686,12 @@ impl<T: Actor> ActorWeak<T> {
     /// [`upgrade`](ActorWeak::upgrade) and check the returned `Option`.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        // Both channels must have strong references for the actor to be alive
-        self.sender.strong_count() > 0 && self.terminate_sender.strong_count() > 0
+        // Every primary sender (mailbox, terminate, idle-subscribe) must still
+        // have a strong reference for the actor to be alive. Mirror the same
+        // set checked by `upgrade()` so the two calls cannot disagree.
+        self.sender.strong_count() > 0
+            && self.terminate_sender.strong_count() > 0
+            && self.idle_subscribe_sender.strong_count() > 0
     }
 }
 

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -19,7 +19,8 @@ pub enum FailurePhase {
     OnStop,
     /// Actor failed during [`on_idle`](crate::Actor::on_idle), and then
     /// [`on_stop`](crate::Actor::on_stop) also failed during cleanup.
-    /// The primary error is from `on_idle`; the `on_stop` error is logged.
+    /// The primary `on_idle` error is exposed via [`ActorResult::error`]; the
+    /// `on_stop` error is exposed via [`ActorResult::secondary_error`].
     OnIdleThenOnStop,
 }
 
@@ -144,8 +145,17 @@ pub enum ActorResult<T: Actor> {
         /// This will be `None` specifically when the failure occurred during the [`on_start`](Actor::on_start) phase,
         /// as the actor wasn't fully initialized.
         actor: Option<T>,
-        /// The error that caused the failure
+        /// The error that caused the failure (the primary cause).
+        ///
+        /// For [`FailurePhase::OnIdleThenOnStop`] this holds the original `on_idle` error;
+        /// the subsequent `on_stop` error is exposed via [`secondary_error`](Self::Failed#structfield.secondary_error).
         error: T::Error,
+        /// Secondary error, set only when a *cleanup* hook also failed after the primary failure.
+        ///
+        /// Currently set only for [`FailurePhase::OnIdleThenOnStop`], where it carries the
+        /// `on_stop` error that was emitted while cleaning up after a failed `on_idle`.
+        /// `None` for every other phase.
+        secondary_error: Option<T::Error>,
         /// The lifecycle phase during which the failure occurred
         phase: FailurePhase,
         /// Whether the actor was killed (`true`) or was attempting to stop gracefully (`false`)
@@ -242,7 +252,8 @@ impl<T: Actor> ActorResult<T> {
 
     /// Returns `true` if `on_stop` also failed after an `on_idle` error.
     ///
-    /// The primary error is from `on_idle`; the `on_stop` error is logged separately.
+    /// The primary `on_idle` error is exposed via [`error()`](Self::error); the
+    /// `on_stop` cleanup error is exposed via [`secondary_error()`](Self::secondary_error).
     pub fn is_cleanup_failed(&self) -> bool {
         matches!(
             self,
@@ -353,6 +364,33 @@ impl<T: Actor> ActorResult<T> {
         match self {
             ActorResult::Completed { .. } => None,
             ActorResult::Failed { error: cause, .. } => Some(cause),
+        }
+    }
+
+    /// Returns the secondary error if a cleanup hook also failed.
+    ///
+    /// Currently populated only when [`is_cleanup_failed()`](Self::is_cleanup_failed)
+    /// is `true` (phase [`FailurePhase::OnIdleThenOnStop`]). In that case, the value
+    /// is the error returned by `on_stop` during cleanup; the primary `on_idle` error
+    /// remains accessible via [`error()`](Self::error).
+    pub fn secondary_error(&self) -> Option<&T::Error> {
+        match self {
+            ActorResult::Failed {
+                secondary_error, ..
+            } => secondary_error.as_ref(),
+            ActorResult::Completed { .. } => None,
+        }
+    }
+
+    /// Consumes the result and returns the secondary error if a cleanup hook also failed.
+    ///
+    /// See [`secondary_error()`](Self::secondary_error) for semantics.
+    pub fn into_secondary_error(self) -> Option<T::Error> {
+        match self {
+            ActorResult::Failed {
+                secondary_error, ..
+            } => secondary_error,
+            ActorResult::Completed { .. } => None,
         }
     }
 

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -148,7 +148,8 @@ pub enum ActorResult<T: Actor> {
         /// The error that caused the failure (the primary cause).
         ///
         /// For [`FailurePhase::OnIdleThenOnStop`] this holds the original `on_idle` error;
-        /// the subsequent `on_stop` error is exposed via [`secondary_error`](Self::Failed#structfield.secondary_error).
+        /// the subsequent `on_stop` error is exposed via the `secondary_error` field
+        /// (or the [`ActorResult::secondary_error`] accessor).
         error: T::Error,
         /// Secondary error, set only when a *cleanup* hook also failed after the primary failure.
         ///

--- a/src/dead_letter.rs
+++ b/src/dead_letter.rs
@@ -67,7 +67,7 @@
 //!
 //!     // Dead letters are automatically logged when message delivery fails
 //!     let (actor_ref, handle) = spawn::<MyActor>(MyActor);
-//!     actor_ref.stop().await.unwrap();
+//!     actor_ref.stop().await;
 //!     handle.await.unwrap();
 //!
 //!     // This will log a dead letter warning

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,18 +5,44 @@ use crate::Identity;
 use std::time::Duration;
 
 #[derive(Debug)]
+#[non_exhaustive]
 /// Represents errors that can occur in the rsactor framework.
 ///
 /// These errors may be encountered during various actor operations, such as sending messages
 /// with [`tell`](crate::actor_ref::ActorRef::tell) or [`ask`](crate::actor_ref::ActorRef::ask),
 /// or during actor lifecycle operations like [`spawn`](crate::spawn).
+///
+/// This enum is marked `#[non_exhaustive]` so new variants can be added in future versions
+/// without breaking existing exhaustive matches — callers should include a `_` arm when
+/// matching on `Error`.
 pub enum Error {
-    /// Error when sending a message to an actor
+    /// Error when sending a message to an actor's channel that has been closed
+    /// (the actor is no longer alive).
+    ///
+    /// For "channel full" failures see [`Error::ChannelFull`].
     Send {
         /// ID of the actor that failed to receive the message
         identity: Identity,
         /// Additional context about the error
         details: String,
+    },
+    /// Error when a bounded channel is currently at capacity.
+    ///
+    /// Unlike [`Error::Send`] (which means the actor is dead), this is a *transient*
+    /// failure — the actor is alive and the channel will drain as the runtime makes
+    /// progress. [`Error::is_retryable`] returns `true` for this variant.
+    ///
+    /// Currently emitted only by
+    /// [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle) when the bounded
+    /// subscribe buffer (capacity
+    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY))
+    /// is saturated.
+    ChannelFull {
+        /// ID of the actor whose channel was full
+        identity: Identity,
+        /// Static label identifying which bounded channel was full
+        /// (e.g. `"idle_subscribe"`).
+        channel: &'static str,
     },
     /// Error when receiving a response from an actor
     Receive {
@@ -78,57 +104,42 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Send {
-                identity: actor_id,
-                details,
-            } => {
+            Error::Send { identity, details } => {
+                write!(f, "Failed to send message to actor {identity}: {details}")
+            }
+            Error::ChannelFull { identity, channel } => {
                 write!(
                     f,
-                    "Failed to send message to actor {}: {}",
-                    actor_id.name(),
-                    details
+                    "Bounded channel '{channel}' for actor {identity} is at capacity"
                 )
             }
-            Error::Receive {
-                identity: actor_id,
-                details,
-            } => {
+            Error::Receive { identity, details } => {
                 write!(
                     f,
-                    "Failed to receive reply from actor {}: {}",
-                    actor_id.name(),
-                    details
+                    "Failed to receive reply from actor {identity}: {details}"
                 )
             }
             Error::Timeout {
-                identity: actor_id,
+                identity,
                 timeout,
                 operation,
             } => {
                 write!(
                     f,
-                    "{} operation to actor {} timed out after {:?}",
-                    operation,
-                    actor_id.name(),
-                    timeout
+                    "{operation} operation to actor {identity} timed out after {timeout:?}"
                 )
             }
             Error::Downcast {
-                identity: actor_id,
+                identity,
                 expected_type,
             } => {
                 write!(
                     f,
-                    "Failed to downcast reply from actor {} to expected type '{}'",
-                    actor_id.name(),
-                    expected_type
+                    "Failed to downcast reply from actor {identity} to expected type '{expected_type}'"
                 )
             }
-            Error::Runtime {
-                identity: actor_id,
-                details,
-            } => {
-                write!(f, "Runtime error in actor {}: {}", actor_id.name(), details)
+            Error::Runtime { identity, details } => {
+                write!(f, "Runtime error in actor {identity}: {details}")
             }
             Error::MailboxCapacity { message } => {
                 write!(f, "Mailbox capacity error: {message}")
@@ -136,16 +147,13 @@ impl std::fmt::Display for Error {
             Error::Join { identity, source } => {
                 write!(
                     f,
-                    "Failed to join spawned task from actor {}: {}",
-                    identity.name(),
-                    source
+                    "Failed to join spawned task from actor {identity}: {source}"
                 )
             }
             Error::PriorityChannelNotEnabled { identity } => {
                 write!(
                     f,
-                    "Priority channel is not enabled for actor {}: enable it via SpawnOptions::with_priority()",
-                    identity.name()
+                    "Priority channel is not enabled for actor {identity}: enable it via SpawnOptions::with_priority()"
                 )
             }
         }
@@ -181,6 +189,7 @@ impl Error {
     /// | Error Type | Retryable | Reason |
     /// |------------|-----------|--------|
     /// | `Timeout` | ✓ Yes | Transient; may succeed with longer timeout |
+    /// | `ChannelFull` | ✓ Yes | Transient; bounded buffer drains as actor makes progress |
     /// | `Send` | ✗ No | Actor stopped; channel permanently closed |
     /// | `Receive` | ✗ No | Reply channel dropped; cannot recover |
     /// | `Downcast` | ✗ No | Type mismatch; programming error |
@@ -219,7 +228,7 @@ impl Error {
     /// ```
     #[must_use]
     pub fn is_retryable(&self) -> bool {
-        matches!(self, Error::Timeout { .. })
+        matches!(self, Error::Timeout { .. } | Error::ChannelFull { .. })
     }
 
     /// Returns actionable debugging tips for this error.
@@ -243,6 +252,12 @@ impl Error {
                 "Verify the actor is still running with `actor_ref.is_alive()`",
                 "The actor's mailbox is closed - the actor has terminated",
                 "Consider using `ActorWeak` for long-lived references",
+            ],
+            Error::ChannelFull { .. } => &[
+                "Transient failure - retry after a short delay or batch your sends",
+                "Bounded channels drain as the actor processes work; the actor is alive",
+                "For subscribe_idle specifically, batch subscriptions across handler invocations \
+                 or raise IDLE_SUBSCRIBE_CHANNEL_CAPACITY if you regularly fan out > 32 streams",
             ],
             Error::Receive { .. } => &[
                 "The actor dropped the reply channel before responding",
@@ -275,7 +290,7 @@ impl Error {
             Error::Join { .. } => &[
                 "The spawned task panicked or was cancelled by the runtime",
                 "Run with RUST_BACKTRACE=1 or RUST_BACKTRACE=full for panic details",
-                "Use `ActorResult::is_join_failed()` to confirm this failure type",
+                "Match on `Error::Join { source, .. }` and use `source.is_panic()` / `source.is_cancelled()` to distinguish the cause",
                 "Check for unwrap(), expect(), or panic!() calls in actor code",
                 "Verify tokio runtime wasn't shut down while actor was running",
             ],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@
 //! let current_data: String = actor_ref.ask(GetData).await?;
 //! let new_count: u32 = actor_ref.ask(IncrementMsg(5)).await?;
 //!
-//! actor_ref.stop().await?;
+//! actor_ref.stop().await;
 //! let actor_result = join_handle.await?;
 //! # Ok(())
 //! # }
@@ -305,7 +305,11 @@ use futures::FutureExt;
 pub use rsactor_derive::{message_handlers, Actor};
 
 /// Internal function used by derive macros to log handler errors.
-/// When `tracing` feature is enabled, uses `tracing::error!`; otherwise, uses `eprintln!`.
+///
+/// This surfaces user-handler `Result::Err` values through the most appropriate channel:
+/// when the `tracing` feature is enabled, it emits a structured `tracing::error!` event;
+/// otherwise it falls back to `eprintln!` so users who have not wired up a subscriber
+/// still see handler errors on stderr instead of silently dropping them.
 #[doc(hidden)]
 pub fn __log_handler_error(
     actor: &dyn std::fmt::Display,
@@ -325,7 +329,7 @@ pub fn __log_handler_error(
     );
 }
 
-use std::{fmt::Debug, future::Future, sync::atomic::AtomicU64, sync::OnceLock};
+use std::{future::Future, sync::atomic::AtomicU64, sync::OnceLock};
 
 #[cfg(feature = "deadlock-detection")]
 use std::collections::HashMap;
@@ -334,7 +338,7 @@ use std::sync::Mutex;
 
 use tokio::sync::{mpsc, oneshot};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Identity {
     /// Unique ID of the actor
     pub id: u64,

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -27,8 +27,6 @@ pub(crate) struct MetricsCollector {
     /// Number of messages processed (regular mailbox only — priority messages are
     /// counted separately so callers can detect priority-channel abuse).
     message_count: AtomicU64,
-    /// Number of errors during message handling
-    error_count: AtomicU64,
     /// Cumulative processing time for regular messages, in nanoseconds (saturating)
     total_processing_nanos: AtomicU64,
     /// Maximum regular message processing time observed in nanoseconds
@@ -50,7 +48,6 @@ impl MetricsCollector {
     pub fn new() -> Self {
         Self {
             message_count: AtomicU64::new(0),
-            error_count: AtomicU64::new(0),
             total_processing_nanos: AtomicU64::new(0),
             max_processing_nanos: AtomicU64::new(0),
             priority_message_count: AtomicU64::new(0),
@@ -112,15 +109,6 @@ impl MetricsCollector {
         self.update_last_activity();
     }
 
-    /// Records an error during message handling.
-    ///
-    /// Reserved for future error tracking integration.
-    #[inline]
-    #[allow(dead_code)]
-    pub fn record_error(&self) {
-        self.error_count.fetch_add(1, Ordering::Relaxed);
-    }
-
     /// Updates the last activity timestamp to now.
     fn update_last_activity(&self) {
         let millis = SystemTime::now()
@@ -169,7 +157,6 @@ impl MetricsCollector {
             max_priority_processing_time: Duration::from_nanos(
                 self.max_priority_processing_nanos.load(Ordering::Relaxed),
             ),
-            error_count: self.error_count.load(Ordering::Relaxed),
             uptime: self.start_instant.elapsed(),
             last_activity: self.get_last_activity(),
         }
@@ -181,12 +168,6 @@ impl MetricsCollector {
     #[inline]
     pub fn message_count(&self) -> u64 {
         self.message_count.load(Ordering::Relaxed)
-    }
-
-    /// Returns the total number of errors recorded.
-    #[inline]
-    pub fn error_count(&self) -> u64 {
-        self.error_count.load(Ordering::Relaxed)
     }
 
     /// Returns the average processing time per message.
@@ -320,7 +301,6 @@ mod tests {
         let snapshot = collector.snapshot();
 
         assert_eq!(snapshot.message_count, 0);
-        assert_eq!(snapshot.error_count, 0);
         assert_eq!(snapshot.avg_processing_time, Duration::ZERO);
         assert_eq!(snapshot.max_processing_time, Duration::ZERO);
         assert!(snapshot.last_activity.is_none());
@@ -337,16 +317,6 @@ mod tests {
         assert_eq!(collector.avg_processing_time(), Duration::from_millis(150));
         assert_eq!(collector.max_processing_time(), Duration::from_millis(200));
         assert!(collector.last_activity().is_some());
-    }
-
-    #[test]
-    fn test_record_error() {
-        let collector = MetricsCollector::new();
-
-        collector.record_error();
-        collector.record_error();
-
-        assert_eq!(collector.error_count(), 2);
     }
 
     #[test]

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -20,13 +20,7 @@ use std::time::{Duration, SystemTime};
 /// let metrics = actor_ref.metrics();
 ///
 /// println!("Messages processed: {}", metrics.message_count);
-/// println!("Error rate: {:.2}%",
-///     if metrics.message_count > 0 {
-///         (metrics.error_count as f64 / metrics.message_count as f64) * 100.0
-///     } else {
-///         0.0
-///     }
-/// );
+/// println!("Average processing time: {:?}", metrics.avg_processing_time);
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -58,12 +52,6 @@ pub struct MetricsSnapshot {
     /// Maximum time spent processing any single priority message.
     pub max_priority_processing_time: Duration,
 
-    /// Total number of errors that occurred during message handling.
-    ///
-    /// This counts errors returned by message handlers, not framework-level errors
-    /// like channel closure or timeouts.
-    pub error_count: u64,
-
     /// Time elapsed since the actor was started.
     ///
     /// This is measured from when the actor's `on_start` completed successfully.
@@ -84,7 +72,6 @@ impl Default for MetricsSnapshot {
             priority_message_count: 0,
             avg_priority_processing_time: Duration::ZERO,
             max_priority_processing_time: Duration::ZERO,
-            error_count: 0,
             uptime: Duration::ZERO,
             last_activity: None,
         }
@@ -102,7 +89,6 @@ mod tests {
         assert_eq!(snapshot.message_count, 0);
         assert_eq!(snapshot.avg_processing_time, Duration::ZERO);
         assert_eq!(snapshot.max_processing_time, Duration::ZERO);
-        assert_eq!(snapshot.error_count, 0);
         assert_eq!(snapshot.uptime, Duration::ZERO);
         assert!(snapshot.last_activity.is_none());
     }
@@ -116,7 +102,6 @@ mod tests {
             priority_message_count: 7,
             avg_priority_processing_time: Duration::from_micros(80),
             max_priority_processing_time: Duration::from_millis(2),
-            error_count: 3,
             uptime: Duration::from_secs(60),
             last_activity: Some(SystemTime::now()),
         };
@@ -135,7 +120,6 @@ mod tests {
             cloned.max_priority_processing_time,
             Duration::from_millis(2)
         );
-        assert_eq!(cloned.error_count, 3);
         assert_eq!(cloned.uptime, Duration::from_secs(60));
         assert!(cloned.last_activity.is_some());
     }
@@ -147,6 +131,5 @@ mod tests {
 
         assert!(debug_str.contains("MetricsSnapshot"));
         assert!(debug_str.contains("message_count"));
-        assert!(debug_str.contains("error_count"));
     }
 }

--- a/tests/actor_control_tests.rs
+++ b/tests/actor_control_tests.rs
@@ -57,7 +57,7 @@ async fn test_actor_control_from_actor_ref() {
     assert!(control.is_alive());
 
     // Stop via control
-    control.stop().await.expect("stop should succeed");
+    control.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -80,7 +80,7 @@ async fn test_actor_control_multiple_actors() {
 
     // Stop all actors via controls
     for control in &controls {
-        control.stop().await.expect("stop should succeed");
+        control.stop().await;
     }
 
     let result_a = handle_a.await.expect("actor A should complete");
@@ -98,7 +98,7 @@ async fn test_actor_control_stop() {
     let control: Box<dyn ActorControl> = (&actor_ref).into();
 
     // Stop via control
-    control.stop().await.expect("stop should succeed");
+    control.stop().await;
 
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
@@ -114,7 +114,7 @@ async fn test_actor_control_kill() {
     let control: Box<dyn ActorControl> = (&actor_ref).into();
 
     // Kill via control
-    control.kill().expect("kill should succeed");
+    control.kill();
 
     let result = handle.await.expect("actor should complete");
     assert!(result.was_killed());
@@ -141,7 +141,7 @@ async fn test_actor_control_clone() {
     assert!(control_clone1.is_alive());
     assert!(control_clone2.is_alive());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -161,7 +161,7 @@ async fn test_actor_control_downgrade() {
     assert_eq!(control.identity(), weak_control.identity());
     assert!(weak_control.is_alive());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -185,7 +185,7 @@ async fn test_actor_control_downgrade_upgrade_roundtrip() {
     assert_eq!(weak_control.identity(), control2.identity());
 
     // Can use the upgraded control to stop
-    control2.stop().await.expect("stop should succeed");
+    control2.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -206,7 +206,7 @@ async fn test_weak_actor_control_upgrade() {
     let strong = weak_control.upgrade().expect("upgrade should succeed");
     assert_eq!(strong.identity(), actor_ref.identity());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -219,7 +219,7 @@ async fn test_weak_actor_control_upgrade_after_stop() {
     let weak_control: Box<dyn WeakActorControl> = ActorRef::downgrade(&actor_ref).into();
 
     // Stop and drop the actor
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     drop(actor_ref);
 
     let _ = handle.await;
@@ -248,7 +248,7 @@ async fn test_weak_actor_control_clone() {
     assert!(weak_control.upgrade().is_some());
     assert!(weak_clone.upgrade().is_some());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -272,7 +272,7 @@ async fn test_actor_control_debug() {
     assert!(control_debug.contains("ActorControl"));
     assert!(weak_debug.contains("WeakActorControl"));
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 

--- a/tests/actor_ref_drop_tests.rs
+++ b/tests/actor_ref_drop_tests.rs
@@ -131,7 +131,7 @@ async fn test_actor_ref_drop_terminates_actor_after_processing_messages() {
     debug!("All messages sent, calling stop before dropping actor_ref");
 
     // Instead of just dropping, call stop explicitly to ensure graceful shutdown
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
 
     // Now drop the actor_ref
     drop(actor_ref);
@@ -210,7 +210,7 @@ async fn test_actor_ref_drop_with_slow_messages() {
     debug!("All slow messages sent, stopping and dropping actor_ref");
 
     // Stop the actor explicitly and then drop the reference
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     drop(actor_ref);
 
     // Wait for the actor to complete (should take at least 150ms due to processing delays)
@@ -344,7 +344,7 @@ async fn test_multiple_actor_refs_drop_behavior() {
     debug!("Stopping actor before dropping last clone");
 
     // Explicitly stop the actor before dropping the last reference
-    actor_ref_clone2.stop().await.expect("Failed to stop actor");
+    actor_ref_clone2.stop().await;
 
     debug!("Dropping last clone");
     drop(actor_ref_clone2);
@@ -432,7 +432,7 @@ async fn test_actor_ref_clone_drop_behavior() {
         .expect("Failed to send after clone drop");
 
     // Explicitly stop before dropping original
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     println!("Stopping actor before dropping original reference");
     drop(actor_ref);
 
@@ -491,7 +491,7 @@ async fn test_actor_ref_drop_vs_explicit_stop() {
         }
 
         // Explicitly stop the actor
-        actor_ref.stop().await.expect("Failed to stop actor");
+        actor_ref.stop().await;
 
         let result = handle.await.expect("Actor should complete");
         assert!(
@@ -621,7 +621,7 @@ async fn test_actor_weak_reference_basic_functionality() {
     );
 
     // Stop the actor using the upgraded reference
-    upgraded_ref.stop().await.expect("Failed to stop actor");
+    upgraded_ref.stop().await;
     drop(upgraded_ref);
 
     let result = handle.await.expect("Actor task should complete");
@@ -665,7 +665,7 @@ async fn test_actor_weak_reference_after_actor_drop() {
         .expect("Failed to send message");
 
     // Stop and drop the actor reference
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     drop(actor_ref);
 
     // Wait for the actor to complete
@@ -765,7 +765,7 @@ async fn test_actor_weak_reference_clone_behavior() {
         .expect("Failed to send from upgrade3");
 
     // Stop the actor
-    upgrade3_ref.stop().await.expect("Failed to stop actor");
+    upgrade3_ref.stop().await;
     drop(actor_ref);
     drop(upgrade3_ref);
 
@@ -828,7 +828,7 @@ async fn test_actor_weak_reference_with_kill() {
     assert!(weak_ref.is_alive(), "ActorWeak should be alive before kill");
 
     // Kill the actor
-    actor_ref.kill().expect("Failed to kill actor");
+    actor_ref.kill();
     drop(actor_ref);
 
     let result = handle.await.expect("Actor task should complete");
@@ -923,7 +923,7 @@ async fn test_actor_weak_reference_upgrade_race_condition() {
     tokio::time::sleep(std::time::Duration::from_millis(25)).await;
 
     // Stop the actor
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     drop(actor_ref);
 
     // Wait for the upgrade task to complete
@@ -1002,7 +1002,7 @@ async fn test_actor_weak_reference_identity_consistency() {
         .expect("Failed to send message");
 
     // Stop the actor
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     drop(actor_ref);
     drop(upgraded);
     drop(upgraded_clone);

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -99,7 +99,7 @@ async fn test_actor_result_completed_stopped_normally() {
 
     // Wait for actor to start and then stop it gracefully
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    actor_ref.stop().await.expect("Stop should succeed");
+    actor_ref.stop().await;
 
     let result = handle.await.expect("Actor should complete");
 
@@ -153,7 +153,7 @@ async fn test_actor_result_completed_killed() {
 
     // Wait for actor to start and then kill it
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    actor_ref.kill().expect("Kill should succeed");
+    actor_ref.kill();
 
     let result = handle.await.expect("Actor should complete");
 
@@ -292,7 +292,7 @@ async fn test_actor_result_failed_on_stop_graceful() {
 
     // Wait for actor to start and then stop it gracefully
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    actor_ref.stop().await.expect("Stop should succeed");
+    actor_ref.stop().await;
 
     let result = handle.await.expect("Handle should not fail");
 
@@ -334,7 +334,7 @@ async fn test_actor_result_failed_on_stop_killed() {
 
     // Wait for actor to start and then kill it
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    actor_ref.kill().expect("Kill should succeed");
+    actor_ref.kill();
 
     let result = handle.await.expect("Handle should not fail");
 
@@ -621,7 +621,7 @@ async fn test_blocking_tell_works_outside_runtime() {
     thread_handle.join().expect("Thread should not panic");
 
     // Clean up
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     let _result = handle.await.expect("Actor task failed");
 }
 
@@ -653,7 +653,7 @@ async fn test_blocking_ask_works_outside_runtime() {
     thread_handle.join().expect("Thread should not panic");
 
     // Clean up
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     let _result = handle.await.expect("Actor task failed");
 }
 

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -223,6 +223,7 @@ async fn test_actor_result_failed_on_start() {
     let result_copy = ActorResult::Failed::<FailureTestActor> {
         actor: None,
         error: anyhow::anyhow!("Test failure in on_start"),
+        secondary_error: None,
         phase: FailurePhase::OnStart,
         killed: false,
     };
@@ -416,6 +417,7 @@ async fn test_actor_result_from_failed_with_actor() {
             value: 456,
         }),
         error: anyhow::anyhow!("test error"),
+        secondary_error: None,
         phase: FailurePhase::OnIdle,
         killed: false,
     };
@@ -440,6 +442,7 @@ async fn test_actor_result_from_failed_without_actor() {
     let result = ActorResult::Failed::<TestActor> {
         actor: None,
         error: anyhow::anyhow!("startup error"),
+        secondary_error: None,
         phase: FailurePhase::OnStart,
         killed: false,
     };
@@ -478,6 +481,7 @@ async fn test_actor_result_into_error_failed() {
     let result = ActorResult::Failed::<TestActor> {
         actor: None,
         error: anyhow::anyhow!("test into_error"),
+        secondary_error: None,
         phase: FailurePhase::OnStart,
         killed: false,
     };
@@ -511,6 +515,7 @@ async fn test_actor_result_debug_format() {
     let failed_result = ActorResult::Failed::<TestActor> {
         actor: None,
         error: anyhow::anyhow!("debug error"),
+        secondary_error: None,
         phase: FailurePhase::OnStart,
         killed: false,
     };
@@ -549,6 +554,7 @@ async fn test_all_boolean_combinations() {
     let result3 = ActorResult::Failed::<TestActor> {
         actor: None,
         error: anyhow::anyhow!("error3"),
+        secondary_error: None,
         phase: FailurePhase::OnStart,
         killed: false,
     };
@@ -561,6 +567,7 @@ async fn test_all_boolean_combinations() {
             value: 4,
         }),
         error: anyhow::anyhow!("error4"),
+        secondary_error: None,
         phase: FailurePhase::OnIdle,
         killed: false,
     };
@@ -573,6 +580,7 @@ async fn test_all_boolean_combinations() {
             value: 5,
         }),
         error: anyhow::anyhow!("error5"),
+        secondary_error: None,
         phase: FailurePhase::OnStop,
         killed: false,
     };
@@ -585,6 +593,7 @@ async fn test_all_boolean_combinations() {
             value: 6,
         }),
         error: anyhow::anyhow!("error6"),
+        secondary_error: None,
         phase: FailurePhase::OnStop,
         killed: true,
     };

--- a/tests/ask_join_tests.rs
+++ b/tests/ask_join_tests.rs
@@ -107,7 +107,7 @@ async fn test_ask_join_successful_computation() -> Result<()> {
     let task_count = actor_ref.ask(GetTaskCount).await?;
     assert_eq!(task_count, 1);
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -159,7 +159,7 @@ async fn test_ask_join_multiple_concurrent_tasks() -> Result<()> {
     let task_count = actor_ref.ask(GetTaskCount).await?;
     assert_eq!(task_count, 3);
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -181,7 +181,7 @@ async fn test_ask_join_panicked_task() -> Result<()> {
         Err(e) => panic!("Expected Join error, got: {:?}", e),
     }
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -203,7 +203,7 @@ async fn test_ask_join_cancelled_task() -> Result<()> {
         Err(e) => panic!("Expected Join error, got: {:?}", e),
     }
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -237,7 +237,7 @@ async fn test_ask_join_vs_regular_ask() -> Result<()> {
     assert!(manual_result >= 40); // At least 40 (20*2 + 0)
     assert!(auto_result >= 40); // At least 40 (20*2 + counter)
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -248,7 +248,7 @@ async fn test_ask_join_with_actor_stopped() -> Result<()> {
     let (actor_ref, actor_handle) = spawn::<TaskSpawnerActor>(TaskSpawnerActor { task_counter });
 
     // Stop the actor first
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
 
     // Try to use ask_join on stopped actor
@@ -291,7 +291,7 @@ async fn test_ask_join_timeout_behavior() -> Result<()> {
     assert!(elapsed >= Duration::from_millis(190)); // Allow some tolerance
     assert_eq!(result, 2); // 1 * 2 + 0
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }
@@ -319,7 +319,7 @@ async fn test_ask_join_error_source() -> Result<()> {
         _ => panic!("Expected Join error"),
     }
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     actor_handle.await?;
     Ok(())
 }

--- a/tests/blocking_without_runtime_tests.rs
+++ b/tests/blocking_without_runtime_tests.rs
@@ -80,7 +80,7 @@ async fn test_tell_blocking_without_runtime() {
     println!("Final counter value: {}", final_counter);
     assert_eq!(final_counter, 42);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -115,7 +115,7 @@ async fn test_ask_blocking_without_runtime() {
         }
     }
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -184,7 +184,7 @@ async fn test_multiple_blocking_calls_without_runtime() {
         .expect("Failed to get counter");
     assert_eq!(final_counter, 15);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -231,7 +231,7 @@ async fn test_blocking_calls_without_timeout_and_without_runtime() {
         }
     }
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -270,7 +270,7 @@ async fn test_blocking_tell_with_timeout() {
     println!("Final counter value: {}", final_counter);
     assert_eq!(final_counter, 42);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -304,7 +304,7 @@ async fn test_blocking_ask_with_timeout() {
         }
     }
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -342,7 +342,7 @@ async fn test_blocking_with_timeout_inside_tokio_context() {
     let counter_value = join_handle.await.expect("Blocking task panicked");
     assert_eq!(counter_value, 10, "Counter should be 10 after increment");
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -351,7 +351,7 @@ async fn test_blocking_ask_timeout_on_stopped_actor() {
     let (actor_ref, handle) = spawn::<RuntimelessTestActor>(0);
 
     // Stop the actor first
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 
     // Test blocking_ask with timeout on stopped actor
@@ -373,7 +373,7 @@ async fn test_blocking_tell_timeout_on_stopped_actor() {
     let (actor_ref, handle) = spawn::<RuntimelessTestActor>(0);
 
     // Stop the actor first
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 
     // Test blocking_tell with timeout on stopped actor
@@ -417,7 +417,7 @@ async fn test_blocking_tell_from_async_multi_thread_context() {
         .expect("Failed to get counter");
     assert_eq!(counter, 10);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -436,7 +436,7 @@ async fn test_blocking_ask_from_async_multi_thread_context() {
         .expect("blocking_ask (timeout) from async ctx should succeed");
     assert_eq!(val, 42);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -473,7 +473,7 @@ async fn test_blocking_tell_with_timeout_on_current_thread_runtime() {
         .expect("Failed to get counter");
     assert_eq!(counter, 11);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -491,6 +491,6 @@ async fn test_blocking_ask_with_timeout_on_current_thread_runtime() {
     .expect("blocking_ask with timeout on current_thread runtime should succeed");
     assert_eq!(val, 13);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }

--- a/tests/coverage_improvement_tests.rs
+++ b/tests/coverage_improvement_tests.rs
@@ -57,7 +57,7 @@ mod default_lifecycle_tests {
         assert_eq!(response, "pong");
 
         // Stop the actor gracefully - this triggers the default on_stop
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(result.is_completed());
     }
@@ -74,7 +74,7 @@ mod default_lifecycle_tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Kill triggers on_stop with killed=true
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let result = handle.await.unwrap();
         assert!(result.is_completed());
         assert!(result.was_killed());
@@ -89,7 +89,7 @@ mod default_lifecycle_tests {
         });
 
         // Graceful stop triggers on_stop with killed=false
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(result.is_completed());
         assert!(!result.was_killed());
@@ -128,7 +128,7 @@ mod actor_weak_tests {
         // Verify identity is accessible from weak ref
         assert_eq!(weak.identity(), actor_ref.identity());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -139,7 +139,7 @@ mod actor_weak_tests {
 
         assert!(weak.is_alive());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // After stop, the weak reference should no longer be upgradeable
@@ -199,7 +199,7 @@ mod actor_ref_clone_tests {
         let id2: Identity = cloned_ref.ask(GetIdentity).await.unwrap();
         assert_eq!(id1, id2);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -210,7 +210,7 @@ mod actor_ref_clone_tests {
         // Actor should be alive initially
         assert!(actor_ref.is_alive());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // After stop and join, is_alive might still return true
@@ -253,7 +253,7 @@ mod weak_clone_tests {
 
         assert_eq!(strong1.identity(), strong2.identity());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -286,7 +286,7 @@ mod timeout_tests {
         let (actor_ref, handle) = spawn::<SlowActor>(SlowActor);
 
         // Stop the actor immediately
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // Try to send with timeout to stopped actor
@@ -491,7 +491,7 @@ mod on_stop_error_tests {
         assert_eq!(response, "pong");
 
         // Stop the actor - this will trigger on_stop which fails
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         assert!(result.is_failed());
@@ -507,7 +507,7 @@ mod on_stop_error_tests {
         let (actor_ref, handle) = spawn::<FailingOnStopActor>(());
 
         // Kill the actor - this will trigger on_stop which fails
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let result = handle.await.unwrap();
 
         assert!(result.is_failed());
@@ -582,7 +582,7 @@ mod dead_letter_tests {
         init_test_logger();
         let (actor_ref, handle) = spawn::<DeadLetterActor>(DeadLetterActor);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // Try to tell a stopped actor
@@ -595,7 +595,7 @@ mod dead_letter_tests {
         init_test_logger();
         let (actor_ref, handle) = spawn::<DeadLetterActor>(DeadLetterActor);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // Try to ask a stopped actor
@@ -699,7 +699,7 @@ mod actor_result_from_tests {
     async fn test_actor_result_into_tuple_completed() {
         let (actor_ref, handle) = spawn::<FromTestActor>(FromTestActor { value: 42 });
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         // Convert ActorResult to tuple
@@ -737,7 +737,7 @@ mod actor_result_from_tests {
 
         let (actor_ref, handle) = spawn::<FailOnStopActor>(100);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         assert!(result.is_failed());
@@ -851,7 +851,7 @@ mod blocking_timeout_tests {
             "blocking_tell with timeout should succeed for fast message"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -872,7 +872,7 @@ mod blocking_timeout_tests {
         assert!(result.is_ok(), "blocking_ask with timeout should succeed");
         assert_eq!(result.unwrap(), "fast done");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -900,7 +900,7 @@ mod blocking_timeout_tests {
         // The key is covering the timeout code path
         let _ = result; // just making sure it executed
 
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 
@@ -923,7 +923,7 @@ mod blocking_timeout_tests {
             "blocking_ask should timeout on slow message"
         );
 
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 
@@ -933,7 +933,7 @@ mod blocking_timeout_tests {
         let (actor_ref, handle) = spawn::<BlockingTimeoutActor>(BlockingTimeoutActor);
 
         // Stop the actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -957,7 +957,7 @@ mod blocking_timeout_tests {
         let (actor_ref, handle) = spawn::<BlockingTimeoutActor>(BlockingTimeoutActor);
 
         // Stop the actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -1018,7 +1018,7 @@ mod tracing_coverage_tests {
         let slow_response: String = actor_ref.ask(TracingSlowPing).await.unwrap();
         assert_eq!(slow_response, "slow pong");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1036,7 +1036,7 @@ mod tracing_coverage_tests {
             .await
             .unwrap();
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1052,7 +1052,7 @@ mod tracing_coverage_tests {
             .unwrap();
         assert_eq!(response, "pong");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1062,7 +1062,7 @@ mod tracing_coverage_tests {
         let (actor_ref, handle) = spawn::<TracingTestActor>(TracingTestActor);
 
         // Test kill() with tracing
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let result = handle.await.unwrap();
         assert!(result.was_killed());
     }
@@ -1073,7 +1073,7 @@ mod tracing_coverage_tests {
         let (actor_ref, handle) = spawn::<TracingTestActor>(TracingTestActor);
 
         // Test stop() with tracing
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(!result.was_killed());
     }
@@ -1093,7 +1093,7 @@ mod actor_result_methods_tests {
             data: "test".to_string(),
         });
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         // Use to_result() for conversion
@@ -1132,7 +1132,7 @@ mod actor_result_methods_tests {
             data: "into_actor_test".to_string(),
         });
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         let maybe_actor = result.into_actor();
@@ -1168,7 +1168,7 @@ mod actor_result_methods_tests {
             data: "test".to_string(),
         });
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         // Completed result should have no error
@@ -1213,7 +1213,7 @@ mod ask_join_tests {
         let result: i32 = actor_ref.ask_join(SpawnTask { value: 21 }).await.unwrap();
         assert_eq!(result, 42);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -1244,7 +1244,7 @@ mod blocking_error_paths_tests {
         let (actor_ref, handle) = spawn::<BlockingErrorActor>(BlockingErrorActor);
 
         // Stop actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -1267,7 +1267,7 @@ mod blocking_error_paths_tests {
         let (actor_ref, handle) = spawn::<BlockingErrorActor>(BlockingErrorActor);
 
         // Stop actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -1398,7 +1398,7 @@ mod actor_result_debug_tests {
     async fn test_actor_result_debug_completed() {
         let (actor_ref, handle) = spawn::<DebugTestActor>(DebugTestActor { value: 42 });
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
 
         // Test Debug implementation
@@ -1469,7 +1469,7 @@ mod deprecated_blocking_methods_tests {
 
         assert!(result.is_ok(), "deprecated tell_blocking should succeed");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1491,7 +1491,7 @@ mod deprecated_blocking_methods_tests {
         assert!(result.is_ok(), "deprecated ask_blocking should succeed");
         assert_eq!(result.unwrap(), "deprecated_response");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1501,7 +1501,7 @@ mod deprecated_blocking_methods_tests {
         let (actor_ref, handle) = spawn::<DeprecatedMethodsActor>(DeprecatedMethodsActor);
 
         // Stop the actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -1525,7 +1525,7 @@ mod deprecated_blocking_methods_tests {
         let (actor_ref, handle) = spawn::<DeprecatedMethodsActor>(DeprecatedMethodsActor);
 
         // Stop the actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         let actor_clone = actor_ref.clone();
@@ -1615,7 +1615,7 @@ mod ask_join_error_tests {
             e => panic!("Expected Join error, got: {:?}", e),
         }
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1642,7 +1642,7 @@ mod ask_join_error_tests {
             e => panic!("Expected Join error, got: {:?}", e),
         }
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1655,7 +1655,7 @@ mod ask_join_error_tests {
         let result: i32 = actor_ref.ask_join(SpawnSuccessTask(21)).await.unwrap();
         assert_eq!(result, 42);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1665,7 +1665,7 @@ mod ask_join_error_tests {
         let (actor_ref, handle) = spawn::<AskJoinErrorActor>(AskJoinErrorActor);
 
         // Stop the actor first
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
 
         // ask_join to stopped actor should fail with Send error
@@ -1712,7 +1712,7 @@ mod actor_ref_debug_tests {
             "Debug should contain ActorRef"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -1730,7 +1730,7 @@ mod actor_ref_debug_tests {
             "Debug should contain ActorWeak"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -1762,11 +1762,10 @@ mod kill_edge_cases_tests {
         let (actor_ref, handle) = spawn::<KillEdgeCaseActor>(KillEdgeCaseActor);
 
         // Stop the actor
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
 
-        // Now try to kill the stopping actor - should succeed (idempotent)
-        let result = actor_ref.kill();
-        assert!(result.is_ok(), "kill to stopping actor should succeed");
+        // Now try to kill the stopping actor — idempotent, no-op.
+        actor_ref.kill();
 
         handle.await.unwrap();
     }
@@ -1776,11 +1775,10 @@ mod kill_edge_cases_tests {
         init_test_logger();
         let (actor_ref, handle) = spawn::<KillEdgeCaseActor>(KillEdgeCaseActor);
 
-        // Send multiple kill signals rapidly - should all succeed
-        // (channel capacity is 1, so subsequent kills hit the Full case)
+        // Send multiple kill signals rapidly — channel capacity is 1, so
+        // subsequent kills hit the Full case and are silently ignored.
         for _ in 0..10 {
-            let result = actor_ref.kill();
-            assert!(result.is_ok(), "rapid kill calls should succeed");
+            actor_ref.kill();
         }
 
         let result = handle.await.unwrap();
@@ -1792,13 +1790,12 @@ mod kill_edge_cases_tests {
         init_test_logger();
         let (actor_ref, handle) = spawn::<KillEdgeCaseActor>(KillEdgeCaseActor);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(result.is_completed());
 
-        // Kill after actor is completely stopped - should succeed (channel closed case)
-        let kill_result = actor_ref.kill();
-        assert!(kill_result.is_ok(), "kill to stopped actor should succeed");
+        // Kill after actor is completely stopped — hits Closed branch, idempotent no-op.
+        actor_ref.kill();
     }
 }
 
@@ -1827,13 +1824,12 @@ mod stop_edge_cases_tests {
         init_test_logger();
         let (actor_ref, handle) = spawn::<StopEdgeCaseActor>(StopEdgeCaseActor);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(result.is_completed());
 
-        // Stop after actor is completely stopped - should succeed (channel closed case)
-        let stop_result = actor_ref.stop().await;
-        assert!(stop_result.is_ok(), "stop to stopped actor should succeed");
+        // Stop after actor is completely stopped — hits Closed branch, idempotent no-op.
+        actor_ref.stop().await;
     }
 
     #[tokio::test]
@@ -1842,8 +1838,8 @@ mod stop_edge_cases_tests {
         let (actor_ref, handle) = spawn::<StopEdgeCaseActor>(StopEdgeCaseActor);
 
         // Send multiple stop signals
-        actor_ref.stop().await.unwrap();
-        actor_ref.stop().await.unwrap(); // Second stop should also succeed
+        actor_ref.stop().await;
+        actor_ref.stop().await; // Second stop should also succeed
 
         let result = handle.await.unwrap();
         assert!(result.is_completed());
@@ -1916,7 +1912,7 @@ mod on_run_disable_tests {
             "on_idle should not be called again after the stream completed"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -1992,7 +1988,7 @@ mod message_trait_tests {
         assert_eq!(received[0], "string:hello");
         assert_eq!(received[1], "int:21");
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -2028,7 +2024,7 @@ mod is_alive_edge_cases_tests {
         let _: bool = actor_ref.ask(Ping).await.unwrap();
         assert!(actor_ref.is_alive());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2038,7 +2034,7 @@ mod is_alive_edge_cases_tests {
         let (actor_ref, handle) = spawn::<IsAliveTestActor>(IsAliveTestActor);
 
         assert!(actor_ref.is_alive());
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
 
         // Wait for actor to complete
         handle.await.unwrap();
@@ -2064,7 +2060,7 @@ mod is_alive_edge_cases_tests {
         // Cloned ref should still be alive
         assert!(cloned_ref.is_alive());
 
-        cloned_ref.stop().await.unwrap();
+        cloned_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -2126,7 +2122,7 @@ mod actual_timeout_tests {
             e => panic!("Expected Timeout error, got: {:?}", e),
         }
 
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 
@@ -2142,7 +2138,7 @@ mod actual_timeout_tests {
 
         assert!(result.is_ok());
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -2203,7 +2199,7 @@ mod lifecycle_phase_tests {
         let value = tracker.load(Ordering::SeqCst);
         assert!(value >= 11, "Expected at least 11, got {}", value);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = handle.await.unwrap();
         assert!(result.is_completed());
 
@@ -2283,7 +2279,7 @@ mod metrics_api_tests {
             "Should have processed at least 3 messages"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2302,7 +2298,7 @@ mod metrics_api_tests {
         // Message count should be at least 1
         assert!(actor_ref.message_count() >= 1);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2324,7 +2320,7 @@ mod metrics_api_tests {
             "Avg processing time should be non-zero"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2345,24 +2341,7 @@ mod metrics_api_tests {
             "Max processing time should be at least 40ms"
         );
 
-        actor_ref.stop().await.unwrap();
-        handle.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_metrics_error_count() {
-        init_test_logger();
-        let (actor_ref, handle) = spawn::<MetricsTestActor>(());
-
-        // Error count should start at 0
-        assert_eq!(actor_ref.error_count(), 0);
-
-        // Even after sending messages, error_count stays 0 (no actual errors)
-        let _: i32 = actor_ref.ask(QuickMsg).await.unwrap();
-        tokio::time::sleep(Duration::from_millis(10)).await;
-        assert_eq!(actor_ref.error_count(), 0);
-
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2381,7 +2360,7 @@ mod metrics_api_tests {
             "Uptime should be at least 40ms"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 
@@ -2404,7 +2383,7 @@ mod metrics_api_tests {
             "Last activity should be Some after processing message"
         );
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 }
@@ -2458,7 +2437,7 @@ mod tell_with_timeout_tests {
         // not when waiting for the handler to complete
 
         // Clean up
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 }
@@ -2514,7 +2493,7 @@ mod blocking_timeout_expiry_tests {
         // This might succeed (queued) or timeout depending on timing
         // The important thing is that the timeout path is exercised
 
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 
@@ -2543,7 +2522,7 @@ mod blocking_timeout_expiry_tests {
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
 
-        actor_ref.kill().unwrap();
+        actor_ref.kill();
         let _ = handle.await;
     }
 }
@@ -2583,7 +2562,7 @@ mod actor_weak_upgrade_tests {
         let upgraded_ref = upgraded.unwrap();
         let _: String = upgraded_ref.ask(GetIdentity).await.unwrap();
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         handle.await.unwrap();
     }
 

--- a/tests/debugging_tools_tests.rs
+++ b/tests/debugging_tools_tests.rs
@@ -217,7 +217,7 @@ async fn test_dead_letter_on_stopped_actor() {
     let initial = rsactor::dead_letter_count();
 
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // This should trigger a dead letter
@@ -235,7 +235,7 @@ async fn test_dead_letter_count_increments() {
     let initial = rsactor::dead_letter_count();
 
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // Multiple failed sends should increment counter
@@ -258,7 +258,7 @@ async fn test_dead_letter_after_full_stop() {
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
 
     // Stop and wait for handle to ensure actor is fully stopped
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // Now try to send - this should definitely fail
@@ -283,7 +283,7 @@ async fn test_dead_letter_multiple_actors_isolation() {
     let (actor2, handle2) = spawn::<TestActor>(TestActor);
 
     // Stop only actor1
-    actor1.stop().await.unwrap();
+    actor1.stop().await;
     handle1.await.unwrap();
 
     // Record count after actor1 stopped but before our sends
@@ -304,7 +304,7 @@ async fn test_dead_letter_multiple_actors_isolation() {
     );
 
     // Cleanup: stop actor2
-    actor2.stop().await.unwrap();
+    actor2.stop().await;
     handle2.await.unwrap();
 
     // Overall: we should have at least 1 more dead letter than when we started
@@ -355,7 +355,7 @@ async fn test_dead_letter_with_timeout() {
     }
 
     // Cleanup
-    actor_ref.kill().unwrap();
+    actor_ref.kill();
     let _ = handle.await;
 }
 
@@ -364,7 +364,7 @@ async fn test_dead_letter_blocking_tell() {
     let initial = rsactor::dead_letter_count();
 
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // Clone for blocking context
@@ -415,7 +415,7 @@ async fn test_dead_letter_ask_with_timeout() {
     );
 
     // Cleanup
-    actor_ref.kill().unwrap();
+    actor_ref.kill();
     let _ = handle.await;
 }
 
@@ -437,7 +437,7 @@ async fn test_dead_letter_blocking_ask() {
     }
 
     let (actor_ref, handle) = spawn::<BlockingAskActor>(BlockingAskActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // Clone for blocking context
@@ -475,7 +475,7 @@ async fn test_dead_letter_ask_on_stopped_actor() {
     }
 
     let (actor_ref, handle) = spawn::<AskActor>(AskActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // ask() on stopped actor should trigger ActorStopped dead letter
@@ -505,7 +505,7 @@ async fn test_dead_letter_concurrent_asks_to_stopped_actor() {
     }
 
     let (actor_ref, handle) = spawn::<ConcurrentActor>(ConcurrentActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // Record count right before our concurrent sends
@@ -578,7 +578,7 @@ async fn test_retry_pattern_with_is_retryable() {
     let result = send_with_retry(&actor_ref, 3).await;
     assert!(result.is_ok());
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -593,7 +593,7 @@ async fn test_dead_letter_race_condition() {
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
 
     // Stop and immediately try to send (don't wait for handle)
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     let result = actor_ref.tell(Ping).await;
 
     // Wait for handle to complete
@@ -674,7 +674,7 @@ async fn test_dead_letter_timeout_while_stopping() {
 
     // Brief delay then stop actor
     tokio::time::sleep(Duration::from_millis(10)).await;
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 
     let result = timeout_handle.await.unwrap();
     let _ = handle.await;
@@ -888,16 +888,10 @@ async fn test_kill_when_terminate_channel_full() {
     // Send a message to keep the actor busy
     let _ = actor_ref.tell(SlowMessage).await;
 
-    // First kill should succeed
-    let result1 = actor_ref.kill();
-    assert!(result1.is_ok(), "First kill should succeed");
-
-    // Second kill should also succeed (hits Full branch - returns Ok)
-    let result2 = actor_ref.kill();
-    assert!(
-        result2.is_ok(),
-        "Second kill should succeed (terminate channel full case)"
-    );
+    // kill() is idempotent — both calls succeed even when the second one hits
+    // the Full branch (terminate channel has capacity 1 and is already occupied).
+    actor_ref.kill();
+    actor_ref.kill();
 
     // Clean up
     let _ = handle.await;
@@ -910,15 +904,11 @@ async fn test_kill_when_actor_already_stopped() {
     let (actor_ref, handle) = spawn::<TestActor>(TestActor);
 
     // Stop the actor gracefully and wait for it to finish
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
-    // Now kill should hit the Closed branch (channel is closed)
-    let result = actor_ref.kill();
-    assert!(
-        result.is_ok(),
-        "Kill on stopped actor should succeed (terminate channel closed case)"
-    );
+    // kill() on a stopped actor hits the Closed branch and remains idempotent.
+    actor_ref.kill();
 }
 
 #[tokio::test]
@@ -949,7 +939,7 @@ async fn test_default_on_run_behavior() {
     assert!(result, "Actor with default on_run should process messages");
 
     // Stop the actor
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -987,7 +977,7 @@ async fn test_deprecated_tell_blocking_method() {
 
     assert!(result.is_ok(), "Deprecated tell_blocking should work");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1027,7 +1017,7 @@ async fn test_deprecated_ask_blocking_method() {
     assert!(result.is_ok(), "Deprecated ask_blocking should work");
     assert_eq!(result.unwrap(), "test_value");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1100,7 +1090,7 @@ async fn test_weak_handler_clone() {
         "Cloned weak ask should upgrade"
     );
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1151,7 +1141,7 @@ async fn test_tell_handler_blocking_tell() {
         "Message should have been received"
     );
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1191,7 +1181,7 @@ async fn test_ask_handler_blocking_ask() {
     assert!(result.is_ok(), "blocking_ask via trait should succeed");
     assert_eq!(result.unwrap(), "blocking_ask_response");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1214,7 +1204,7 @@ async fn test_actor_control_from_conversions() {
     assert!(control.is_alive(), "Actor should be alive");
 
     // Stop via control
-    control.stop().await.unwrap();
+    control.stop().await;
     handle.await.unwrap();
 }
 
@@ -1242,7 +1232,7 @@ async fn test_weak_actor_control_from_reference() {
         "Weak control should upgrade"
     );
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1275,7 +1265,7 @@ async fn test_ask_handler_from_actor_ref() {
     let result: i32 = ask_handler.ask(AskHandlerFromMessage).await.unwrap();
     assert_eq!(result, 42);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }
 
@@ -1315,6 +1305,6 @@ async fn test_weak_ask_handler_from_reference() {
         panic!("Weak handler should be upgradeable");
     }
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 }

--- a/tests/derive_macro_tests.rs
+++ b/tests/derive_macro_tests.rs
@@ -59,7 +59,7 @@ async fn test_derive_actor_basic_functionality() {
     assert_eq!(new_value, 100);
 
     // Stop the actor
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -73,7 +73,7 @@ async fn test_derive_actor_error_type() {
     // This test ensures the actor can be spawned without error handling
     let (actor_ref, join_handle) = spawn::<TestActor>(actor_instance);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 
     // The join handle should complete successfully
     let result = join_handle.await.unwrap();
@@ -100,7 +100,7 @@ async fn test_derive_actor_args_type() {
     assert_eq!(value, original_value);
     assert_eq!(name, original_name);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test with a unit struct
@@ -124,7 +124,7 @@ async fn test_derive_actor_unit_struct() {
     let response = actor_ref.ask(Ping).await.unwrap();
     assert_eq!(response, "pong");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test with a tuple struct
@@ -161,7 +161,7 @@ async fn test_derive_actor_tuple_struct() {
     assert_eq!(first, "hello");
     assert_eq!(second, 456);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test with an enum
@@ -244,7 +244,7 @@ async fn test_derive_actor_enum_basic() {
     let state = actor_ref.ask(GetState).await.unwrap();
     assert!(matches!(state, StateActor::Idle));
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -276,7 +276,7 @@ async fn test_derive_actor_enum_state_transitions() {
     let processing_data = actor_ref.ask(GetProcessingData).await.unwrap();
     assert_eq!(processing_data, None);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -291,7 +291,7 @@ async fn test_derive_actor_enum_variant_data() {
     let is_idle = actor_ref.ask(IsIdle).await.unwrap();
     assert!(!is_idle);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -309,7 +309,7 @@ async fn test_derive_actor_enum_completed_variant() {
     let is_idle = actor_ref.ask(IsIdle).await.unwrap();
     assert!(!is_idle);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test with a simple enum without data
@@ -383,7 +383,7 @@ async fn test_derive_actor_simple_enum() {
     let direction = actor_ref.ask(GetDirection).await.unwrap();
     assert_eq!(direction, DirectionActor::East);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -415,7 +415,7 @@ async fn test_derive_actor_enum_full_rotation() {
         assert_eq!(direction, expected);
     }
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // =============================================================================
@@ -459,7 +459,7 @@ async fn test_message_handlers_macro_basic() {
     let result = actor_ref.ask(TestMessage).await.unwrap();
     assert_eq!(result, 42);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test for generic support in derive macro
@@ -505,7 +505,7 @@ async fn test_derive_actor_with_generics() {
     let new_data = actor_ref.ask(SetData("world".to_string())).await.unwrap();
     assert_eq!(new_data, "world");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -520,7 +520,7 @@ async fn test_derive_actor_with_generics_numeric() {
     let new_data = actor_ref.ask(SetData(456)).await.unwrap();
     assert_eq!(new_data, 456);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test actor with complex where clauses and multiple generic parameters
@@ -594,7 +594,7 @@ async fn test_derive_actor_multi_generics() {
     let new_both = actor_ref.ask(MultiGetBoth).await.unwrap();
     assert_eq!(new_both, (vec![4, 5], "updated".to_string()));
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test edge cases for handler method validation
@@ -650,7 +650,7 @@ async fn test_handler_edge_cases() {
     let value = actor_ref.ask(EdgeGetValue).await.unwrap();
     assert_eq!(value, 3); // 1 + 2
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test that the derive macro works with complex struct patterns
@@ -730,7 +730,7 @@ async fn test_complex_struct_actor() {
     let new_data = actor_ref.ask(ComplexGetPrivateData).await.unwrap();
     assert_eq!(new_data, vec![1, 2, 3, 4]);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // Test that lifetimes and references work correctly in messages
@@ -777,7 +777,7 @@ async fn test_reference_handling() {
     let data = actor_ref.ask(GetDataRef).await.unwrap();
     assert_eq!(data, "updated_data");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 // =============================================================================
@@ -906,9 +906,9 @@ async fn test_enhanced_macro_features_integration() {
     assert_eq!(complex_id, 999);
 
     // Stop all actors
-    generic_ref.stop().await.unwrap();
-    multi_ref.stop().await.unwrap();
-    complex_ref.stop().await.unwrap();
+    generic_ref.stop().await;
+    multi_ref.stop().await;
+    complex_ref.stop().await;
 }
 
 // Test macro resilience with edge cases
@@ -936,9 +936,9 @@ async fn test_macro_edge_cases() {
     assert_eq!(processing_data, Some("edge_processing".to_string()));
 
     // Stop all actors
-    unit_ref.stop().await.unwrap();
-    tuple_ref.stop().await.unwrap();
-    enum_ref.stop().await.unwrap();
+    unit_ref.stop().await;
+    tuple_ref.stop().await;
+    enum_ref.stop().await;
 }
 
 // Performance test to ensure macros don't introduce significant overhead
@@ -967,7 +967,7 @@ async fn test_macro_performance() {
 
     // Clean up
     for actor_ref in actors {
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
     }
 
     let duration = start.elapsed();
@@ -1210,7 +1210,7 @@ async fn test_successful_error_handling_examples() {
     let result = actor_ref.ask(ValidMessage).await.unwrap();
     assert_eq!(result, 42);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -1271,7 +1271,7 @@ async fn test_multiple_handlers_same_actor() {
     let new_name = actor_ref.ask(SetName("updated".to_string())).await.unwrap();
     assert_eq!(new_name, "updated");
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -1324,7 +1324,7 @@ async fn test_handler_with_result_return_type() {
     let result = actor_ref.ask(GetNegative).await.unwrap();
     assert_eq!(result, Err("Value is not negative".to_string()));
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 
     // Test with negative value
     let actor = ResultActor { value: -10 };
@@ -1336,7 +1336,7 @@ async fn test_handler_with_result_return_type() {
     let result = actor_ref.ask(GetNegative).await.unwrap();
     assert_eq!(result, Ok(-10));
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -1390,7 +1390,7 @@ async fn test_handler_with_option_return_type() {
     let at_10 = actor_ref.ask(GetAt(10)).await.unwrap();
     assert_eq!(at_10, None);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -1441,5 +1441,5 @@ async fn test_mixed_handler_patterns() {
     let result = actor_ref.ask(Reset).await.unwrap();
     assert_eq!(result, 0);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }

--- a/tests/generic_tests.rs
+++ b/tests/generic_tests.rs
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(value, None);
 
         // Stop actor and wait
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
         if let ActorResult::Completed { actor, killed: _ } = result {
@@ -139,7 +139,7 @@ mod tests {
         assert_eq!(value, None);
 
         // Stop actor and wait
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
         if let ActorResult::Completed { actor, killed: _ } = result {
@@ -169,7 +169,7 @@ mod tests {
         let value: Option<MyTestData> = actor_ref.ask(GetValue).await.unwrap();
         assert_eq!(value, None);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
         if let ActorResult::Completed { actor, killed: _ } = result {
@@ -206,7 +206,7 @@ mod tests {
         assert_eq!(value, None);
 
         // Stop actor
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
     }
@@ -252,7 +252,7 @@ mod tests {
         assert_eq!(w_as_string, "updated".to_string());
 
         // Stop actor
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
     }
@@ -280,7 +280,7 @@ mod tests {
         assert_eq!(serialized.unwrap(), "{\"value\":\"test\"}".to_string());
 
         // Stop actor
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
     }
@@ -308,7 +308,7 @@ mod tests {
         assert_eq!(serialized.unwrap(), "<data>example</data>".to_string());
 
         // Stop actor
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
         assert!(result.is_completed());
     }

--- a/tests/handler_tests.rs
+++ b/tests/handler_tests.rs
@@ -99,7 +99,7 @@ async fn test_tell_handler_from_actor_ref() {
     assert!(handler.as_control().is_alive());
 
     // Stop via actor_ref (lifecycle control is separate from handler)
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -127,8 +127,8 @@ async fn test_tell_handler_multiple_actors_same_message() {
     }
 
     // Stop all actors via actor_ref
-    actor_a.stop().await.expect("stop should succeed");
-    actor_b.stop().await.expect("stop should succeed");
+    actor_a.stop().await;
+    actor_b.stop().await;
 
     let result_a = handle_a.await.expect("actor A should complete");
     let result_b = handle_b.await.expect("actor B should complete");
@@ -165,7 +165,7 @@ async fn test_tell_handler_clone_boxed() {
         .await
         .expect("cloned handler tell should succeed");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -191,7 +191,7 @@ async fn test_tell_handler_clone_trait() {
     handlers[0].tell(Ping).await.expect("should work");
     handlers_clone[0].tell(Ping).await.expect("should work");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -211,7 +211,7 @@ async fn test_tell_handler_debug() {
     assert!(debug_str.contains("TellHandler"));
     assert!(debug_str.contains("identity"));
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -226,7 +226,7 @@ async fn test_tell_handler_kill() {
     let _handler: Box<dyn TellHandler<Ping>> = (&actor_ref).into();
 
     // Kill via actor_ref (lifecycle control is separate from handler)
-    actor_ref.kill().expect("kill should succeed");
+    actor_ref.kill();
 
     let result = handle.await.expect("actor should complete");
     assert!(result.was_killed());
@@ -253,7 +253,7 @@ async fn test_ask_handler_from_actor_ref() {
     assert_eq!(status.name, "ask_test");
     assert!(status.alive);
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -283,8 +283,8 @@ async fn test_ask_handler_multiple_actors_same_reply_type() {
     assert_eq!(responses[1].name, "ActorB-100");
 
     // Stop all actors via actor_ref
-    actor_a.stop().await.expect("stop should succeed");
-    actor_b.stop().await.expect("stop should succeed");
+    actor_a.stop().await;
+    actor_b.stop().await;
 
     let _ = handle_a.await;
     let _ = handle_b.await;
@@ -307,7 +307,7 @@ async fn test_ask_handler_clone() {
 
     assert_eq!(status1, status2);
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -341,7 +341,7 @@ async fn test_weak_tell_handler_from_actor_weak() {
         .expect("upgrade should succeed while actor is alive");
     strong.tell(Ping).await.expect("tell should succeed");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -358,7 +358,7 @@ async fn test_weak_tell_handler_upgrade_after_stop() {
     let weak_handler: Box<dyn WeakTellHandler<Ping>> = actor_weak.into();
 
     // Stop the actor
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     drop(actor_ref);
 
     let _ = handle.await;
@@ -394,8 +394,8 @@ async fn test_weak_tell_handler_multiple_actors() {
     }
 
     // Stop actors
-    actor_a.stop().await.expect("stop should succeed");
-    actor_b.stop().await.expect("stop should succeed");
+    actor_a.stop().await;
+    actor_b.stop().await;
 
     let _ = handle_a.await;
     let _ = handle_b.await;
@@ -418,7 +418,7 @@ async fn test_weak_tell_handler_batch_operations() {
         strong.tell(Ping).await.expect("should work");
     }
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
 }
@@ -444,7 +444,7 @@ async fn test_weak_tell_handler_clone() {
     assert!(weak_handler.upgrade().is_some());
     assert!(weak_clone.upgrade().is_some());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -469,7 +469,7 @@ async fn test_weak_ask_handler_from_actor_weak() {
 
     assert_eq!(status.name, "weak_ask");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -500,8 +500,8 @@ async fn test_weak_ask_handler_multiple_actors() {
     assert_eq!(responses[0].name, "WeakAskA");
     assert_eq!(responses[1].name, "ActorB-77");
 
-    actor_a.stop().await.expect("stop should succeed");
-    actor_b.stop().await.expect("stop should succeed");
+    actor_a.stop().await;
+    actor_b.stop().await;
 
     let _ = handle_a.await;
     let _ = handle_b.await;
@@ -529,7 +529,7 @@ async fn test_tell_handler_as_control() {
     assert!(control.is_alive());
 
     // Stop via control
-    control.stop().await.expect("stop should succeed");
+    control.stop().await;
 
     let result = handle.await.expect("actor should complete");
     assert!(result.stopped_normally());
@@ -556,7 +556,7 @@ async fn test_ask_handler_as_control() {
     assert_eq!(status.name, "ask_as_control");
 
     // Kill via control
-    control.kill().expect("kill should succeed");
+    control.kill();
 
     let result = handle.await.expect("actor should complete");
     assert!(result.was_killed());
@@ -584,7 +584,7 @@ async fn test_handler_as_control_multiple_actors() {
 
     // Stop all via unified control interface
     for control in &controls {
-        control.stop().await.expect("stop should succeed");
+        control.stop().await;
     }
 
     let result_a = handle_a.await.expect("actor A should complete");
@@ -620,7 +620,7 @@ async fn test_downgrade_from_tell_handler() {
     let upgraded = weak_handler.upgrade().expect("should be able to upgrade");
     upgraded.tell(Ping).await.expect("tell should work");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -648,7 +648,7 @@ async fn test_downgrade_from_ask_handler() {
 
     assert_eq!(status.name, "ask_downgrade");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -683,7 +683,7 @@ async fn test_roundtrip_strong_weak_strong() {
     strong1.tell(Ping).await.expect("should work");
     strong2.tell(Ping).await.expect("should work");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -706,7 +706,7 @@ async fn test_from_actor_ref_ownership() {
 
     handler.tell(Ping).await.expect("should work");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -726,7 +726,7 @@ async fn test_from_actor_ref_reference() {
     // Original actor_ref is still usable
     actor_ref.tell(Ping).await.expect("should work");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -745,7 +745,7 @@ async fn test_from_actor_weak_ownership() {
 
     assert!(handler.upgrade().is_some());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -766,7 +766,7 @@ async fn test_from_actor_weak_reference() {
     assert!(handler.upgrade().is_some());
     assert!(actor_weak.upgrade().is_some());
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -790,7 +790,7 @@ async fn test_tell_handler_with_timeout() {
         .await
         .expect("tell_with_timeout should succeed");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -812,7 +812,7 @@ async fn test_ask_handler_with_timeout() {
 
     assert_eq!(status.name, "ask_timeout");
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 
@@ -845,7 +845,7 @@ async fn test_all_handlers_debug_formatting() {
     assert!(weak_tell_debug.contains("WeakTellHandler"));
     assert!(weak_ask_debug.contains("WeakAskHandler"));
 
-    actor_ref.stop().await.expect("stop should succeed");
+    actor_ref.stop().await;
     let _ = handle.await;
 }
 

--- a/tests/panic_handling_tests.rs
+++ b/tests/panic_handling_tests.rs
@@ -130,7 +130,7 @@ mod tests {
         assert_eq!(result, 8);
 
         // Stop gracefully
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let actor_result = join_handle.await.unwrap();
 
         match actor_result {
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(result, 5);
 
         // Stop gracefully
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let actor_result = join_handle.await.unwrap();
 
         match actor_result {
@@ -234,7 +234,7 @@ mod tests {
         // Verify counter was reset
         assert_eq!(actor_ref.ask(SafeMessage(1)).await?, 1);
 
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         join_handle.await.unwrap();
 
         Ok(())
@@ -265,8 +265,8 @@ mod tests {
         assert!(result.is_err());
 
         // Clean up
-        actor_ref1.stop().await?;
-        actor_ref3.stop().await?;
+        actor_ref1.stop().await;
+        actor_ref3.stop().await;
 
         let result1 = join_handle1.await.unwrap();
         let result3 = join_handle3.await.unwrap();
@@ -373,7 +373,7 @@ mod supervision_tests {
         assert_eq!(actor_ref.ask(SafeMessage(2)).await?, 3);
 
         // Stop gracefully
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
 
         assert!(matches!(result, ActorResult::Completed { .. }));
@@ -428,7 +428,7 @@ mod advanced_tests {
     async fn test_successful_on_start() -> Result<()> {
         let (actor_ref, join_handle) = spawn::<StartupPanicActor>(false);
 
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
 
         assert!(matches!(result, ActorResult::Completed { .. }));
@@ -469,7 +469,7 @@ mod advanced_tests {
     async fn test_panic_during_on_stop() -> Result<()> {
         let (actor_ref, join_handle) = spawn::<StopPanicActor>(true);
 
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let join_result = join_handle.await;
 
         // on_stop panic should be caught
@@ -483,7 +483,7 @@ mod advanced_tests {
     async fn test_normal_on_stop() -> Result<()> {
         let (actor_ref, join_handle) = spawn::<StopPanicActor>(false);
 
-        actor_ref.stop().await?;
+        actor_ref.stop().await;
         let result = join_handle.await.unwrap();
 
         assert!(matches!(result, ActorResult::Completed { .. }));
@@ -530,7 +530,7 @@ mod advanced_tests {
 
         async fn handle(&mut self, _msg: KillMessage, actor_ref: &ActorRef<Self>) -> Self::Reply {
             // Actor kills itself
-            let _ = actor_ref.kill();
+            actor_ref.kill();
         }
     }
 
@@ -538,13 +538,13 @@ mod advanced_tests {
     async fn test_kill_vs_graceful_stop_with_panic() -> Result<()> {
         // Test graceful stop with panic
         let (actor_ref1, join_handle1) = spawn::<KillTestActor>(true);
-        actor_ref1.stop().await?;
+        actor_ref1.stop().await;
         let result1 = join_handle1.await;
         assert!(result1.is_err() && result1.unwrap_err().is_panic());
 
         // Test kill (should not trigger on_stop panic)
         let (actor_ref2, join_handle2) = spawn::<KillTestActor>(true);
-        let _ = actor_ref2.kill();
+        actor_ref2.kill();
         let result2 = join_handle2.await.unwrap();
         assert!(matches!(
             result2,
@@ -833,8 +833,8 @@ mod integration_tests {
         assert_eq!(actor3_ref.ask(SimpleMsg).await?, 3);
 
         // Clean up
-        actor1_ref.stop().await?;
-        actor3_ref.stop().await?;
+        actor1_ref.stop().await;
+        actor3_ref.stop().await;
 
         let result1 = actor1_handle.await.unwrap();
         let result2 = actor2_handle.await;

--- a/tests/priority_signal_tests.rs
+++ b/tests/priority_signal_tests.rs
@@ -157,7 +157,7 @@ async fn default_spawn_has_no_priority_channel() {
         !actor_ref.has_priority_channel(),
         "spawn() must not enable the priority channel"
     );
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -184,7 +184,7 @@ async fn tell_priority_on_disabled_actor_returns_not_enabled_error() {
         "PriorityChannelNotEnabled must not increment the dead letter counter"
     );
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -202,7 +202,7 @@ async fn ask_priority_on_disabled_actor_returns_not_enabled_error() {
     assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
     assert_eq!(dead_letter_count(), before);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@ async fn priority_bypasses_saturated_regular_mailbox() {
     // Drain the rest gracefully.
     release.notify_one();
     release.notify_one();
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test]
@@ -274,7 +274,7 @@ async fn ask_priority_returns_typed_reply() {
         .unwrap();
     assert_eq!(reply, 42);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 // ---------------------------------------------------------------------------
@@ -304,7 +304,7 @@ async fn kill_overtakes_pending_priority_messages() {
 
     // Kill the actor. Per §5.A-1, kill MUST overtake pending priority messages
     // and the queued PingPriority MUST NOT be processed.
-    actor_ref.kill().unwrap();
+    actor_ref.kill();
     release.notify_one(); // unblock the in-flight handler so the loop progresses
 
     let result = handle.await.unwrap();
@@ -343,7 +343,7 @@ async fn priority_message_pending_at_stop_is_processed_before_on_stop() {
         .tell_priority(PingPriority, DEFAULT_TIMEOUT)
         .await
         .unwrap();
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     release.notify_one();
 
     let result = handle.await.unwrap();
@@ -400,7 +400,7 @@ async fn stop_drain_loop_processes_racing_priority_send() {
             tokio::time::sleep(Duration::from_millis(1)).await;
         }
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
 
         // Race: spawn a few priority senders concurrently with releasing the
         // blocker. Some sends will be accepted, some will be rejected after
@@ -451,7 +451,7 @@ async fn priority_send_after_stop_drain_records_dead_letter() {
 
     let opts = SpawnOptions::new().with_priority();
     let (actor_ref, handle) = spawn_with_options::<CounterActor>((), opts);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     let before = dead_letter_count();
@@ -513,7 +513,7 @@ async fn tell_priority_timeout_on_wedged_actor_records_dead_letter() {
 
     // Cleanup: release the wedge and shut down.
     release.notify_one();
-    actor_ref.kill().unwrap();
+    actor_ref.kill();
     let _ = handle.await;
 }
 
@@ -575,7 +575,7 @@ async fn actor_weak_upgrade_succeeds_when_only_priority_strong_dropped() {
         .unwrap_err();
     assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
 
-    let _ = upgraded.stop().await;
+    upgraded.stop().await;
 }
 
 #[tokio::test]
@@ -598,7 +598,7 @@ async fn actor_weak_upgrade_preserves_priority_when_other_strong_alive() {
     );
 
     drop(other_strong);
-    let _ = upgraded.stop().await;
+    upgraded.stop().await;
 }
 
 // ---------------------------------------------------------------------------
@@ -619,7 +619,7 @@ async fn blocking_tell_priority_succeeds_when_enabled() {
     let (_normal, priority) = actor_ref.ask(GetCounts).await.unwrap();
     assert_eq!(priority, 1);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -636,7 +636,7 @@ async fn blocking_ask_priority_returns_reply() {
     .unwrap();
     assert_eq!(reply, 100);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 // Verify that the blocking priority variants can be called directly from an
@@ -658,7 +658,7 @@ async fn blocking_tell_priority_from_async_multi_thread_context() {
     let (_normal, priority) = actor_ref.ask(GetCounts).await.unwrap();
     assert_eq!(priority, 1);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -671,7 +671,7 @@ async fn blocking_ask_priority_from_async_multi_thread_context() {
         .expect("blocking_ask_priority from async ctx should succeed");
     assert_eq!(reply, 8);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 // On a current_thread runtime, blocking_*_priority cannot take the
@@ -698,7 +698,7 @@ async fn blocking_tell_priority_on_current_thread_runtime() {
     let (_normal, priority) = actor_ref.ask(GetCounts).await.unwrap();
     assert_eq!(priority, 1);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -715,7 +715,7 @@ async fn blocking_ask_priority_on_current_thread_runtime() {
     .expect("blocking_ask_priority on current_thread runtime should succeed");
     assert_eq!(reply, 21);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -729,7 +729,7 @@ async fn blocking_priority_on_disabled_actor_returns_not_enabled() {
     .unwrap()
     .unwrap_err();
     assert!(matches!(err, Error::PriorityChannelNotEnabled { .. }));
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }
 
 // ---------------------------------------------------------------------------
@@ -780,7 +780,7 @@ async fn capacity_one_serializes_concurrent_priority_admission() {
     );
 
     release.notify_one();
-    actor_ref.kill().unwrap();
+    actor_ref.kill();
 }
 
 // ---------------------------------------------------------------------------
@@ -873,7 +873,7 @@ async fn priority_handler_runs_before_queued_regular_messages() {
 
     // Release R1 and let everything drain.
     r1_release.notify_one();
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     let order = log.lock().unwrap().clone();
@@ -931,5 +931,5 @@ async fn priority_metrics_counters_are_distinct_from_regular() {
     assert_eq!(actor_ref.priority_message_count(), 3);
     assert_eq!(actor_ref.message_count(), 6);
 
-    let _ = actor_ref.stop().await;
+    actor_ref.stop().await;
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -958,6 +958,7 @@ async fn test_actor_fail_on_stop_during_graceful_stop() {
             error,
             phase,
             killed,
+            ..
         } => {
             assert_eq!(
                 phase,
@@ -1021,6 +1022,7 @@ async fn test_actor_fail_on_stop_during_kill() {
             error,
             phase,
             killed,
+            ..
         } => {
             assert_eq!(
                 phase,
@@ -1080,6 +1082,7 @@ async fn test_actor_fail_on_stop_after_on_run_failure() {
             error,
             phase,
             killed,
+            ..
         } => {
             assert_eq!(
                 phase,
@@ -1144,6 +1147,7 @@ async fn test_actor_on_stop_success_after_on_run_failure() {
             error,
             phase,
             killed,
+            ..
         } => {
             assert_eq!(
                 phase,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -116,7 +116,7 @@ async fn setup_actor() -> (
 async fn test_spawn_and_actor_ref_id() {
     let (actor_ref, handle, _counter, _lpmt) = setup_actor().await;
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     let result = handle.await.expect("Actor task failed");
     assert!(
         result.is_completed(),
@@ -164,7 +164,7 @@ async fn test_actor_ref_ask() {
         .expect("ask failed for GetCounterMsg after update");
     assert_eq!(count_after_update, 10);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     let _result = handle.await.expect("Actor task failed");
 }
 
@@ -184,7 +184,7 @@ async fn test_actor_ref_tell() {
         Some("UpdateCounterMsg".to_string())
     );
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     let _result = handle.await.expect("Actor task failed");
 }
 
@@ -200,7 +200,7 @@ async fn test_actor_ref_stop() {
         .expect("ask sent before stop should succeed");
     assert_eq!(count_val, 100);
 
-    actor_ref.stop().await.expect("stop command failed");
+    actor_ref.stop().await;
 
     let result = handle.await.expect("Actor task failed");
     assert!(
@@ -247,7 +247,7 @@ async fn test_actor_ref_kill() {
 
     // Immediately send kill, without waiting for the previous message to be processed.
     // The dedicated terminate channel and biased select in Runtime should prioritize this.
-    actor_ref.kill().expect("kill command failed");
+    actor_ref.kill();
 
     let result = handle.await.expect("Actor task failed to complete");
 
@@ -585,10 +585,7 @@ async fn test_actor_with_string_error_type() {
     assert_eq!(reply, "SimpleMsg processed");
 
     // Stop the actor
-    actor_ref
-        .stop()
-        .await
-        .expect("Failed to stop StringErrorActor");
+    actor_ref.stop().await;
     let result = handle.await.expect("StringErrorActor task failed");
 
     assert!(
@@ -628,7 +625,7 @@ async fn test_spawn_and_stop_dummy_actor() {
     // if on_start does nothing.
     // tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    actor_ref.stop().await.expect("Failed to stop dummy actor");
+    actor_ref.stop().await;
     let result = handle.await.expect("Dummy actor task failed");
 
     assert!(
@@ -669,7 +666,7 @@ async fn test_actor_ref_blocking_tell() {
         Some("UpdateCounterMsg".to_string())
     );
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -717,7 +714,7 @@ async fn test_actor_ref_blocking_ask() {
 
     join_handle.await.expect("Blocking task panicked");
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -755,7 +752,7 @@ async fn test_actor_ref_blocking_ask_no_timeout() {
         .await
         .expect("Blocking task for blocking_ask with None timeout panicked");
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -764,13 +761,9 @@ async fn test_actor_ref_kill_multiple_times() {
     let (actor_ref, handle, _counter, _lpmt) = setup_actor().await;
 
     // Call kill multiple times
-    actor_ref.kill().expect("First kill command failed");
-    actor_ref
-        .kill()
-        .expect("Second kill command should also succeed (idempotent)");
-    actor_ref
-        .kill()
-        .expect("Third kill command should also succeed (idempotent)");
+    actor_ref.kill();
+    actor_ref.kill();
+    actor_ref.kill();
 
     let result = handle.await.expect("Actor task failed to complete");
 
@@ -810,10 +803,7 @@ async fn test_actor_ref_is_alive() {
         "Actor should be alive after spawn (stop test)"
     );
 
-    actor_ref_stop_test
-        .stop()
-        .await
-        .expect("Failed to stop actor (stop test)");
+    actor_ref_stop_test.stop().await;
     let result_stop = handle_stop_test
         .await
         .expect("Actor task failed after stop (stop test)");
@@ -843,9 +833,7 @@ async fn test_actor_ref_is_alive() {
         "Actor should be alive before kill (kill test)"
     );
 
-    actor_ref_kill_test
-        .kill()
-        .expect("kill command failed (kill test)");
+    actor_ref_kill_test.kill();
     let result_kill = handle_kill_test
         .await
         .expect("Actor task failed after kill (kill test)");
@@ -897,7 +885,7 @@ async fn test_ask_with_timeout() {
         .expect("ask_with_timeout for GetCounterMsg should succeed");
     assert_eq!(count, 0);
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -928,7 +916,7 @@ async fn test_tell_with_timeout() {
     // it's hard to create a realistic timeout situation for tell_with_timeout
     // Without introducing artificial delays or mocks
 
-    actor_ref.stop().await.expect("Failed to stop actor");
+    actor_ref.stop().await;
     handle.await.expect("Actor task failed");
 }
 
@@ -955,7 +943,7 @@ async fn test_actor_fail_on_stop_during_graceful_stop() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Gracefully stop the actor - this should trigger on_stop failure
-    actor_ref.stop().await.expect("stop command should succeed");
+    actor_ref.stop().await;
 
     let result = handle.await.expect("Join handle should not fail");
     assert!(
@@ -1018,7 +1006,7 @@ async fn test_actor_fail_on_stop_during_kill() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Kill the actor - this should trigger on_stop failure
-    actor_ref.kill().expect("kill command should succeed");
+    actor_ref.kill();
 
     let result = handle.await.expect("Join handle should not fail");
     assert!(
@@ -1208,7 +1196,7 @@ async fn test_actor_on_stop_success_during_graceful_stop() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Gracefully stop the actor - this should succeed
-    actor_ref.stop().await.expect("stop command should succeed");
+    actor_ref.stop().await;
 
     let result = handle.await.expect("Join handle should not fail");
     assert!(
@@ -1260,7 +1248,7 @@ async fn test_actor_on_stop_success_during_kill() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // Kill the actor - this should succeed
-    actor_ref.kill().expect("kill command should succeed");
+    actor_ref.kill();
 
     let result = handle.await.expect("Join handle should not fail");
     assert!(


### PR DESCRIPTION
## Summary

Replaces `on_run` with a stream-based `on_idle` handler driven by subscriptions, and bundles a series of follow-up refactors (perf, API cleanup, docs, CI). Combined diff vs `main` covers 6 commits.

### Headline changes
- **`on_idle` replaces `on_run`** ([`92caa71`](../commit/92caa71)) — the runtime now owns a `SelectAll` of streams registered via `ActorRef::subscribe_idle`, so timer/event state survives across `select!` cancellations (the chief footgun of the old `on_run` async block). New `Actor::IdleEvent` associated type.
- **Reuse caller's runtime in `blocking_*`** ([`f3ef28d`](../commit/f3ef28d)) — fast path uses `block_in_place` + `Handle::block_on` when called from a multi-thread runtime, avoiding the thread+runtime spawn for the common case.
- **Surface `on_stop` cleanup error** ([`b5da823`](../commit/b5da823)) — `ActorResult::Failed` gains `secondary_error: Option<T::Error>`, populated for `OnIdleThenOnStop`. Closes the API gap where the phase variant advertised a dual failure but only one error was reachable.
- **Lifecycle hot-path tightening** ([`b5da823`](../commit/b5da823)) — move `on_idle_span` construction into the idle arm; drop a redundant `format!` that defeated `tracing` lazy formatting; differentiate explicit vs implicit graceful-stop logs.
- **Defensive: tolerate `wait_for_graph()` poisoning** ([`b5da823`](../commit/b5da823)) — match the symmetric `WaitForGuard::drop` behaviour.
- **Boilerplate consolidation** ([`b5da823`](../commit/b5da823)) — `run_blocking_with_runtime` helper replaces 4 copies of thread/runtime/join boilerplate (~80 LOC removed).
- **Post-review API cleanup** ([`9d2deda`](../commit/9d2deda)) and **doc/CI fixes** ([`c201cbd`](../commit/c201cbd), [`c7d2456`](../commit/c7d2456)).

### Breaking changes
- `Actor::on_run` removed; replace with `on_idle` + `subscribe_idle`. New required `type IdleEvent` (set to `()` if unused; `#[derive(Actor)]` fills it in).
- `ActorResult::Failed` has new `secondary_error` field — exhaustive patterns must add `..` or destructure the field.
- Other API surface adjustments from `9d2deda` post-review cleanup.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (all 415+ unit/integration/doc tests pass)
- [ ] Manual: spec-compliant downstream actor still compiles/runs against `subscribe_idle` API
- [ ] Reviewer: confirm `secondary_error` field semantics align with intended error-recovery patterns for supervisors

🤖 Generated with [Claude Code](https://claude.com/claude-code)