### PR TITLE
Fix flaky priority MSRV test and update 0.16.0 skills

### DIFF
--- a/skills/rsactor-actor/SKILL.md
+++ b/skills/rsactor-actor/SKILL.md
@@ -66,6 +66,7 @@ struct MyActorArgs {
 impl Actor for MyActor {
     type Args = MyActorArgs;
     type Error = anyhow::Error;
+    type IdleEvent = (); // No periodic/idle work here (see Pattern 3 for idle streams)
 
     async fn on_start(args: Self::Args, _actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         // Complex initialization logic
@@ -74,14 +75,6 @@ impl Actor for MyActor {
             connection,
             count: 0,
         })
-    }
-
-    // Optional: background task that runs concurrently with message processing
-    // Return Ok(true) to keep calling on_run, Ok(false) to stop
-    async fn on_run(&mut self, _actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        // Called repeatedly while returning Ok(true)
-        // Use tokio::select! for multiple async operations
-        Ok(true)
     }
 
     // Optional: cleanup when actor stops
@@ -103,44 +96,54 @@ impl MyActor {
 
 ### Pattern 3: Actor with Periodic Tasks
 
-Use `on_run` with `tokio::select!` for timers and async operations:
+Periodic/idle work is driven by `Stream`s you register with `subscribe_idle`. Map each
+stream's items to an `IdleEvent` and react to them in `on_idle`. The idle channel is
+**opt-in** — spawn with `SpawnOptions::new().with_idle()`:
 
 ```rust
-use rsactor::{Actor, ActorRef, ActorWeak, message_handlers};
+use rsactor::{Actor, ActorRef, ActorWeak, SpawnOptions, message_handlers, spawn_with_options};
+use futures::stream::StreamExt;
 use tokio::time::{interval, Duration};
+use tokio_stream::wrappers::IntervalStream;
+
+// The event type yielded by the subscribed stream(s)
+#[derive(Debug, Clone, Copy)]
+struct Tick;
 
 struct PeriodicActor {
-    tick_interval: tokio::time::Interval,
     tick_count: u32,
 }
 
 impl Actor for PeriodicActor {
-    type Args = Self;
+    type Args = ();
     type Error = anyhow::Error;
+    type IdleEvent = Tick; // required associated type
 
-    async fn on_start(args: Self::Args, _: &ActorRef<Self>) -> Result<Self, Self::Error> {
-        Ok(args)
+    async fn on_start(_: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        // Register a periodic stream; the runtime drives it and calls on_idle per tick.
+        actor_ref.subscribe_idle(
+            IntervalStream::new(interval(Duration::from_secs(1))).map(|_| Tick),
+        )?;
+        Ok(Self { tick_count: 0 })
     }
 
-    async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        tokio::select! {
-            _ = self.tick_interval.tick() => {
-                self.tick_count += 1;
-                println!("Tick #{}", self.tick_count);
-            }
-        }
-        Ok(true)  // Continue calling on_run
+    // Called once per yielded event, but only while the mailbox is empty.
+    async fn on_idle(&mut self, _event: Tick, _: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        self.tick_count += 1;
+        println!("Tick #{}", self.tick_count);
+        Ok(())
     }
 }
 ```
 
-**Spawning:**
+**Spawning** (the idle channel must be enabled, or `subscribe_idle` errors and `on_idle` never fires):
 ```rust
-let (actor_ref, handle) = rsactor::spawn::<PeriodicActor>(PeriodicActor {
-    tick_interval: interval(Duration::from_secs(1)),
-    tick_count: 0,
-});
+let (actor_ref, handle) =
+    spawn_with_options::<PeriodicActor>((), SpawnOptions::new().with_idle());
 ```
+
+> For multiple sources, make `IdleEvent` an enum and `subscribe_idle` one stream per
+> variant; dispatch on the event in `on_idle`.
 
 ## Key Rules
 
@@ -162,14 +165,14 @@ actor_ref.tell(MyMessage { data: "hello".into() }).await?;
 // Request-response (ask)
 let response: String = actor_ref.ask(MyMessage { data: "hello".into() }).await?;
 
-// Stop actor gracefully
-actor_ref.stop().await?;
+// Stop actor gracefully (stop() and kill() are infallible — no `?`)
+actor_ref.stop().await;
 
 // Wait for actor completion
 let result = join_handle.await?;
 match result {
     rsactor::ActorResult::Completed { actor, killed } => { /* success */ }
-    rsactor::ActorResult::Failed { actor, error, phase, killed } => { /* failure */ }
+    rsactor::ActorResult::Failed { actor, error, phase, killed, .. } => { /* failure */ }
 }
 ```
 
@@ -179,10 +182,11 @@ match result {
 use rsactor::{
     Actor,           // Core trait
     ActorRef,        // Strong reference for sending messages
-    ActorWeak,       // Weak reference (used in on_run, on_stop)
+    ActorWeak,       // Weak reference (used in on_idle, on_stop)
     ActorResult,     // Result of actor lifecycle
     message_handlers, // Macro for handler impl block
-    spawn,           // Function to create actors
+    spawn,           // Create actors with default options
+    spawn_with_options, SpawnOptions, // Opt into the idle/priority channels (e.g. with_idle())
     // For polymorphic handler collections
     TellHandler, AskHandler, WeakTellHandler, WeakAskHandler,
     // For type-erased lifecycle management

--- a/skills/rsactor-guide/SKILL.md
+++ b/skills/rsactor-guide/SKILL.md
@@ -36,7 +36,7 @@ impl MyActor {
 async fn main() -> anyhow::Result<()> {
     let (actor_ref, handle) = spawn::<MyActor>(MyActor);
     actor_ref.tell(Ping).await?;
-    actor_ref.stop().await?;
+    actor_ref.stop().await; // stop() is infallible
     handle.await?;
     Ok(())
 }
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 spawn()
   → on_start()     [initialization, returns Self]
-  → on_run() loop  [concurrent with message processing]
+  → on_idle()      [reacts to subscribed idle-stream events, concurrent with messages]
   → on_stop()      [cleanup on shutdown]
   → ActorResult    [Completed or Failed]
 ```
@@ -71,14 +71,15 @@ spawn()
 impl Actor for MyActor {
     type Args = MyActorArgs;  // Arguments passed to spawn()
     type Error = anyhow::Error;
+    type IdleEvent = ();      // Event type delivered to on_idle; () when there is no idle work
 
     // Required: Initialize actor state
     async fn on_start(args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error>;
 
-    // Optional: Background task (called repeatedly while returning Ok(true))
-    // Return Ok(true) to keep calling, Ok(false) to stop idle processing
-    async fn on_run(&mut self, actor_ref: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-        Ok(false)  // Default: no idle processing
+    // Optional: react to events from streams registered with `actor_ref.subscribe_idle(...)`.
+    // Requires the idle channel: spawn with `SpawnOptions::new().with_idle()`.
+    async fn on_idle(&mut self, event: Self::IdleEvent, actor_ref: &ActorWeak<Self>) -> Result<(), Self::Error> {
+        Ok(())  // Default: no-op
     }
 
     // Optional: Cleanup on shutdown
@@ -120,11 +121,12 @@ let result = actor_ref.ask_with_timeout(MyQuery, Duration::from_secs(5)).await?;
 ## Actor Control
 
 ```rust
-// Graceful stop (process remaining messages first)
-actor_ref.stop().await?;
+// Graceful stop (process remaining queued messages first)
+actor_ref.stop().await; // infallible (returns ())
 
-// Immediate stop (skip remaining messages)
-actor_ref.kill().await?;
+// Immediate termination (drop queued messages). kill() is sync and infallible.
+// Cooperative: a running handler finishes first — it cannot interrupt an in-flight `.await`.
+actor_ref.kill();
 
 // Check if alive
 if actor_ref.is_alive() { /* ... */ }
@@ -144,10 +146,11 @@ match result {
         // killed: true if stopped via kill(), false if stop()
         println!("Final state: {:?}", actor);
     }
-    ActorResult::Failed { actor, error, phase, killed } => {
+    ActorResult::Failed { actor, error, phase, killed, .. } => {
         // actor: Option<A> - may be None if failed in on_start
         // error: The error that caused failure
-        // phase: "on_start", "on_run", "on_stop", or "handler"
+        // secondary_error: Option<E> - the on_stop error when phase is OnIdleThenOnStop
+        // phase: FailurePhase::{OnStart, OnIdle, OnStop, OnIdleThenOnStop}
         eprintln!("Failed in {}: {}", phase, error);
     }
 }
@@ -208,7 +211,7 @@ for control in &controls {
 
 // Stop all actors
 for control in &controls {
-    control.stop().await?;
+    control.stop().await; // infallible
 }
 ```
 
@@ -216,19 +219,32 @@ for control in &controls {
 
 ### Periodic Tasks
 
+Register streams with `subscribe_idle` in `on_start`, react in `on_idle`. Requires the
+idle channel — spawn with `SpawnOptions::new().with_idle()`:
+
 ```rust
-async fn on_run(&mut self, _: &ActorWeak<Self>) -> Result<bool, Self::Error> {
-    tokio::select! {
-        _ = self.interval.tick() => {
-            self.do_periodic_work();
-        }
-        _ = self.some_future => {
-            self.handle_event();
-        }
-    }
-    Ok(true)  // Continue calling on_run
+use futures::stream::StreamExt;
+use tokio::time::{interval, Duration};
+use tokio_stream::wrappers::IntervalStream;
+
+#[derive(Clone, Copy)]
+struct Tick;
+// In the Actor impl: `type IdleEvent = Tick;`
+
+async fn on_start(_: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
+    actor_ref.subscribe_idle(
+        IntervalStream::new(interval(Duration::from_secs(1))).map(|_| Tick),
+    )?;
+    Ok(/* ... */)
+}
+
+async fn on_idle(&mut self, _event: Tick, _: &ActorWeak<Self>) -> Result<(), Self::Error> {
+    self.do_periodic_work();
+    Ok(())
 }
 ```
+
+For multiple sources, make `IdleEvent` an enum and subscribe one stream per variant.
 
 ### Actor Supervision (Parent-Child)
 
@@ -281,7 +297,7 @@ use rsactor::Error;
 fn handle_error(err: &Error) {
     // Check if operation can be retried
     if err.is_retryable() {
-        // Only Timeout errors are retryable
+        // Retryable variants: Timeout and ChannelFull
         println!("Retrying...");
     }
 
@@ -378,7 +394,8 @@ let result: String = actor_ref.blocking_ask(query, Some(Duration::from_secs(10))
 - Check message type matches exactly
 
 ### Actor stops unexpectedly
-- Check `on_run` returns `Ok(true)` or `Ok(false)` (errors cause shutdown)
+- Check `on_idle` returns `Ok(())` (an `Err` shuts the actor down)
+- If `on_idle`/`subscribe_idle` seem to do nothing, confirm the actor was spawned with `SpawnOptions::new().with_idle()` (otherwise `subscribe_idle` returns `Error::IdleChannelNotEnabled`)
 - Check handler errors
 - Use `ActorResult::Failed` to see the error and phase
 
@@ -398,7 +415,7 @@ use rsactor::{
     // Macros
     message_handlers,
     // Functions
-    spawn,
+    spawn, spawn_with_options, SpawnOptions,
     // Handler traits (for polymorphism)
     TellHandler, AskHandler, WeakTellHandler, WeakAskHandler,
     // Control traits (for type-erased lifecycle management)

--- a/skills/rsactor-handler/SKILL.md
+++ b/skills/rsactor-handler/SKILL.md
@@ -181,7 +181,7 @@ let controls: Vec<Box<dyn ActorControl>> = vec![
 // Check status and stop all
 for control in &controls {
     println!("Actor {} alive: {}", control.identity(), control.is_alive());
-    control.stop().await?;
+    control.stop().await; // stop() is infallible (returns ())
 }
 ```
 

--- a/tests/priority_signal_tests.rs
+++ b/tests/priority_signal_tests.rs
@@ -24,11 +24,15 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
 
-// Tests that read the global dead-letter counter must not run concurrently
-// with each other within this test binary, otherwise their `before`/`after`
-// captures race. The mutex is held across `.await` points (the test body),
-// so it must be `tokio::sync::Mutex` rather than `std::sync::Mutex`
-// (clippy::await_holding_lock).
+// The dead-letter counter is process-global. Any test that *reads* it
+// (`before`/`after` deltas) must not run concurrently with any test that
+// *generates* a dead letter (a timeout, or a send to a closed/killed actor),
+// or the generator's increment leaks into the reader's measurement window.
+// So BOTH kinds acquire this lock, and every holder fully joins its actor(s)
+// (`handle.await`) before releasing it — guaranteeing no dead letter is
+// recorded after the lock is dropped. The mutex is held across `.await` points
+// (the test body), so it must be `tokio::sync::Mutex` rather than
+// `std::sync::Mutex` (clippy::await_holding_lock).
 fn dead_letter_serial_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -211,6 +215,10 @@ async fn ask_priority_on_disabled_actor_returns_not_enabled_error() {
 
 #[tokio::test]
 async fn priority_bypasses_saturated_regular_mailbox() {
+    // The saturating `tell_with_timeout` below times out and records a dead
+    // letter, so this test must serialize against the dead-letter readers.
+    let _serial = dead_letter_serial_lock().lock().await;
+
     let started = Arc::new(AtomicU32::new(0));
     let release = Arc::new(Notify::new());
 
@@ -218,7 +226,7 @@ async fn priority_bypasses_saturated_regular_mailbox() {
     // actor while a second BlockMe sits in the channel slot. Any further
     // regular send would block on admission.
     let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
-    let (actor_ref, _handle) =
+    let (actor_ref, handle) =
         spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
 
     // 1) Saturate the regular mailbox: the first BlockMe is being processed,
@@ -261,6 +269,7 @@ async fn priority_bypasses_saturated_regular_mailbox() {
     release.notify_one();
     release.notify_one();
     actor_ref.stop().await;
+    handle.await.unwrap(); // fully quiesce before releasing the serial lock
 }
 
 #[tokio::test]
@@ -283,6 +292,10 @@ async fn ask_priority_returns_typed_reply() {
 
 #[tokio::test]
 async fn kill_overtakes_pending_priority_messages() {
+    // kill() drops the pending priority message, which is recorded as a dead
+    // letter during teardown; serialize against the dead-letter readers.
+    let _serial = dead_letter_serial_lock().lock().await;
+
     let started = Arc::new(AtomicU32::new(0));
     let release = Arc::new(Notify::new());
 
@@ -384,6 +397,11 @@ async fn stop_drain_loop_processes_racing_priority_send() {
     //   this is not currently a concern.
     // - ITERS = 200 keeps the assertion robust across scheduling jitter while
     //   still completing in well under a second on a typical laptop.
+
+    // Each iteration's racing tell_priority calls produce Timeout/Send dead
+    // letters; serialize against the dead-letter readers. (Each iteration joins
+    // its actor below, so nothing leaks past this lock.)
+    let _serial = dead_letter_serial_lock().lock().await;
 
     const ITERS: usize = 200;
     let mut saw_post_close_send = false;
@@ -738,11 +756,15 @@ async fn blocking_priority_on_disabled_actor_returns_not_enabled() {
 
 #[tokio::test]
 async fn capacity_one_serializes_concurrent_priority_admission() {
+    // One racing send times out and kill() drops the admitted priority message —
+    // both record dead letters; serialize against the dead-letter readers.
+    let _serial = dead_letter_serial_lock().lock().await;
+
     let started = Arc::new(AtomicU32::new(0));
     let release = Arc::new(Notify::new());
 
     let opts = SpawnOptions::new().mailbox_capacity(1).with_priority();
-    let (actor_ref, _handle) =
+    let (actor_ref, handle) =
         spawn_with_options::<BlockingActor>((started.clone(), release.clone()), opts);
 
     actor_ref.tell(BlockMe).await.unwrap();
@@ -781,6 +803,7 @@ async fn capacity_one_serializes_concurrent_priority_admission() {
 
     release.notify_one();
     actor_ref.kill();
+    let _ = handle.await; // fully quiesce before releasing the serial lock
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #98, which was merged at the release commit (`751cc88`) **before** these two changes landed. As a result `main`'s MSRV Check is currently red and the 0.16.0 skills update is missing from `main`.

## Commits
- **`test(priority): serialize dead-letter generators against counter readers`** — fixes the flaky `tell_priority_on_disabled_actor_returns_not_enabled_error` failure observed on the `windows-latest` MSRV runner. The dead-letter counter is process-global; only the tests that *read* it held the serial lock, so the tests that *generate* dead letters (timeouts, sends to a killed/closed actor) ran concurrently and leaked increments into a reader's `before`/`after` window. Now the generators take the lock too, and each joins its actor (`handle.await`) before releasing it, so no dead letter is recorded past the lock boundary.
- **`docs(skills): update Claude Code skills for the 0.16.0 API`** — brings the rsactor-actor / rsactor-guide / rsactor-handler skills in line with 0.16.0 (on_idle subscription model, infallible `stop`/`kill`, `ActorResult::secondary_error`, `is_retryable` covering `ChannelFull`).

## Why before tagging v0.16.0
`rust.yml` runs `cargo test --all-features` on `windows-latest`, so the same flake can intermittently fail the **Release** workflow (which gates on `rust.yml`). Landing this keeps `main` green and the release stable.