### PR TITLE
fix(actor): silence unused_variables warning without tracing feature

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -707,9 +707,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             guard = MessageProcessingGuard,
                         );
                     }
-                    msg @ (Some(MailboxMessage::StopGracefully(_)) | None) => {
+                    _msg @ (Some(MailboxMessage::StopGracefully(_)) | None) => {
                         #[cfg(feature = "tracing")]
-                        match &msg {
+                        match &_msg {
                             Some(_) => debug!("Actor termination: explicit graceful stop"),
                             None => debug!("Actor termination: all strong refs dropped"),
                         }


### PR DESCRIPTION
## Summary

In `run_actor_lifecycle`, the termination match arm bound `msg @ (Some(MailboxMessage::StopGracefully(_)) | None)` but only consumed it inside a `#[cfg(feature = "tracing")]` block. Default builds (without the `tracing` feature) therefore dropped the only use of `msg` and emitted an `unused_variables` warning.

Renaming the binding to `_msg` keeps the value available to the tracing build (`match &_msg` still distinguishes graceful-stop vs. all-refs-dropped) while compiling cleanly when `tracing` is off. No behavior change.

## Testing

- `cargo check` — clean, no warnings
- `cargo check --features tracing` — clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)