### PR TITLE
fix(log): downgrade dropped-reply log, unify handler-error routing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,26 +306,27 @@ pub use rsactor_derive::{message_handlers, Actor};
 
 /// Internal function used by derive macros to log handler errors.
 ///
-/// This surfaces user-handler `Result::Err` values through the most appropriate channel:
-/// when the `tracing` feature is enabled, it emits a structured `tracing::error!` event;
-/// otherwise it falls back to `eprintln!` so users who have not wired up a subscriber
-/// still see handler errors on stderr instead of silently dropping them.
+/// Surfaces a user handler's `Result::Err` value through `tracing::error!`. The
+/// `tracing` crate is always a dependency — the `tracing` *feature* only gates
+/// `#[tracing::instrument]` spans, not logging — so this routes through the user's
+/// configured subscriber unconditionally, exactly like dead-letter logging. Keying
+/// the channel on the `tracing` feature instead would be wrong: the feature is
+/// unrelated to whether a subscriber exists, so it could send handler errors to
+/// `eprintln!` even when the user has a subscriber wired up, or silently drop them
+/// when they don't.
+///
+/// A handler returning `Err` is a genuine actor-side fault (unlike a dropped reply,
+/// which is the caller's decision), so `error!` is the appropriate level.
 #[doc(hidden)]
 pub fn __log_handler_error(
     actor: &dyn std::fmt::Display,
     message_type: &str,
     error: &dyn std::fmt::Display,
 ) {
-    #[cfg(feature = "tracing")]
     tracing::error!(
         actor = %actor,
         message_type = %message_type,
         "handler returned error: {}", error
-    );
-    #[cfg(not(feature = "tracing"))]
-    eprintln!(
-        "[ERROR] handler returned error: {} (actor: {}, message_type: {})",
-        error, actor, message_type
     );
 }
 
@@ -486,22 +487,29 @@ where
         async move {
             let result = Message::handle(actor, *self, &actor_ref).await;
             if let Some(channel) = reply_channel {
-                match channel.send(Box::new(result)) {
-                    Ok(_) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::debug!(
-                            actor = %actor_ref.identity(),
-                            "Reply sent successfully"
-                        );
-                    }
-                    Err(_) => {
-                        tracing::error!(
-                            actor = %actor_ref.identity(),
-                            message_type = %std::any::type_name::<T>(),
-                            "Failed to send reply - receiver dropped"
-                        );
-                    }
+                // `oneshot::Sender::send` fails only when the receiver has been
+                // dropped, i.e. the caller stopped waiting for the reply before
+                // the handler finished (`ask_with_timeout` elapsed, the caller's
+                // future was cancelled, a hedged request lost the race, ...). That
+                // is a normal, caller-driven outcome — not an actor fault — and the
+                // caller side already records a dead letter. So both arms log at
+                // `debug`, never `error`, to keep routine timeouts/cancellations
+                // out of error-level monitoring.
+                let send_result = channel.send(Box::new(result));
+                #[cfg(feature = "tracing")]
+                match send_result {
+                    Ok(_) => tracing::debug!(
+                        actor = %actor_ref.identity(),
+                        "Reply sent successfully"
+                    ),
+                    Err(_) => tracing::debug!(
+                        actor = %actor_ref.identity(),
+                        message_type = %std::any::type_name::<T>(),
+                        "Reply not delivered - receiver no longer waiting"
+                    ),
                 }
+                #[cfg(not(feature = "tracing"))]
+                let _ = send_result;
             } else {
                 <A as Message<T>>::on_tell_result(&result, &actor_ref);
             }


### PR DESCRIPTION
## What

Two related logging corrections in `src/lib.rs`. No control-flow changes — only log level and routing.

### 1. Dropped-reply log: `error!` → `debug!`
When an `ask` caller stops waiting before the handler finishes (`ask_with_timeout` elapsed, the caller future was cancelled, or a hedged request lost the race), the actor's reply has nowhere to go. `oneshot::Sender::send` fails **only** when the receiver was dropped, so this path is exclusively "caller stopped waiting" — never an actor fault. It was logged **unconditionally at `error!`**, flooding error-level monitoring/alerts with routine timeouts, and the same event is **already recorded as a dead letter (`warn!`) on the caller side**. Downgraded to `debug!`, now symmetric with the success arm.

### 2. `__log_handler_error`: route through `tracing` unconditionally
It branched on the `tracing` **feature** to pick `tracing::error!` vs an `eprintln!` fallback. But that feature only gates `#[tracing::instrument]` spans, not logging, and is unrelated to whether a subscriber exists. Consequences:
- feature **off** + subscriber **on** → handler errors bypass the subscriber to stderr
- feature **on** + subscriber **off** → handler errors silently dropped

Now always uses `tracing::error!`, consistent with dead-letter logging. A handler returning `Err` is a genuine actor-side fault, so `error!` remains the right level there.

## Why
A caller-side timeout is a normal, expected outcome; logging it at `error!` on the actor side mislabels it, duplicates the caller-side dead letter at a higher severity, and pollutes error-rate/alerting signals. The `__log_handler_error` change removes a footgun where enabling/disabling the `tracing` feature silently changed whether handler errors are visible.

## Testing
- `cargo build` (default / `--features tracing`) — clean
- `cargo clippy --all-targets --all-features` and default — no warnings
- Full suite `cargo test --all-features` — **416 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)