### PR TITLE
docs: align documentation with 0.16.0 API and add migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Target release: **0.16.0**. This release reworks the actor idle / periodic-work
+model, makes the lifecycle control APIs (`stop` / `kill`) infallible, and
+hardens error reporting. Most call sites are mechanical to update — the
+compiler points at each one. See
+[Migrating from 0.15.x to 0.16.0](#migrating-from-015x-to-0160).
+
 ### ⚠️ BREAKING CHANGES
 
-- **Idle-event channel is now opt-in.** `Actor::on_idle` /
-  `ActorRef::subscribe_idle` require the actor to be spawned with
+- **`Actor::on_run` is removed and replaced by a stream-based `Actor::on_idle`.**
+  The old `on_run` future was rebuilt inside the runtime's `select!` on every
+  iteration, so any timer or await state created inside it (e.g.
+  `tokio::time::sleep`) was dropped whenever a competing branch (message
+  arrival, priority signal) won — a 1-second sleep racing sub-second message
+  traffic would never fire. The new model is a subscription: register `Stream`s
+  of events via `ActorRef::subscribe_idle` and react to each yielded event in
+  `on_idle(&mut self, event, actor_weak)`. Stream state (interval schedules,
+  channel buffers) lives in the runtime and survives `select!` cancellation, so
+  periodic work fires reliably even under message pressure, and subscriptions
+  can be added dynamically from message handlers — not only `on_start`.
+  - New **required** associated type `Actor::IdleEvent: Send + 'static`.
+    `#[derive(Actor)]` auto-fills it as `()`; manual `Actor` impls must add it.
+  - `FailurePhase::OnRun` → `OnIdle`, `FailurePhase::OnRunThenOnStop` →
+    `OnIdleThenOnStop`.
+
+- **The idle-event channel is now opt-in.** `on_idle` / `subscribe_idle`
+  require the actor to be spawned with
   `spawn_with_options(args, SpawnOptions::new().with_idle())`. The channel is
   off by default so that actors which never use idle events no longer pay for
   an always-active branch in the runtime's `select!` loop on every message.
@@ -19,24 +41,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (4.57 → 5.90 M msg/s), `tell` latency −27% (238 ns → 174 ns). `ask` is
   unaffected (dominated by two context switches).
 
-  See [Migrating from 0.15.x to 0.16.0](#migrating-from-015x-to-0160) for what
-  to change.
+- **`ActorRef::stop()` and `ActorRef::kill()` no longer return `Result<()>`.**
+  Both are idempotent, so the "always `Ok`" return type was misleading.
+  `stop()` now returns `()` (still `async`) and `kill()` returns `()`. The same
+  applies to `ActorControl::stop` (now `BoxFuture<'_, ()>`) and
+  `ActorControl::kill` (now `()`). Drop any `?`, `.unwrap()`, `.expect(...)`,
+  or `let _ =` at call sites.
+
+- **`Error` is now `#[non_exhaustive]`** and gains an
+  `Error::ChannelFull { identity, channel }` variant. `subscribe_idle` emits it
+  on bounded-buffer saturation (previously an `Error::Send` distinguishable only
+  by substring). `Error::is_retryable()` now returns `true` for `ChannelFull` in
+  addition to `Timeout`. Exhaustive `match` on `Error` must add a wildcard arm.
+
+- **`ActorResult::Failed` gains a `secondary_error: Option<T::Error>` field.**
+  It is populated for `FailurePhase::OnIdleThenOnStop` with the `on_stop`
+  cleanup error, closing a gap where a dual failure (an `on_idle` error followed
+  by an `on_stop` error) could not be recovered programmatically. New accessors
+  `ActorResult::secondary_error()` and `into_secondary_error()`. Exhaustive
+  `ActorResult::Failed { .. }` patterns must add the new field or `..`.
+
+- **`error_count` is removed** from `MetricsCollector` (`error_count`,
+  `record_error`), `MetricsSnapshot` (`error_count`), and `ActorRef`
+  (`error_count()`) — no writer for it ever existed in the framework code.
 
 ### Added
 
+- `Actor::on_idle(&mut self, event, actor_weak)` and the required associated
+  type `Actor::IdleEvent` — react to events yielded by subscribed idle streams.
+- `ActorRef::subscribe_idle(stream)` — register a `Stream` of `IdleEvent`s for
+  the actor's idle loop. Synchronous and `try_send`-based so subscribing from
+  `on_start` cannot deadlock the runtime; can also be called from message
+  handlers to attach sources dynamically.
 - `SpawnOptions::with_idle()` — enables the idle-event channel for the spawned
   actor (mirrors `with_priority()`).
 - `ActorRef::has_idle_channel()` — reports whether the idle channel is enabled.
 - `Error::IdleChannelNotEnabled` — returned by `subscribe_idle` when the actor
-  was spawned without `with_idle()`. This is a configuration error and is
-  **not** recorded as a dead letter.
+  was spawned without `with_idle()`. A configuration error; **not** recorded as
+  a dead letter.
+- `Error::ChannelFull { identity, channel }` — bounded-buffer saturation
+  (currently emitted by `subscribe_idle`). Retryable.
+- `ActorResult::secondary_error()` / `ActorResult::into_secondary_error()` —
+  recover the `on_stop` cleanup error after an `OnIdleThenOnStop` failure.
+- `Identity` now derives `Hash`, so it can be used directly as a `HashMap` key.
 
 ### Changed
 
-- `ActorWeak::upgrade` / `ActorWeak::is_alive` now treat the idle-subscribe and
-  priority channels as **secondary**: only the mailbox and terminate channels
-  are required for an upgrade to succeed (previously idle-subscribe was also
-  required).
 - **Faster `blocking_*` APIs from `async fn` contexts.** When called on a
   multi-thread Tokio runtime (e.g. from an `async fn → sync fn → blocking_*`
   bridge or from `spawn_blocking`), `blocking_tell`, `blocking_ask`,
@@ -55,34 +105,139 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `"tell"` when the slow path delegated through the async `tell`). The
   timeout case and the no-timeout case were already labeled
   `"blocking_tell"`; this aligns the remaining edge case.
+- `ActorWeak::upgrade` / `ActorWeak::is_alive` now treat the idle-subscribe and
+  priority channels as **secondary**: only the mailbox and terminate channels
+  are required for an upgrade to succeed (previously idle-subscribe was also
+  required).
+
+### Removed
+
+- `Actor::on_run` — replaced by `Actor::on_idle` (see breaking changes).
+- `MetricsCollector::error_count` / `MetricsCollector::record_error`,
+  `MetricsSnapshot::error_count`, and `ActorRef::error_count()`.
+
+### Fixed
+
+- A dropped `ask` reply (the caller timed out, was cancelled, or a hedged
+  request lost the race) was logged unconditionally at `error!`, even though it
+  is a normal caller-driven outcome already recorded as a dead letter on the
+  caller side. Downgraded to `debug!` so routine timeouts and cancellations no
+  longer flood error-level monitoring.
+- Handler errors were routed to `eprintln!` or `tracing::error!` depending on
+  the `tracing` *feature*, which only gates instrumentation spans and is
+  unrelated to whether a subscriber exists — so errors could hit stderr even
+  with a subscriber configured, or be dropped silently without one. They now
+  always route through `tracing::error!`, consistent with dead-letter logging.
 
 ### Migrating from 0.15.x to 0.16.0
 
-Things to check when upgrading:
+Most of these are mechanical; the compiler flags each affected call site.
 
-- **Do you implement `Actor::on_idle` or call `ActorRef::subscribe_idle`?**
-  - **No** → nothing to do. The idle channel is off by default and the rest of
-    the API is source-compatible.
-  - **Yes** → enable the idle channel at spawn time:
+- **`on_run` → `on_idle` (the main change).** Move periodic logic out of
+  `on_run` into a `Stream` subscribed from `on_start`, and react to its events
+  in `on_idle`:
 
-    ```rust
-    // Before (0.15.x): idle was always available
-    let (actor_ref, join) = spawn::<MyActor>(args);
+  ```rust
+  // Before (0.15.x): periodic work driven by on_run
+  impl Actor for MyActor {
+      type Args = ();
+      type Error = anyhow::Error;
 
-    // After (0.16.0): opt in explicitly
-    use rsactor::{spawn_with_options, SpawnOptions};
-    let (actor_ref, join) =
-        spawn_with_options::<MyActor>(args, SpawnOptions::new().with_idle());
-    ```
+      async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+          Ok(MyActor { interval: tokio::time::interval(Duration::from_secs(1)) })
+      }
 
-    `spawn_with_mailbox_capacity(args, n)` becomes
-    `spawn_with_options(args, SpawnOptions::new().mailbox_capacity(n).with_idle())`.
+      // Returned `bool` controlled whether on_run was called again.
+      async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
+          self.interval.tick().await;
+          self.do_periodic_work();
+          Ok(true)
+      }
+  }
 
-- **How failures surface:** without `with_idle()`, `subscribe_idle` returns
-  `Error::IdleChannelNotEnabled` (a configuration error, not a dead letter) and
-  `on_idle` is never driven. If you `?` the `subscribe_idle` result in
-  `on_start`, the actor fails to start with a clear error rather than silently
-  no-op'ing. Guard proactively with `ActorRef::has_idle_channel()` if needed.
+  // After (0.16.0): subscribe a stream, react in on_idle
+  use tokio_stream::{wrappers::IntervalStream, StreamExt};
+
+  struct Tick; // your IdleEvent type
+
+  impl Actor for MyActor {
+      type Args = ();
+      type Error = anyhow::Error;
+      type IdleEvent = Tick; // NEW: required associated type
+
+      async fn on_start(_: (), actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+          actor_ref.subscribe_idle(
+              IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
+                  .map(|_| Tick),
+          )?;
+          Ok(MyActor { /* ... */ })
+      }
+
+      async fn on_idle(&mut self, _: Tick, _: &ActorWeak<Self>) -> Result<(), Self::Error> {
+          self.do_periodic_work();
+          Ok(())
+      }
+  }
+  ```
+
+  Actors that don't do periodic work need no `on_idle`; just set
+  `type IdleEvent = ();` (or use `#[derive(Actor)]`, which fills it in).
+
+- **Enable the idle channel at spawn time** if you use `on_idle` /
+  `subscribe_idle`:
+
+  ```rust
+  // Before (0.15.x): idle was always available
+  let (actor_ref, join) = spawn::<MyActor>(args);
+
+  // After (0.16.0): opt in explicitly
+  use rsactor::{spawn_with_options, SpawnOptions};
+  let (actor_ref, join) =
+      spawn_with_options::<MyActor>(args, SpawnOptions::new().with_idle());
+  ```
+
+  `spawn_with_mailbox_capacity(args, n)` becomes
+  `spawn_with_options(args, SpawnOptions::new().mailbox_capacity(n).with_idle())`.
+
+  Without `with_idle()`, `subscribe_idle` returns `Error::IdleChannelNotEnabled`
+  (a configuration error, not a dead letter) and `on_idle` is never driven.
+  Propagating that error with `?` in `on_start` makes the actor fail to start
+  with a clear message instead of silently no-op'ing; guard proactively with
+  `ActorRef::has_idle_channel()` if needed.
+
+- **`stop()` / `kill()` are now infallible.** Remove `?` / `.unwrap()` /
+  `.expect(...)` / `let _ =`:
+
+  ```rust
+  // Before
+  actor_ref.stop().await?;
+  actor_ref.kill()?;
+
+  // After
+  actor_ref.stop().await;
+  actor_ref.kill();
+  ```
+
+- **`Error` is `#[non_exhaustive]`.** Add a wildcard arm to any exhaustive
+  `match` on `Error`, and note `is_retryable()` now also covers `ChannelFull`.
+
+- **`ActorResult::Failed` has a new field.** Exhaustive patterns must account
+  for `secondary_error`:
+
+  ```rust
+  // Before
+  ActorResult::Failed { error, phase } => { /* ... */ }
+
+  // After — add `..`, or bind the new field
+  ActorResult::Failed { error, phase, .. } => { /* ... */ }
+  ```
+
+- **`FailurePhase` variants renamed:** `OnRun` → `OnIdle`,
+  `OnRunThenOnStop` → `OnIdleThenOnStop`.
+
+- **`error_count` removed.** It never had a writer, so it always read `0`;
+  remove any reads of `MetricsSnapshot::error_count` /
+  `ActorRef::error_count()`.
 
 - **`ActorWeak` upgrade semantics:** the idle-subscribe and priority channels
   are now *secondary* — `ActorWeak::upgrade` / `is_alive` succeed based on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Testing
+- `cargo test` - Run all tests (unit and integration)
+- `cargo test --all-features` - Run tests with all features enabled
+- `cargo test --example <name>` - Test a specific example
+- `RUST_LOG=debug cargo run --example <name> --features tracing` - Run example with tracing enabled
+
+### Code Quality
+- `cargo fmt` - Format all code
+- `cargo fmt --check` - Check formatting without modifying files (CI validation)
+- `cargo clippy --all-targets --all-features -- -D warnings` - Lint with clippy (CI configuration)
+- `cargo check --all-features` - Type check without building
+
+**Before committing:** Always run `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` to ensure CI passes.
+
+### Building and Examples
+- `cargo build --all-features` - Build with all features
+- `cargo run --example <name>` - Run a specific example (see examples/ directory)
+- `cargo doc --no-deps --all-features` - Build documentation
+
+### Security and Dependencies
+- `cargo audit` - Run security audit (requires cargo-audit installation)
+
+## Repository Architecture
+
+### Core Actor Framework (src/)
+- `lib.rs` - Main library entry point, core actor system, spawn functions
+- `actor.rs` - Actor trait definition and lifecycle management
+- `actor_ref.rs` - ActorRef and ActorWeak for actor communication
+- `actor_result.rs` - ActorResult enum for lifecycle outcomes
+- `error.rs` - Error types used throughout the framework
+
+### Derive Macros (rsactor-derive/)
+- Procedural macro crate providing `#[derive(Actor)]` and `#[message_handlers]` attributes
+- Separate crate to isolate proc-macro dependencies
+
+### Key Design Patterns
+
+#### Message Handling
+Two approaches supported:
+1. **Recommended**: `#[message_handlers]` macro with `#[handler]` method attributes
+2. **Manual**: Implement `Message<T>` trait directly (for advanced use cases)
+
+#### Actor Creation
+Two patterns:
+1. **Simple**: `#[derive(Actor)]` for basic actors without complex initialization
+2. **Manual**: Implement `Actor` trait with custom `on_start` logic
+
+#### Type Safety System
+- `ActorRef<T>` provides compile-time type safety (primary usage)
+- `ActorControl` trait provides type-erased lifecycle management for heterogeneous collections
+- Handler traits (`TellHandler`, `AskHandler`) enable type-erased message sending
+- Generic actors fully supported with proper trait bounds
+
+### Testing Strategy
+- Integration tests in `tests/` directory cover various scenarios
+- Examples serve as both documentation and integration tests
+- CI runs all examples automatically to verify functionality
+- Both unit testing and actor lifecycle testing patterns supported
+
+### Feature Flags
+- `tracing` - Enables `#[tracing::instrument]` spans (logging via `tracing` crate is always available)
+- `metrics` - Actor performance metrics (message count, processing time, etc.)
+- `test-utils` - Testing utilities including dead letter counter
+- `deadlock-detection` - Runtime deadlock detection for `ask` cycles (panics on detection)
+- All examples conditionally support tracing when feature is enabled
+
+### Actor Lifecycle
+1. **Creation**: `spawn()` calls `Actor::on_start()`
+2. **Idle**: `on_idle()` reacts to events from `Stream`s registered via `ActorRef::subscribe_idle`, running concurrently with message processing. Opt-in: enable the idle channel with `SpawnOptions::with_idle()`. (Replaced the removed `on_run()` in 0.16.0.)
+3. **Termination**: `on_stop()` called during graceful/immediate shutdown
+4. **Result**: `ActorResult` enum indicates completion or failure with detailed phase information
+
+### Cross-Platform Support
+- Workspace supports multiple platforms (Linux, Windows, macOS)
+- Android cross-compilation tested in CI
+- MSRV: Rust 1.75.0+
+
+### Documentation
+- Extensive inline documentation with examples
+- FAQ.md covers common usage patterns and advanced scenarios
+- Examples demonstrate various actor patterns and use cases

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ A Simple and Efficient In-Process Actor Model Implementation for Rust.
 ### Actor Lifecycle
 Three well-defined hooks for managing actor behavior:
 - `on_start`: Initializes the actor's state (required)
-- `on_run`: Runs concurrently with message processing, returns `bool` to control repeated invocation (optional)
+- `on_idle`: Reacts to events yielded by `Stream`s registered with `subscribe_idle`, running concurrently with message processing. **Opt-in** via `SpawnOptions::with_idle()` (optional; replaced `on_run` in 0.16.0)
 - `on_stop`: Cleanup before termination, with `killed` flag for graceful vs immediate (optional)
 
-Supports **graceful termination** (`stop()`) and **immediate termination** (`kill()`), with `ActorResult` enum representing lifecycle outcomes.
+Supports **graceful termination** (`stop()`) and **immediate termination** (`kill()`) — both infallible since 0.16.0 — with the `ActorResult` enum representing lifecycle outcomes.
 
 ### Type Safety
 - **Compile-Time Safety**: `ActorRef<T>` ensures message handling consistency and prevents type-related runtime errors
@@ -66,10 +66,10 @@ Unlike broader frameworks like Actix, rsActor specializes exclusively in **local
 
 ```toml
 [dependencies]
-rsactor = "0.15" # Check crates.io for the latest version
+rsactor = "0.16" # Check crates.io for the latest version
 
 # Optional: Enable tracing support for detailed observability
-# rsactor = { version = "0.15", features = ["tracing"] }
+# rsactor = { version = "0.16", features = ["tracing"] }
 ```
 
 For using the derive macros, you'll also need the `message_handlers` attribute macro which is included by default.
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let count = actor_ref.ask(GetCount).await?;
     println!("Count: {}", count); // Prints: Count: 1
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await; // infallible since 0.16.0
     Ok(())
 }
 ```
@@ -151,9 +151,10 @@ struct CounterActor {
 impl Actor for CounterActor {
     type Args = u32; // Define an args type for actor creation
     type Error = anyhow::Error;
+    type IdleEvent = (); // No idle events; `()` when on_idle is unused (since 0.16.0)
 
     // on_start is required and must be implemented.
-    // on_run and on_stop are optional and have default implementations.
+    // on_idle and on_stop are optional and have default implementations.
     async fn on_start(initial_count: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!("CounterActor (id: {}) started. Initial count: {}", actor_ref.identity(), initial_count);
         Ok(CounterActor {
@@ -187,7 +188,7 @@ async fn main() -> Result<()> {
     let new_count: u32 = actor_ref.ask(Increment(5)).await?;
     info!("Incremented count: {}", new_count);
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await; // infallible since 0.16.0
     info!("Stop signal sent to CounterActor (ID: {})", actor_ref.identity());
 
     let actor_result = join_handle.await?;
@@ -241,7 +242,7 @@ To enable tracing support, add the `tracing` feature to your dependencies:
 
 ```toml
 [dependencies]
-rsactor = { version = "0.15", features = ["tracing"] }
+rsactor = { version = "0.16", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -281,7 +282,7 @@ Actor B handler: actor_ref_a.ask(msg).await  ← waiting for A's reply
 
 ```toml
 [dependencies]
-rsactor = { version = "0.15", features = ["deadlock-detection"] }
+rsactor = { version = "0.16", features = ["deadlock-detection"] }
 ```
 
 Detected scenarios include self-ask, 2-actor cycles (A → B → A), and indirect chains (A → B → C → A). When a cycle is found, the framework panics with a descriptive message showing the full cycle path, because deadlocks are design errors that should be fixed during development.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -33,10 +33,10 @@ This section describes the sequence of events when a user defines an actor and s
     b.  If `on_start()` returns `Ok(actor_instance)`, this instance is stored. The runtime then enters the main processing loop using `tokio::select!` to handle:
         - Messages from the mailbox (highest priority after termination)
         - Termination signals (with bias priority)
-        - The actor's `on_run()` idle handler (lowest priority, only when message queue is empty)
-    c.  The actor's `on_run()` method serves as an idle handler, called when the message queue is empty. It returns `Ok(true)` to continue idle processing, `Ok(false)` to disable it, or `Err(e)` to terminate with an error.
-    d.  If `on_start()` fails (returns `Err(e)`), the actor fails to start. The `run_actor_lifecycle` function will return `ActorResult::Failed { actor: None, error: e, phase: FailurePhase::OnStart, killed: false }`.
-    e.  When the actor terminates (due to `on_run()` errors, explicit stop/kill, or all references being dropped), the actor's `on_stop()` method is called for cleanup before the `JoinHandle` resolves to an appropriate `ActorResult`.
+        - Idle events from subscribed streams (lowest priority, only present when the idle channel is enabled and only polled when the message queue is empty)
+    c.  The idle channel is opt-in: enable it with `SpawnOptions::with_idle()` and spawn via `spawn_with_options`. When enabled, the actor registers `Stream`s of events (typically in `on_start`) via `ActorRef::subscribe_idle(stream)`. The runtime owns these streams and, whenever the mailbox is empty, calls `on_idle(&mut self, event, actor_weak)` for each yielded event. `on_idle` returns `Result<(), Error>`: `Ok(())` continues, while `Err(e)` terminates the actor. The subscribed stream itself controls cadence and termination — keeping its timer/await state alive in the runtime rather than rebuilding it each loop iteration. Without `with_idle()`, the idle arm is absent, `subscribe_idle` returns `Error::IdleChannelNotEnabled`, and `on_idle` never fires.
+    d.  If `on_start()` fails (returns `Err(e)`), the actor fails to start. The `run_actor_lifecycle` function will return `ActorResult::Failed { actor: None, error: e, secondary_error: None, phase: FailurePhase::OnStart, killed: false }`.
+    e.  When the actor terminates (due to `on_idle()` errors, explicit stop/kill, or all references being dropped), the actor's `on_stop()` method is called for cleanup before the `JoinHandle` resolves to an appropriate `ActorResult`.
 
 ## 2. Message Passing (tell/ask)
 
@@ -84,7 +84,7 @@ This section details how an actor is terminated using `ActorRef::stop` (graceful
 *   **`ControlSignal::Terminate`:** A control signal for immediate termination, sent via a dedicated, prioritized channel.
 *   **Mailbox Channel & Terminate Channel:** Used to deliver these signals.
 *   **Message Loop:** Handles these signals in its `tokio::select!` loop with biased priority for termination.
-*   **`ActorResult<A>`:** An enum (`Completed`, `Failed`) indicating the outcome of the actor's lifecycle. The `Completed` variant includes the final actor state and a `killed` flag. The `Failed` variant includes error details, failure phase, and optional actor state.
+*   **`ActorResult<A>`:** An enum (`Completed`, `Failed`) indicating the outcome of the actor's lifecycle. The `Completed` variant includes the final actor state and a `killed` flag. The `Failed` variant includes error details, an optional `secondary_error` (the `on_stop` cleanup error when the phase is `OnIdleThenOnStop`), failure phase, and optional actor state.
 *   **`JoinHandle<ActorResult<A>>`:** Resolves when the actor's task completes, providing the `ActorResult`.
 
 **Diagram:**
@@ -109,8 +109,8 @@ This section details how an actor is terminated using `ActorRef::stop` (graceful
         ii. It calls `on_stop(&actor_weak, true)` with `killed: true`.
     e.  The `JoinHandle` resolves with `ActorResult::Completed { actor: final_actor_state, killed: true }`.
 
-3.  **`on_run` returning `Err(_)`:**
-    a.  If `on_run` returns `Err(e)`, it signals a runtime failure. The message loop calls `on_stop(&actor_weak, false)` and the `JoinHandle` resolves with `ActorResult::Failed { actor: Some(final_actor_state), error: e, phase: FailurePhase::OnRun, killed: false }`.
+3.  **`on_idle` returning `Err(_)`:**
+    a.  If `on_idle` returns `Err(e)`, it signals a runtime failure. The message loop calls `on_stop(&actor_weak, false)` and the `JoinHandle` resolves with `ActorResult::Failed { actor: Some(final_actor_state), error: e, secondary_error: None, phase: FailurePhase::OnIdle, killed: false }`. If `on_stop` itself also fails during this cleanup, the phase becomes `FailurePhase::OnIdleThenOnStop` and the `on_stop` error is carried in `secondary_error`.
 
 4.  **All `ActorRef`s dropped:**
     a.  If all `ActorRef` instances for an actor are dropped, its mailbox channel will close.
@@ -159,7 +159,7 @@ This section provides a comprehensive view of the actor lifecycle from creation 
 The actor lifecycle consists of three main phases:
 
 1. **Initialization Phase**: The actor is created via `on_start()`. If this fails, no actor instance exists.
-2. **Processing Phase**: The actor processes messages and executes `on_run()` as an idle handler when the message queue is empty.
+2. **Processing Phase**: The actor processes messages and, when the idle channel is enabled via `SpawnOptions::with_idle()`, drives `on_idle()` from subscribed idle streams whenever the message queue is empty.
 3. **Termination Phase**: The actor is cleaned up via `on_stop()` before the task completes.
 
 Each phase can result in different `ActorResult` outcomes, providing detailed information about the actor's final state.
@@ -176,7 +176,7 @@ This section details how different types of errors are handled throughout the ac
 rsActor provides comprehensive error handling across all lifecycle phases:
 
 1. **Initialization Errors**: Failed `on_start()` results in no actor instance being created.
-2. **Runtime Errors**: Failed `on_run()` terminates the actor but preserves the final state.
+2. **Runtime Errors**: Failed `on_idle()` terminates the actor but preserves the final state.
 3. **Cleanup Errors**: Failed `on_stop()` is reported but doesn't prevent termination.
 4. **Message Handler Errors**: Should be handled within handlers using error reply types.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,7 +26,7 @@ A3:
 *   **Features:** Compared to Kameo, `rsActor` provides:
     - Concrete `ActorRef<T>` with compile-time type safety
     - Optional tracing support for production observability
-    - Straightforward lifecycle management with `on_start`, `on_run`, and `on_stop` hooks
+    - Straightforward lifecycle management with `on_start`, optional `on_idle`, and `on_stop` hooks
     - Both `#[message_handlers]` macro and manual `Message<T>` trait implementation
 *   **Error Handling:** Uses `ActorResult` enum to indicate startup or runtime failures with detailed error information and failure phases.
 
@@ -50,7 +50,7 @@ A4: To define an actor, you can choose between two approaches:
     *   Defining an associated type `Args` (the type of arguments your `on_start` method will take).
     *   Defining an associated type `Error` (the error type your actor's lifecycle methods can return).
     *   Implementing an `on_start` method which initializes your actor from the arguments.
-    *   Implementing `on_run` and `on_stop` methods, which are optional and have default implementations.
+    *   Implementing `on_idle` and `on_stop` methods, which are optional and have default implementations.
 4.  Define the message types your actor will handle.
 5.  For each message type, implement the `Message<MessageType>` trait for your actor struct.
 6.  Use the `#[message_handlers]` macro to implement message handling, or the deprecated `impl_message_handler!` macro.
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Current count: {}", current_count);
 
     // Gracefully stop the actor
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     Ok(())
 }
 ```
@@ -222,7 +222,7 @@ A8: To stop an actor, you can use:
 
 1.  **Graceful Stop**:
     ```rust
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     ```
     This sends a stop signal to the actor and waits for it to shut down cleanly. The actor will continue processing its current message, then call `on_stop` before terminating.
 
@@ -346,7 +346,7 @@ A11: The lifecycle of an actor in `rsActor` follows these stages:
 
 2.  **Running**:
     *   The actor processes messages from its mailbox.
-    *   The `on_run` idle handler is called when the message queue is empty.
+    *   The `on_idle` handler is called for each event yielded by a `Stream` registered via `ActorRef::subscribe_idle`, but only while the mailbox is empty. Messages always have priority over idle events.
     *   This continues until the actor is stopped or encounters an error.
 
 3.  **Termination**:
@@ -356,11 +356,11 @@ A11: The lifecycle of an actor in `rsActor` follows these stages:
 The actor's lifecycle methods are:
 
 *   `on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error>`: Called when the actor is starting. Creates and returns the actor instance.
-*   `on_run(&mut self, actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error>`: Called when the message queue is empty (idle handler).
-    *   If `on_run` returns `Ok(true)`, the actor continues calling `on_run` when idle.
-    *   If `on_run` returns `Ok(false)`, idle processing is disabled; the actor only processes messages.
-    *   If `on_run` returns `Err(e)`, the actor terminates due to a runtime error, resulting in `ActorResult::Failed` with `phase: FailurePhase::OnRun`.
-*   `on_stop(&mut self, actor_weak: &ActorWeak<Self>, killed: bool) -> Result<(), Self::Error>`: Called when the actor is stopping (including after `on_run` errors). The `killed` parameter is `true` if the actor was killed, and `false` if it was stopped gracefully.
+*   `on_idle(&mut self, event: Self::IdleEvent, actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error>`: Called for each event yielded by a `Stream` registered via `ActorRef::subscribe_idle`, but only while the mailbox is empty.
+    *   Requires the associated type `Actor::IdleEvent` (set to `()` when there is no idle work; `#[derive(Actor)]` fills this in automatically).
+    *   Requires the idle channel to be enabled at spawn time via `SpawnOptions::new().with_idle()`. Without it, `subscribe_idle` returns `Error::IdleChannelNotEnabled` and `on_idle` is never called. Check at runtime with `actor_ref.has_idle_channel()`.
+    *   If `on_idle` returns `Err(e)`, the actor terminates due to a runtime error, resulting in `ActorResult::Failed` with `phase: FailurePhase::OnIdle`.
+*   `on_stop(&mut self, actor_weak: &ActorWeak<Self>, killed: bool) -> Result<(), Self::Error>`: Called when the actor is stopping (including after `on_idle` errors). The `killed` parameter is `true` if the actor was killed, and `false` if it was stopped gracefully.
 
 **Q12: What is the `ActorResult` enum?**
 
@@ -373,16 +373,16 @@ A12: The `ActorResult` enum represents the outcome of an actor's lifecycle when 
 
 2.  **`ActorResult::Failed`**:
     *   Indicates that the actor failed during its lifecycle.
-    *   Contains the optional actor state (`actor: Option<A>`), the error that caused the failure (`error: E`), the phase in which the failure occurred (`phase: FailurePhase`), and a boolean `killed` indicating whether the actor was killed.
-    *   The `FailurePhase` can be `OnStart`, `OnRun`, or `OnStop`.
+    *   Contains the optional actor state (`actor: Option<A>`), the error that caused the failure (`error: E`), an optional secondary error (`secondary_error: Option<E>`, the `on_stop` cleanup error when the phase is `OnIdleThenOnStop`), the phase in which the failure occurred (`phase: FailurePhase`), and a boolean `killed` indicating whether the actor was killed.
+    *   The `FailurePhase` can be `OnStart`, `OnIdle`, `OnStop`, or `OnIdleThenOnStop`.
 
 **Q13: How do I handle errors in actors?**
 
 A13: Error handling in `rsActor` happens at several levels:
 
-*   **Lifecycle - `on_start`:** If `on_start` returns `Err(e)`, the actor never starts, and the `JoinHandle` will resolve to `ActorResult::Failed { actor: None, error: e, phase: FailurePhase::OnStart, killed: false }`. Since the actor wasn't created, the `actor` field is `None`.
-*   **Lifecycle - `on_run`:** If `on_run` returns `Err(e)`, the actor will terminate after calling `on_stop` for cleanup, and the `JoinHandle` will resolve to `ActorResult::Failed { actor: Some(actor_state), error: e, phase: FailurePhase::OnRun, killed: false }`. The `actor` field contains the actor's state.
-*   **Panics:** If a message handler or `on_run` panics, the Tokio task hosting the actor will terminate. Awaiting the `JoinHandle` will then result in an `Err` (typically a `tokio::task::JoinError` indicating a panic). It's generally recommended to handle errors gracefully within your actor logic and return `Result` types from `on_start` and `on_run`, and use `Result` as reply types for messages where appropriate, rather than relying on panics.
+*   **Lifecycle - `on_start`:** If `on_start` returns `Err(e)`, the actor never starts, and the `JoinHandle` will resolve to `ActorResult::Failed { actor: None, error: e, secondary_error: None, phase: FailurePhase::OnStart, killed: false }`. Since the actor wasn't created, the `actor` field is `None`.
+*   **Lifecycle - `on_idle`:** If `on_idle` returns `Err(e)`, the actor will terminate after calling `on_stop` for cleanup, and the `JoinHandle` will resolve to `ActorResult::Failed { actor: Some(actor_state), error: e, secondary_error: None, phase: FailurePhase::OnIdle, killed: false }`. The `actor` field contains the actor's state.
+*   **Panics:** If a message handler or `on_idle` panics, the Tokio task hosting the actor will terminate. Awaiting the `JoinHandle` will then result in an `Err` (typically a `tokio::task::JoinError` indicating a panic). It's generally recommended to handle errors gracefully within your actor logic and return `Result` types from `on_start` and `on_idle`, and use `Result` as reply types for messages where appropriate, rather than relying on panics.
 *   **Message Handling:** For message handling, the `Message<T>::handle` method can return any type as its `Reply`, including a `Result` type. If your message handler might fail, it's a good practice to use a `Result` type as the `Reply` type.
 *   **Sending Messages:** The methods for sending messages (`ask`, `tell`, etc.) return `Result<R, rsactor::Error>`, where `R` is the reply type of the message. These methods can fail if the actor has stopped, the mailbox is full, or a timeout occurs.
 
@@ -512,7 +512,7 @@ A15: Testing actors can be done in several ways:
         let count = actor_ref.ask(GetCount).await.unwrap();
         assert_eq!(count, 5);
 
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
     }
     ```
 
@@ -530,7 +530,7 @@ A15: Testing actors can be done in several ways:
         assert_eq!(count, 10);
 
         // Stop actor gracefully - on_stop is called
-        actor_ref.stop().await.unwrap();
+        actor_ref.stop().await;
 
         // Await handle to get ActorResult
         let result = handle.await.unwrap();
@@ -918,109 +918,126 @@ With the generic syntax, you specify the generic constraints in square brackets,
 
 **Note:** The `#[message_handlers]` macro approach is recommended over `impl_message_handler!` as it provides better ergonomics and reduces boilerplate.
 
-**Q22: How can I effectively use the `on_run` method in my actors?**
+**Q22: How can I effectively use the `on_idle` method in my actors?**
 
-A22: The `on_run` method is an idle handler in the `rsActor` framework, called when the actor's message queue is empty. It returns `Result<bool, Error>` to control idle processing:
-*   `Ok(true)` - Continue calling `on_run` when idle
-*   `Ok(false)` - Disable idle processing; actor only processes messages
-*   `Err(e)` - Terminate with an error
+A22: The `on_idle` method is an idle handler in the `rsActor` framework. Instead of being polled in a loop, it is driven by `Stream`s you register with `ActorRef::subscribe_idle`. The runtime drives those streams and calls `on_idle` once for each event they yield, but only while the mailbox is empty — messages always have priority over idle events, ensuring the actor stays responsive. The handler returns `Result<(), Error>`; returning `Err(e)` terminates the actor with `phase: FailurePhase::OnIdle`.
+
+To use `on_idle` you must:
+*   Declare the associated type `Actor::IdleEvent`, the type of event the streams yield. Set it to `()` when there is no idle work; `#[derive(Actor)]` fills it in as `()` automatically.
+*   Enable the idle channel at spawn time, since it is **opt-in**: spawn with `spawn_with_options(args, SpawnOptions::new().with_idle())`. Without `with_idle()`, `subscribe_idle` returns `Error::IdleChannelNotEnabled` and `on_idle` is never called. Check at runtime with `actor_ref.has_idle_channel()`.
+*   Register one or more streams with `actor_ref.subscribe_idle(stream)`, typically in `on_start` (it is also valid from message handlers). Map each stream's items to your `IdleEvent` type.
 
 Here's how to use it effectively:
 
-*   **Idle Processing:** The `on_run` method is called when there are no messages to process. Messages always have priority over idle processing, ensuring the actor stays responsive.
-
-*   **Periodic Tasks:** You can implement periodic tasks by using `tokio::time` utilities within the `on_run`. For example:
+*   **Periodic Tasks:** Subscribe interval streams that yield tick events. Each tick is delivered to `on_idle` only while the mailbox is empty:
 
     ```rust
+    use futures::stream::StreamExt;
+    use tokio_stream::wrappers::IntervalStream;
+    use std::time::Duration;
+
+    #[derive(Debug, Clone, Copy)]
+    enum Tick {
+        Fast,
+        Slow,
+    }
+
     struct MyActor {
         // ... other fields ...
-        fast_interval: tokio::time::Interval,
-        slow_interval: tokio::time::Interval,
     }
 
-    // Initialize intervals in on_start
-    async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(MyActor {
-            // ... initialize other fields ...
-            fast_interval: tokio::time::interval(std::time::Duration::from_millis(500)),
-            slow_interval: tokio::time::interval(std::time::Duration::from_secs(5)),
-        })
-    }
+    impl Actor for MyActor {
+        type Args = ();
+        type Error = anyhow::Error;
+        type IdleEvent = Tick;
 
-    // Idle handler - called when message queue is empty
-    async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        tokio::select! {
-            _ = self.fast_interval.tick() => {
-                // Handle high-frequency tasks (every 500ms)
-                self.process_high_frequency_work();
-            }
-            _ = self.slow_interval.tick() => {
-                // Handle low-frequency tasks (every 5s)
-                self.process_low_frequency_work();
-            }
+        // Subscribe periodic streams in on_start
+        async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+            actor_ref.subscribe_idle(
+                IntervalStream::new(tokio::time::interval(Duration::from_millis(500)))
+                    .map(|_| Tick::Fast),
+            )?;
+            actor_ref.subscribe_idle(
+                IntervalStream::new(tokio::time::interval(Duration::from_secs(5)))
+                    .map(|_| Tick::Slow),
+            )?;
+            Ok(MyActor { /* ... initialize fields ... */ })
         }
-        Ok(true) // Continue idle processing
+
+        // Idle handler - called for each yielded event while the mailbox is empty
+        async fn on_idle(&mut self, event: Tick, _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+            match event {
+                Tick::Fast => self.process_high_frequency_work(), // every 500ms
+                Tick::Slow => self.process_low_frequency_work(),  // every 5s
+            }
+            Ok(())
+        }
     }
     ```
 
-*   **Consuming Events:** The `on_run` method is ideal for processing events from channels or streams:
+*   **Consuming Events:** Subscribe a stream wrapping a channel or other event source and handle each item in `on_idle`. Do not loop inside a single `on_idle` call — return after handling one event and the runtime will call you again for the next:
 
     ```rust
+    use futures::stream::StreamExt;
+    use tokio_stream::wrappers::ReceiverStream;
+
     struct EventProcessorActor {
-        events_rx: mpsc::Receiver<Event>,
+        // ... other fields ...
     }
 
     impl Actor for EventProcessorActor {
-        // ...
+        type Args = mpsc::Receiver<Event>;
+        type Error = anyhow::Error;
+        type IdleEvent = Event;
 
-        async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-            tokio::select! {
-                Some(event) = self.events_rx.recv() => {
-                    self.process_event(event)?;
-                    Ok(true) // Continue processing
-                }
-                else => {
-                    // Channel closed, stop idle processing
-                    Ok(false)
-                }
-            }
+        async fn on_start(events_rx: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+            actor_ref.subscribe_idle(ReceiverStream::new(events_rx))?;
+            Ok(EventProcessorActor { /* ... */ })
+        }
+
+        async fn on_idle(&mut self, event: Event, _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+            self.process_event(event)?;
+            Ok(())
         }
     }
     ```
 
-*   **Background Processing:** Use `on_run` for background processing tasks:
+*   **Background Processing:** Map a stream to a unit event and drain a work queue one item per call. Returning `Ok(())` lets the runtime deliver the next event:
 
     ```rust
-    async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Process one batch of work items
+    async fn on_idle(&mut self, _event: (), _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        // Process one batch of work items per call
         if let Some(work_item) = self.queue.pop() {
             self.process_work_item(work_item)?;
-            Ok(true) // Continue processing
-        } else {
-            // No work to do, disable idle processing until new work arrives via messages
-            Ok(false)
         }
+        Ok(())
     }
     ```
 
-*   **Combine multiple sources with `tokio::select!`:** You can wait on multiple event sources concurrently:
+*   **Combine multiple sources:** Subscribe several streams, each mapped to a variant of a shared `IdleEvent` enum. The runtime merges them and dispatches each yielded event to `on_idle`:
 
     ```rust
-    async fn on_run(&mut self, actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        tokio::select! {
-            Some(msg) = self.command_rx.recv() => {
-                self.handle_command(msg)?;
-                Ok(true) // Continue
-            }
-            _ = self.health_check_interval.tick() => {
-                self.perform_health_check()?;
-                Ok(true) // Continue
-            }
-            else => {
-                // All channels are closed, disable idle processing
-                Ok(false)
-            }
+    #[derive(Debug)]
+    enum IdleEvent {
+        Command(Command),
+        HealthCheck,
+    }
+
+    async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        actor_ref.subscribe_idle(command_stream.map(IdleEvent::Command))?;
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_secs(10)))
+                .map(|_| IdleEvent::HealthCheck),
+        )?;
+        Ok(Self { /* ... */ })
+    }
+
+    async fn on_idle(&mut self, event: IdleEvent, _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        match event {
+            IdleEvent::Command(cmd) => self.handle_command(cmd)?,
+            IdleEvent::HealthCheck => self.perform_health_check()?,
         }
+        Ok(())
     }
     ```
 
@@ -1146,7 +1163,7 @@ A24: rsActor provides a comprehensive type safety system for actor messaging thr
 
      // Stop all actors gracefully
      for control in &controls {
-         control.stop().await?;
+         control.stop().await;
      }
 
      // Or store handlers for specific message types

--- a/docs/actor_model.md
+++ b/docs/actor_model.md
@@ -89,50 +89,62 @@ While the actor model is well-known for its applicability in distributed systems
 
 Libraries like `rsactor` (see `https://github.com/hiking90/rsactor`) provide simple and efficient in-process actor model implementations for Rust. They simplify the definition of actors, their state, message types, and message handling logic, allowing developers to focus on the application's business logic rather than the boilerplate of actor machinery. For example, you might define an actor that manages a specific resource or performs a particular computation, and other parts of your application would interact with it solely by sending it messages and, where appropriate, receiving responses via messages.
 
-Here's a conceptual example using `rsactor`, demonstrating an actor with an `on_run` idle handler processing multiple tick sources:
+Here's a conceptual example using `rsactor`, demonstrating an actor with an `on_idle` handler that reacts to multiple tick sources subscribed via `subscribe_idle`:
 
 ```rust
-use rsactor::{Actor, ActorRef, ActorWeak, message_handlers, spawn};
+use rsactor::{Actor, ActorRef, ActorWeak, message_handlers, spawn_with_options, SpawnOptions};
 use anyhow::Result;
+use futures::stream::StreamExt;
 use tokio::time::{interval, Duration};
+use tokio_stream::wrappers::IntervalStream;
+
+// Idle event type yielded by the subscribed streams.
+#[derive(Debug, Clone, Copy)]
+enum Tick {
+    FastTick, // emitted every 300ms
+    SlowTick, // emitted every 1 second
+}
 
 // Define actor struct
 struct CounterActor {
-    count: u32,                        // Stores the counter value
-    tick_300ms: tokio::time::Interval, // 300ms interval timer
-    tick_1s: tokio::time::Interval,    // 1 second interval timer
+    count: u32, // Stores the counter value
 }
 
 // Implement Actor trait for complex initialization
 impl Actor for CounterActor {
     type Args = (); // No arguments needed for this actor
     type Error = anyhow::Error; // Define the error type for actor operations
+    type IdleEvent = Tick; // Events delivered to on_idle
 
-    // Initialize the actor with intervals
-    async fn on_start(_args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(CounterActor {
-            count: 0,
-            tick_300ms: interval(Duration::from_millis(300)),
-            tick_1s: interval(Duration::from_secs(1)),
-        })
+    // Initialize the actor and subscribe its idle streams.
+    async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        // Register two periodic streams; the runtime drives them and calls
+        // on_idle for each yielded event while the mailbox is empty.
+        actor_ref.subscribe_idle(
+            IntervalStream::new(interval(Duration::from_millis(300))).map(|_| Tick::FastTick),
+        )?;
+        actor_ref.subscribe_idle(
+            IntervalStream::new(interval(Duration::from_secs(1))).map(|_| Tick::SlowTick),
+        )?;
+
+        Ok(CounterActor { count: 0 })
     }
 
-    // Idle handler called when the message queue is empty.
-    // This demonstrates handling two independent, periodic events using tokio::select!.
-    async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Use the tokio::select! macro to handle the first completed asynchronous operation among several.
-        tokio::select! {
-            // Executes when the 300ms interval timer ticks.
-            _ = self.tick_300ms.tick() => {
+    // Idle handler called for each event from a subscribed stream, but only
+    // while the message queue is empty.
+    // This demonstrates handling two independent, periodic event sources.
+    async fn on_idle(&mut self, event: Tick, _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        match event {
+            // Triggered by the 300ms stream.
+            Tick::FastTick => {
                 self.count += 1; // Increment the counter value by 1.
             }
-            // Executes when the 1s interval timer ticks. (Currently no specific action)
-            _ = self.tick_1s.tick() => {
+            // Triggered by the 1s stream. (Currently no specific action)
+            Tick::SlowTick => {
                 // Could implement different behavior here
             }
         }
-        // Return Ok(true) to continue idle processing, Ok(false) to disable it
-        Ok(true)
+        Ok(())
     }
 }
 
@@ -157,10 +169,12 @@ impl CounterActor {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Spawn the CounterActor and get an ActorRef and JoinHandle.
-    let (actor_ref, join_handle) = spawn::<CounterActor>(());
+    // Spawn the CounterActor with the idle channel enabled (off by default)
+    // and get an ActorRef and JoinHandle.
+    let (actor_ref, join_handle) =
+        spawn_with_options::<CounterActor>((), SpawnOptions::new().with_idle());
 
-    // Allow some time for the actor's on_run to emit a few ticks.
+    // Allow some time for the actor's on_idle handler to process a few ticks.
     tokio::time::sleep(Duration::from_millis(1200)).await; // Wait for ~4 of 300ms ticks and ~1 of 1s ticks
 
     // Send an IncrementMsg to the actor to increment the counter by 5 and await the reply.
@@ -179,7 +193,7 @@ async fn main() -> Result<()> {
     println!("Final count: {}", final_count);
 
     // Gracefully stop the actor.
-    actor_ref.stop().await?; // Gracefully stop the actor
+    actor_ref.stop().await; // Gracefully stop the actor
 
     // Await the actor's termination using the join_handle and print the result.
     let actor_result = join_handle.await?;
@@ -194,7 +208,7 @@ async fn main() -> Result<()> {
                 killed
             );
         }
-        rsactor::ActorResult::Failed { actor, error, phase, killed } => {
+        rsactor::ActorResult::Failed { actor, error, phase, killed, .. } => {
             if let Some(actor_state) = actor {
                 println!(
                     "Main: CounterActor (ID: {}) task failed during phase {:?}. Final state count: {}. Error: {:?}. Killed: {}",
@@ -219,25 +233,26 @@ async fn main() -> Result<()> {
 }
 ```
 In this example:
-- `CounterActor` maintains a `count` and two interval timers as struct fields.
+- `CounterActor` maintains a `count` as its only struct field.
 - The `Actor` trait is implemented:
-    - `on_start` initializes the actor with its state and interval timers.
-    - `on_run` is the idle handler, called when the message queue is empty. It uses `tokio::select!` to wait on two `tokio::time::interval` ticks (300ms and 1 second).
-        - The 300ms tick increments the actor's internal `count`.
-        - The 1s tick performs no specific action in this example.
-        - Return `Ok(true)` to continue idle processing, `Ok(false)` to disable it.
+    - The associated `type IdleEvent = Tick` declares the event type delivered to the idle handler.
+    - `on_start` initializes the actor's state and subscribes two periodic streams via `actor_ref.subscribe_idle(...)`, each mapping its ticks to a `Tick` variant (300ms to `FastTick`, 1 second to `SlowTick`).
+    - `on_idle` is the idle handler, called once per event yielded by a subscribed stream, but only while the message queue is empty. It uses a `match` on the `Tick` event to dispatch the two sources.
+        - The `FastTick` event increments the actor's internal `count`.
+        - The `SlowTick` event performs no specific action in this example.
+        - It returns `Ok(())` on success; returning an `Err` would terminate the actor.
 - Message types `IncrementMsg(u32)` and `GetCountMsg` are defined to interact with the counter.
 - The `#[message_handlers]` macro with `#[handler]` attributes automatically generates `Message` trait implementations and `MessageHandler` trait implementation for these messages.
 - The `main` function:
-    - Spawns the `CounterActor`.
-    - Waits briefly to allow the `on_run` idle handler to execute a few times.
+    - Spawns the `CounterActor` with `spawn_with_options`, enabling the idle channel via `SpawnOptions::new().with_idle()` (it is off by default, and `subscribe_idle`/`on_idle` only function when it is enabled).
+    - Waits briefly to allow the `on_idle` handler to process a few ticks.
     - Sends `IncrementMsg` and `GetCountMsg` to interact with the actor, logging replies.
     - Waits again for more ticks.
     - Sends `GetCountMsg` again to observe changes from both messages and internal ticks.
     - Gracefully stops the actor using `actor_ref.stop()`.
     - Awaits the actor's `join_handle` to ensure clean termination and logs the outcome.
 
-This revised example aligns with the `rsactor` patterns shown in its `README.md` and `lib.rs` documentation, particularly showcasing how the `on_run` method serves as an idle handler that processes background tasks when the message queue is empty, a key feature of the in-process actor model.
+This revised example aligns with the `rsactor` patterns shown in its `README.md` and `lib.rs` documentation, particularly showcasing how the `on_idle` handler, fed by streams registered through `subscribe_idle`, processes background tasks when the message queue is empty, a key feature of the in-process actor model.
 
 ## The Premier Choice for Mutex-Light Concurrency in Rust
 

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -100,30 +100,51 @@ impl Actor for FileProcessor {
 }
 ```
 
-### 3. Use `on_run` for Idle Processing
+### 3. Use `on_idle` for Idle Processing
 
-The `on_run` method is an idle handler called when the message queue is empty. Use it for background tasks:
+The `on_idle` method is an idle handler driven by `Stream`s registered via `ActorRef::subscribe_idle` (typically in `on_start`). The runtime drives the streams and calls `on_idle` once per yielded event, concurrently with message processing. The idle channel is opt-in: spawn with `SpawnOptions::new().with_idle()`. Use it for background tasks such as periodic cleanup or health checks:
 
 ```rust
-async fn on_run(&mut self, actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-    tokio::select! {
-        // Handle periodic cleanup
-        _ = self.cleanup_interval.tick() => {
-            self.cleanup_expired_entries().await?;
-        }
+// An event type that distinguishes the different idle triggers.
+#[derive(Debug, Clone, Copy)]
+enum Tick {
+    Cleanup,
+    HealthCheck,
+}
 
-        // Handle health checks
-        _ = self.health_check_interval.tick() => {
-            if !self.is_healthy().await? {
-                // Consider stopping the actor or alerting
-                let actor_ref = actor_weak.upgrade()
-                    .ok_or_else(|| anyhow::anyhow!("Actor reference no longer valid"))?;
-                actor_ref.stop().await?;
-                return Ok(false); // Stop idle processing
+impl Actor for MyActor {
+    type IdleEvent = Tick;
+    // ... other associated types ...
+
+    async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        // Register one stream per periodic concern; they are merged into on_idle.
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_secs(60)))
+                .map(|_| Tick::Cleanup),
+        )?;
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_secs(10)))
+                .map(|_| Tick::HealthCheck),
+        )?;
+        Ok(Self { /* ... */ })
+    }
+
+    async fn on_idle(&mut self, event: Tick, actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        match event {
+            Tick::Cleanup => {
+                self.cleanup_expired_entries().await?;
+            }
+            Tick::HealthCheck => {
+                if !self.is_healthy().await? {
+                    // Consider stopping the actor or alerting
+                    let actor_ref = actor_weak.upgrade()
+                        .ok_or_else(|| anyhow::anyhow!("Actor reference no longer valid"))?;
+                    actor_ref.stop().await;
+                }
             }
         }
+        Ok(())
     }
-    Ok(true) // Continue idle processing
 }
 ```
 
@@ -159,20 +180,20 @@ let (actor_ref, join_handle) = spawn::<MyActor>(args);
 
 // ... use actor ...
 
-actor_ref.stop().await?;
+actor_ref.stop().await;
 
 match join_handle.await? {
     ActorResult::Completed { actor, killed } => {
         println!("Actor completed successfully");
         // Access final actor state if needed
     }
-    ActorResult::Failed { error, phase, actor, killed } => {
+    ActorResult::Failed { error, phase, actor, killed, .. } => {
         match phase {
             FailurePhase::OnStart => {
                 eprintln!("Actor failed to start: {}", error);
                 // No actor state available
             }
-            FailurePhase::OnRun => {
+            FailurePhase::OnIdle => {
                 eprintln!("Actor failed during runtime: {}", error);
                 // Actor state available for inspection/recovery
                 if let Some(actor_state) = actor {
@@ -264,7 +285,7 @@ async fn test_counter_actor() {
     let count = actor_ref.ask(GetCount).await.unwrap();
     assert_eq!(count, 6);
 
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
 }
 ```
 
@@ -415,7 +436,7 @@ let (actor_ref, join_handle) = spawn::<MyActor>(args);
 // ... use actor ...
 
 // Always handle termination
-actor_ref.stop().await?;
+actor_ref.stop().await;
 let result = join_handle.await?;
 match result {
     ActorResult::Completed { .. } => println!("Actor completed successfully"),

--- a/docs/creation.puml
+++ b/docs/creation.puml
@@ -10,7 +10,7 @@ participant "mpsc::channel (terminate)" as TerminateChannel
 participant "tokio::spawn" as tokio_spawn
 participant "run_actor_lifecycle()" as run_lifecycle
 participant "Actor::on_start(Args)" as on_start_method
-participant "Actor::on_run()" as on_run_method
+participant "Actor::on_idle()" as on_idle_method
 
 User -> UserActor: Defines struct & impl Actor (with Args)
 User -> UserActor: Uses #[message_handlers] macro for message handling
@@ -40,17 +40,16 @@ alt on_start Success
     Main loop handles (biased priority):
     1. Termination signals (highest)
     2. Mailbox messages
-    3. on_run() idle handler (when queue empty)
+    3. on_idle() handler (idle events from subscribed streams, when queue empty; opt-in via with_idle())
   end note
 
-  run_lifecycle -> on_run_method: Calls actor.on_run(&actor_weak).await (when idle)
-  activate on_run_method
-  on_run_method --> run_lifecycle: Returns Result<bool, Error>
-  deactivate on_run_method
+  run_lifecycle -> on_idle_method: Calls actor.on_idle(event, &actor_weak).await (when idle)
+  activate on_idle_method
+  on_idle_method --> run_lifecycle: Returns Result<(), Error>
+  deactivate on_idle_method
 
   note right of run_lifecycle
-    Ok(true): continue calling on_run when idle
-    Ok(false): disable idle processing
+    Ok(()): handled; keep processing
     Err: terminate with ActorResult::Failed
   end note
 

--- a/docs/deadlock_detection.md
+++ b/docs/deadlock_detection.md
@@ -32,7 +32,7 @@ Actor A handler: actor_ref_a.ask(msg).await  ← waiting for own reply
                                                 but own loop is paused = deadlock
 ```
 
-This problem applies to all lifecycle hooks (`on_start`, message handlers, `on_run`, `on_stop`) — any `ask` call from within an actor context can participate in a cycle.
+This problem applies to all lifecycle hooks (`on_start`, message handlers, `on_idle`, `on_stop`) — any `ask` call from within an actor context can participate in a cycle.
 
 ## How It Works
 

--- a/docs/debugging_guide.md
+++ b/docs/debugging_guide.md
@@ -144,7 +144,7 @@ async fn test_dead_letter_tracking() {
     let initial = dead_letter_count();
 
     let (actor_ref, handle) = spawn::<MyActor>(MyActor);
-    actor_ref.stop().await.unwrap();
+    actor_ref.stop().await;
     handle.await.unwrap();
 
     // This will generate a dead letter
@@ -335,7 +335,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Stop the actor
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     handle.await?;
 
     // This will generate a dead letter (logged automatically)

--- a/docs/error_handling.puml
+++ b/docs/error_handling.puml
@@ -6,7 +6,7 @@ participant "ActorRef<T>" as ActorRef
 participant "JoinHandle" as JoinHandle
 participant "Actor" as Actor
 participant "on_start()" as OnStart
-participant "on_run()" as OnRun
+participant "on_idle()" as OnIdle
 participant "on_stop()" as OnStop
 
 == Scenario 1: Initialization Failure ==
@@ -33,16 +33,16 @@ activate JoinHandle
 JoinHandle --> Client: ActorResult::Failed { phase: OnStart, actor: None, ... }
 deactivate JoinHandle
 
-== Scenario 2: Runtime Failure in on_run ==
-note over Actor: Actor is running normally (on_run is idle handler)
-Actor -> OnRun: on_run() called when message queue empty
-activate OnRun
-OnRun -> OnRun: Runtime error occurs (e.g., resource exhaustion)
-OnRun --> Actor: Err(RuntimeError)
-deactivate OnRun
+== Scenario 2: Runtime Failure in on_idle ==
+note over Actor: Actor is running normally (on_idle is idle handler)
+Actor -> OnIdle: on_idle(event) called when message queue empty (subscribed stream yields)
+activate OnIdle
+OnIdle -> OnIdle: Runtime error occurs (e.g., resource exhaustion)
+OnIdle --> Actor: Err(RuntimeError)
+deactivate OnIdle
 
 note over Actor, OnStop
-  When on_run returns an error:
+  When on_idle returns an error:
   - on_stop IS called for cleanup
   - on_stop errors are logged but don't change the result
   - The actor terminates with ActorResult::Failed
@@ -53,12 +53,12 @@ activate OnStop
 OnStop --> Actor: Returns (logged if error)
 deactivate OnStop
 
-Actor --> JoinHandle: ActorResult::Failed { phase: OnRun, actor: Some(actor), error, killed }
+Actor --> JoinHandle: ActorResult::Failed { phase: OnIdle, actor: Some(actor), error, killed, .. }
 
 note right of JoinHandle
   Runtime Failure:
   - Actor instance available for inspection
-  - phase is FailurePhase::OnRun
+  - phase is FailurePhase::OnIdle
   - on_stop WAS called for cleanup
   - killed reflects termination state at error time
 end note
@@ -101,7 +101,7 @@ loop Error Recovery Pattern
         alt FailurePhase::OnStart
             Client -> Client: Fix initialization parameters
             Client -> ActorRef: spawn(corrected_args) [retry with fixes]
-        else FailurePhase::OnRun
+        else FailurePhase::OnIdle
             Client -> Client: Handle runtime state if available
             note right of Client
               Runtime failures provide actor state:
@@ -168,15 +168,16 @@ note over Client, OnStop
      - Use ? operator for early returns
      - Provide meaningful error messages
 
-  2. Runtime (on_run - idle handler):
+  2. Runtime (on_idle - idle handler):
+     - Driven by subscribe_idle() streams; opt-in via with_idle()
      - Called when message queue is empty
-     - Return Ok(true) to continue, Ok(false) to disable
+     - Return Ok(()) when handled; keep running
      - Handle recoverable errors gracefully
      - Use timeouts for external operations
-     - on_stop IS called for cleanup if on_run fails
+     - on_stop IS called for cleanup if on_idle fails
 
   3. Cleanup (on_stop):
-     - Called for stop/kill, ActorRef drop, or on_run error
+     - Called for stop/kill, ActorRef drop, or on_idle error
      - Use Drop trait for additional guaranteed cleanup
      - Differentiate between graceful and forced termination
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let count = actor_ref.ask(GetCount).await?;
     println!("Count: {}", count); // Prints: Count: 1
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     Ok(())
 }
 ```
@@ -68,8 +68,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 For actors that need complex initialization logic:
 
 ```rust
-use rsactor::{Actor, ActorRef, ActorWeak, message_handlers, spawn};
+use rsactor::{Actor, ActorRef, ActorWeak, SpawnOptions, message_handlers, spawn_with_options};
 use anyhow::Result;
+use futures::stream::StreamExt;
+use std::time::Duration;
+use tokio_stream::wrappers::IntervalStream;
+
+// Idle event delivered to on_idle on every tick
+#[derive(Debug, Clone, Copy)]
+struct Heartbeat;
 
 // Define actor struct
 struct CounterActor {
@@ -81,6 +88,8 @@ struct CounterActor {
 impl Actor for CounterActor {
     type Args = (u32, String); // Tuple of initial count and name
     type Error = anyhow::Error;
+    // IdleEvent is the type yielded by streams registered via subscribe_idle
+    type IdleEvent = Heartbeat;
 
     // on_start is required - this is where the actor instance is created
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
@@ -88,18 +97,23 @@ impl Actor for CounterActor {
         println!("CounterActor '{}' (ID: {}) starting with count: {}",
                  name, actor_ref.identity(), initial_count);
 
+        // Register a stream of idle events; the runtime drives it and calls
+        // on_idle for each yielded `Heartbeat`. Requires `with_idle()` at spawn.
+        actor_ref.subscribe_idle(
+            IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
+                .map(|_| Heartbeat),
+        )?;
+
         Ok(CounterActor {
             count: initial_count,
             name,
         })
     }
 
-    // on_run is optional - idle handler called when message queue is empty
-    async fn on_run(&mut self, _actor_weak: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Called when there are no messages to process
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    // on_idle is optional - called for each event yielded by a subscribed idle stream
+    async fn on_idle(&mut self, _event: Heartbeat, _actor_weak: &ActorWeak<Self>) -> Result<(), Self::Error> {
         println!("Actor '{}' heartbeat - current count: {}", self.name, self.count);
-        Ok(true) // Return true to continue idle processing, false to disable it
+        Ok(())
     }
 
     // on_stop is optional - called when the actor is terminating
@@ -133,8 +147,10 @@ impl CounterActor {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Spawn actor with initialization arguments
-    let (actor_ref, join_handle) = spawn::<CounterActor>((10, "MyCounter".to_string()));
+    // Spawn actor with initialization arguments. `with_idle()` enables the idle
+    // channel so subscribe_idle streams are driven and on_idle fires.
+    let (actor_ref, join_handle) =
+        spawn_with_options::<CounterActor>((10, "MyCounter".to_string()), SpawnOptions::new().with_idle());
 
     // Allow actor to run and emit heartbeats
     tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
@@ -147,7 +163,7 @@ async fn main() -> Result<()> {
     println!("Current count: {}", current_count);
 
     // Gracefully stop the actor
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
 
     // Wait for actor to complete and check the result
     match join_handle.await? {
@@ -169,7 +185,7 @@ async fn main() -> Result<()> {
 ### Actor Lifecycle
 
 1. **`on_start`** (required): Creates the actor instance from initialization arguments
-2. **`on_run`** (optional): Idle handler called when message queue is empty, returns `bool` to control continuation
+2. **`on_idle`** (optional): Idle handler driven by `Stream`s registered via `ActorRef::subscribe_idle`; called once per yielded event and returns `Result<(), Error>`. Opt-in by spawning with `SpawnOptions::new().with_idle()`
 3. **`on_stop`** (optional): Cleanup logic when the actor terminates
 
 ### Message Passing

--- a/docs/handler_traits_design.md
+++ b/docs/handler_traits_design.md
@@ -154,7 +154,7 @@ if let Some(strong) = weak_handlers[0].upgrade() {
 }
 
 // After actor stops, upgrade returns None
-actor_a.stop().await?;
+actor_a.stop().await;
 assert!(weak_handlers[0].upgrade().is_none());
 ```
 
@@ -202,7 +202,7 @@ let controls: Vec<Box<dyn ActorControl>> = vec![
 // Check status and stop all
 for control in &controls {
     println!("Actor {} alive: {}", control.identity(), control.is_alive());
-    control.stop().await?;
+    control.stop().await;
 }
 ```
 

--- a/docs/lifecycle.puml
+++ b/docs/lifecycle.puml
@@ -6,7 +6,7 @@ participant "ActorRef<T>" as ActorRef
 participant "JoinHandle" as JoinHandle
 participant "run_actor_lifecycle()" as Lifecycle
 participant "Actor::on_start()" as OnStart
-participant "Actor::on_run()" as OnRun
+participant "Actor::on_idle()" as OnIdle
 participant "Actor::on_stop()" as OnStop
 
 == Initialization Phase ==
@@ -47,27 +47,23 @@ loop Main Actor Loop
     else Message Received
         Lifecycle -> Lifecycle: Process incoming message
         note right of Lifecycle: Handle message via MessageHandler trait
-    else on_run Execution (Idle Handler)
-        Lifecycle -> OnRun: Call actor.on_run(&actor_weak)
-        activate OnRun
+    else on_idle Execution (Idle Handler)
+        Lifecycle -> OnIdle: Call actor.on_idle(event, &actor_weak)
+        activate OnIdle
 
-        alt on_run Continue
-            OnRun --> Lifecycle: Ok(true)
-            deactivate OnRun
-            note right of Lifecycle: Continue calling on_run when idle
-        else on_run Disable
-            OnRun --> Lifecycle: Ok(false)
-            deactivate OnRun
-            note right of Lifecycle: Disable idle processing, only handle messages
-        else on_run Failure
-            OnRun --> Lifecycle: Err(error)
-            deactivate OnRun
+        alt on_idle Handled
+            OnIdle --> Lifecycle: Ok(())
+            deactivate OnIdle
+            note right of Lifecycle: Idle event handled; keep running
+        else on_idle Failure
+            OnIdle --> Lifecycle: Err(error)
+            deactivate OnIdle
             note right of Lifecycle
               Actor terminates due to runtime error.
               on_stop IS called for cleanup.
             end note
             Lifecycle -> OnStop: Call on_stop(&actor_weak, killed)
-            Lifecycle --> JoinHandle: ActorResult::Failed { phase: OnRun, actor: Some(actor), error, killed }
+            Lifecycle --> JoinHandle: ActorResult::Failed { phase: OnIdle, actor: Some(actor), error, killed, .. }
         end
     end
 end
@@ -77,7 +73,7 @@ note over Lifecycle, OnStop
   on_stop is called for:
   - explicit stop/kill requests
   - when all ActorRef instances are dropped
-  - when on_run returns an error (for cleanup)
+  - when on_idle returns an error (for cleanup)
 end note
 
 activate OnStop
@@ -126,13 +122,13 @@ note over OnStart
   ✅ Receives ActorRef for self-reference
 end note
 
-note over OnRun
-  on_run() - Idle Handler:
-  ✅ Optional (default returns Ok(false))
+note over OnIdle
+  on_idle() - Idle Handler:
+  ✅ Optional; opt-in via SpawnOptions::with_idle()
+  ✅ Driven by subscribe_idle() streams
   ✅ Called when message queue is empty
-  ✅ Messages have priority over on_run
-  ✅ Ok(true) continues idle processing
-  ✅ Ok(false) disables idle processing
+  ✅ Messages have priority over on_idle
+  ✅ Ok(()) handled; keep running
   ✅ Err() terminates actor (on_stop called)
   ✅ Receives ActorWeak to avoid cycles
 end note

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -52,7 +52,6 @@ async fn main() {
     println!("Messages processed: {}", metrics.message_count);
     println!("Avg processing time: {:?}", metrics.avg_processing_time);
     println!("Max processing time: {:?}", metrics.max_processing_time);
-    println!("Error count: {}", metrics.error_count);
     println!("Uptime: {:?}", metrics.uptime);
     println!("Last activity: {:?}", metrics.last_activity);
 }
@@ -67,9 +66,7 @@ You can also query individual metrics instead of the full snapshot.
 let message_count = actor_ref.message_count();
 let avg_time = actor_ref.avg_processing_time();
 let max_time = actor_ref.max_processing_time();
-let error_count = actor_ref.error_count();
 let uptime = actor_ref.uptime();
-let last_activity = actor_ref.last_activity();
 ```
 
 ## API Reference
@@ -83,7 +80,9 @@ let last_activity = actor_ref.last_activity();
 | `message_count` | `u64` | Total number of messages processed |
 | `avg_processing_time` | `Duration` | Average processing time per message |
 | `max_processing_time` | `Duration` | Maximum processing time observed |
-| `error_count` | `u64` | Number of errors during message handling |
+| `priority_message_count` | `u64` | Total number of priority-channel messages processed |
+| `avg_priority_processing_time` | `Duration` | Average processing time per priority message |
+| `max_priority_processing_time` | `Duration` | Maximum priority-message processing time observed |
 | `uptime` | `Duration` | Time elapsed since actor started |
 | `last_activity` | `Option<SystemTime>` | Timestamp of last message processing completion |
 
@@ -95,23 +94,16 @@ let last_activity = actor_ref.last_activity();
 | `message_count()` | `u64` | Number of messages processed |
 | `avg_processing_time()` | `Duration` | Average processing time |
 | `max_processing_time()` | `Duration` | Maximum processing time |
-| `error_count()` | `u64` | Error count |
+| `priority_message_count()` | `u64` | Number of priority-channel messages processed |
+| `avg_priority_processing_time()` | `Duration` | Average priority-message processing time |
+| `max_priority_processing_time()` | `Duration` | Maximum priority-message processing time |
 | `uptime()` | `Duration` | Actor uptime |
-| `last_activity()` | `Option<SystemTime>` | Last activity timestamp |
 
 ## Usage Examples
 
-### Calculating Error Rate
+### Tracking Delivery and Handling Failures
 
-```rust
-let metrics = actor_ref.metrics();
-let error_rate = if metrics.message_count > 0 {
-    (metrics.error_count as f64 / metrics.message_count as f64) * 100.0
-} else {
-    0.0
-};
-println!("Error rate: {:.2}%", error_rate);
-```
+Metrics do not count delivery or handling failures. Such failures are surfaced as **dead letters** instead: structured `tracing` warnings, plus `dead_letter_count()` / `reset_dead_letter_count()` under the `test-utils` feature. See [`debugging_guide.md`](debugging_guide.md) for details.
 
 ### Performance Monitoring
 
@@ -146,11 +138,10 @@ async fn monitor_actor(actor_ref: ActorRef<MyActor>) {
 
         let m = actor_ref.metrics();
         println!(
-            "[Monitor] messages={} avg={:?} max={:?} errors={} uptime={:?}",
+            "[Monitor] messages={} avg={:?} max={:?} uptime={:?}",
             m.message_count,
             m.avg_processing_time,
             m.max_processing_time,
-            m.error_count,
             m.uptime
         );
     }
@@ -168,7 +159,7 @@ let (actor_ref, handle) = spawn::<MyActor>(());
 actor_ref.tell(Work).await?;
 
 // Stop the actor
-actor_ref.stop().await?;
+actor_ref.stop().await;
 let _ = handle.await;
 
 // Metrics are still accessible after stop
@@ -241,14 +232,10 @@ actor_processing_time_avg{{actor="{}"}} {}
 # HELP actor_processing_time_max Max processing time in seconds
 # TYPE actor_processing_time_max gauge
 actor_processing_time_max{{actor="{}"}} {}
-# HELP actor_error_count Total errors
-# TYPE actor_error_count counter
-actor_error_count{{actor="{}"}} {}
 "#,
         actor_name, m.message_count,
         actor_name, m.avg_processing_time.as_secs_f64(),
-        actor_name, m.max_processing_time.as_secs_f64(),
-        actor_name, m.error_count
+        actor_name, m.max_processing_time.as_secs_f64()
     )
 }
 ```

--- a/docs/termination.puml
+++ b/docs/termination.puml
@@ -6,13 +6,13 @@ participant "ActorRef<T>" as ActorRef_obj
 participant "MailboxChannel (mpsc)" as MailboxChannel
 participant "TerminateChannel (mpsc)" as TerminateChannel
 participant "run_actor_lifecycle()" as Lifecycle
-participant "Actor::on_run()" as on_run_method
+participant "Actor::on_idle()" as on_idle_method
 participant "Actor::on_stop()" as on_stop_method
 participant "JoinHandle" as JoinHandle_obj
 
 box "Actor Task" #LightCoral
     participant Lifecycle
-    participant on_run_method
+    participant on_idle_method
     participant on_stop_method
 end box
 
@@ -20,11 +20,11 @@ end box
 Lifecycle -> Lifecycle: Main tokio::select! loop (biased)
 activate Lifecycle
 loop Idle Processing (when message queue empty)
-  Lifecycle -> on_run_method: Calls actor.on_run(&actor_weak).await
-  activate on_run_method
-  on_run_method --> Lifecycle: Returns Ok(true), Ok(false), or Err(error)
-  deactivate on_run_method
-  note right of Lifecycle: Ok(true): continue idle processing\nOk(false): disable idle processing\nErr(): terminate with failure
+  Lifecycle -> on_idle_method: Calls actor.on_idle(event, &actor_weak).await
+  activate on_idle_method
+  on_idle_method --> Lifecycle: Returns Ok(()) or Err(error)
+  deactivate on_idle_method
+  note right of Lifecycle: Ok(()): handled; keep running\nErr(): terminate with failure
 end
 
 == Stop Operation (Graceful) ==
@@ -72,24 +72,24 @@ else on_stop Failure
 end
 deactivate Lifecycle
 
-== Termination via on_run Error ==
+== Termination via on_idle Error ==
 note over Lifecycle, on_stop_method
-  When on_run returns an error, on_stop IS called for cleanup.
+  When on_idle returns an error, on_stop IS called for cleanup.
   The actor then terminates with ActorResult::Failed.
 end note
 
-Lifecycle -> on_run_method: Calls actor.on_run(&actor_weak).await
+Lifecycle -> on_idle_method: Calls actor.on_idle(event, &actor_weak).await
 activate Lifecycle
-activate on_run_method
-on_run_method --> Lifecycle: Returns Err(error)
-deactivate on_run_method
+activate on_idle_method
+on_idle_method --> Lifecycle: Returns Err(error)
+deactivate on_idle_method
 
 Lifecycle -> on_stop_method: Calls on_stop(&actor_weak, killed) for cleanup
 activate on_stop_method
 on_stop_method --> Lifecycle: Returns (result logged if error)
 deactivate on_stop_method
 
-Lifecycle --> JoinHandle_obj: ActorResult::Failed { phase: OnRun, actor: Some(actor), error, killed }
+Lifecycle --> JoinHandle_obj: ActorResult::Failed { phase: OnIdle, actor: Some(actor), error, killed, .. }
 deactivate Lifecycle
 
 == All ActorRef Instances Dropped ==

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -192,7 +192,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let count = actor_ref.ask(Increment).await?;
     println!("Count: {}", count);
 
-    actor_ref.stop().await?;
+    actor_ref.stop().await;
     Ok(())
 }
 ```


### PR DESCRIPTION
- CHANGELOG: document the breaking changes for 0.16.0 (on_run replaced by stream-based on_idle, opt-in idle channel, infallible stop/kill, #[non_exhaustive] Error + ChannelFull, ActorResult secondary_error, error_count removal) with a 0.15.x -> 0.16.0 migration guide.
- Guides and PlantUML diagrams: replace on_run with the on_idle + subscribe_idle model, add the IdleEvent associated type and SpawnOptions::with_idle() opt-in.
- Drop ?/.unwrap() on the now-infallible stop()/kill().
- Metrics guide: remove the deleted error_count.
- README and project instructions: refresh the lifecycle description and bump dependency examples to 0.16.