### PR TITLE
fix!: address findings from multi-perspective source review

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -145,7 +145,8 @@ pub trait Actor: Sized + Send + 'static {
     /// This method is the initialization point for an actor and a fundamental part of the actor model design.
     /// Unlike traditional object construction, the actor's instance is created within this asynchronous method,
     /// allowing for complex initialization that may require awaiting resources. This method is called by
-    /// [`spawn`](crate::spawn) or [`spawn_with_mailbox_capacity`](crate::spawn_with_mailbox_capacity).
+    /// [`spawn`](crate::spawn), [`spawn_with_mailbox_capacity`](crate::spawn_with_mailbox_capacity),
+    /// or [`spawn_with_options`](crate::spawn_with_options).
     ///
     /// # Actor State Initialization
     ///
@@ -554,6 +555,11 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             };
         }
     };
+
+    // Anchor the metrics uptime baseline to on_start completion (the actor_ref
+    // strong reference is still held here; it is dropped just below).
+    #[cfg(feature = "metrics")]
+    actor_ref.metrics.mark_started();
 
     debug!("Actor {actor_id} runtime starting - entering main processing loop.");
 

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -36,7 +36,9 @@ fn current_multi_thread_handle() -> Option<Handle> {
 /// identically.
 ///
 /// `panic_msg` describes the failure surfaced when the spawned thread itself
-/// panics (the `join.join()` returns `Err`); it is wrapped in `Error::Send`.
+/// panics (the `join.join()` returns `Err`); it is wrapped in `Error::Runtime`.
+/// A failure to build the temporary runtime is also reported as `Error::Runtime`,
+/// carrying the underlying [`std::io::Error`] as its [`source`](std::error::Error::source).
 fn run_blocking_with_runtime<F, R>(identity: Identity, panic_msg: &'static str, fut: F) -> Result<R>
 where
     F: std::future::Future<Output = Result<R>> + Send + 'static,
@@ -46,17 +48,19 @@ where
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_time()
             .build()
-            .map_err(|e| Error::Send {
+            .map_err(|e| Error::Runtime {
                 identity,
-                details: format!("Failed to create runtime: {}", e),
+                details: "Failed to build blocking runtime".to_string(),
+                source: Some(std::sync::Arc::new(e)),
             })?;
         runtime.block_on(fut)
     });
 
     join.join().unwrap_or_else(|_| {
-        Err(Error::Send {
+        Err(Error::Runtime {
             identity,
             details: panic_msg.to_string(),
+            source: None,
         })
     })
 }
@@ -95,7 +99,11 @@ use std::sync::Arc;
 ///   - [`blocking_ask`](ActorRef::blocking_ask): Send a message and block until a typed reply is received (no runtime context required).
 ///   - [`blocking_tell`](ActorRef::blocking_tell): Send a message and block until it is sent (no runtime context required).
 ///
-///   The new `blocking_*` methods use Tokio's underlying `blocking_send` and `blocking_recv` and can be used from any thread.
+///   The `blocking_*` methods can be called from any thread and from within a
+///   multi-thread Tokio runtime. The exact mechanism (`block_in_place` +
+///   `block_on`, `blocking_send` / `blocking_recv`, or a temporary runtime on a
+///   dedicated thread) depends on the calling context — see each method's
+///   "Execution paths" section for details.
 ///
 /// - **Control Methods**:
 ///   - [`stop`](ActorRef::stop): Gracefully stop the actor.
@@ -203,6 +211,12 @@ impl<T: Actor> ActorRef<T> {
     /// The optional priority channel is intentionally **not** consulted: it is a
     /// secondary channel, and the actor is considered alive as long as the regular
     /// mailbox and the terminate channel remain open.
+    ///
+    /// **Note**: This is a heuristic, point-in-time check. The channels are
+    /// closed only after the actor's loop exits, so this can briefly report
+    /// `true` after `on_stop` has already run, and a `true` result does not
+    /// guarantee that a subsequent send will succeed. A successful send is the
+    /// only definitive liveness signal.
     #[inline]
     pub fn is_alive(&self) -> bool {
         // Both channels must be open for the actor to be considered alive
@@ -773,6 +787,17 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`tell_priority`](Self::tell_priority)
     /// directly from async code where possible.
+    ///
+    /// # Deadlock warning
+    ///
+    /// Never call this (or any `blocking_*` method) from inside the actor's own
+    /// message handler — directly on `self`, or transitively via a cycle that
+    /// routes back into this actor. If the priority slot is full, the call parks
+    /// the actor's message loop synchronously while waiting for admission that
+    /// only that same loop could make room for — an unrecoverable hang that
+    /// `kill()` cannot interrupt (note that `deadlock-detection` only tracks
+    /// `ask` cycles, not `tell`). Prefer the async
+    /// [`tell_priority`](Self::tell_priority) from handler code.
     pub fn blocking_tell_priority<M>(&self, msg: M, timeout: Duration) -> Result<()>
     where
         M: Send + 'static,
@@ -872,6 +897,17 @@ impl<T: Actor> ActorRef<T> {
     /// On a multi-thread runtime the `block_in_place` path holds the calling
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers.
+    ///
+    /// # Deadlock warning
+    ///
+    /// Never call this (or any `blocking_*` method) from inside the actor's own
+    /// message handler — directly on `self`, or transitively via a cycle that
+    /// asks back into this actor. The call parks the actor's message loop
+    /// synchronously while waiting for a reply that only that same loop could
+    /// produce — an unrecoverable hang that `kill()` cannot interrupt. Enable
+    /// the `deadlock-detection` feature to turn such a cycle into an immediate
+    /// panic instead, or use the async [`ask_priority`](Self::ask_priority) from
+    /// handler code.
     pub fn blocking_ask_priority<M>(&self, msg: M, timeout: Duration) -> Result<T::Reply>
     where
         T: Message<M>,
@@ -1008,6 +1044,17 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`tell`](Self::tell) directly
     /// from async code where possible.
+    ///
+    /// # Deadlock warning
+    ///
+    /// Never call this (or any `blocking_*` method) from inside the actor's own
+    /// message handler — directly on `self`, or transitively via a cycle that
+    /// routes back into this actor. If the target mailbox is full, the call
+    /// parks the actor's message loop synchronously while waiting for admission
+    /// that only that same loop could make room for — an unrecoverable hang that
+    /// `kill()` cannot interrupt (note that `deadlock-detection` only tracks
+    /// `ask` cycles, not `tell`). Prefer the async [`tell`](Self::tell) from
+    /// handler code.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_blocking_tell",
@@ -1184,6 +1231,16 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`ask`](Self::ask) directly
     /// from async code where possible.
+    ///
+    /// # Deadlock warning
+    ///
+    /// Never call this (or any `blocking_*` method) from inside the actor's own
+    /// message handler — directly on `self`, or transitively via a cycle that
+    /// asks back into this actor. The call parks the actor's message loop
+    /// synchronously while waiting for a reply that only that same loop could
+    /// produce — an unrecoverable hang that `kill()` cannot interrupt. Enable
+    /// the `deadlock-detection` feature to turn such a cycle into an immediate
+    /// panic instead, or use the async [`ask`](Self::ask) from handler code.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_blocking_ask",
@@ -1431,8 +1488,8 @@ impl<T: Actor> ActorRef<T> {
 
     /// Returns a snapshot of all metrics for this actor.
     ///
-    /// The snapshot includes message count, processing times, error count, uptime,
-    /// and last activity timestamp.
+    /// The snapshot includes message count, processing times, priority message
+    /// counts, uptime, and last activity timestamp.
     ///
     /// # Example
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,12 +67,25 @@ pub enum Error {
         /// The expected type name that the downcast failed to match
         expected_type: &'static str,
     },
-    /// Error when a runtime operation fails
+    /// Error from a runtime-level operation.
+    ///
+    /// Emitted when a `blocking_*` call has to run on a dedicated thread with a
+    /// temporary Tokio runtime (because the caller is not already inside a
+    /// multi-thread runtime) and that runtime fails to build, or its worker
+    /// thread panics. Actor *lifecycle* failures (`on_start` / `on_idle` /
+    /// `on_stop`) are **not** reported here — they surface through
+    /// [`ActorResult::Failed`](crate::ActorResult) carrying the actor's own
+    /// error type.
     Runtime {
         /// ID of the actor where the runtime error occurred
         identity: Identity,
         /// Additional context about the error
         details: String,
+        /// Underlying cause, when one exists (e.g. the [`std::io::Error`] from
+        /// failing to build the runtime). Returned from
+        /// [`Error::source`](std::error::Error::source). `None` when the failure
+        /// has no chainable source (e.g. a worker-thread panic).
+        source: Option<std::sync::Arc<dyn std::error::Error + Send + Sync>>,
     },
     /// Error related to mailbox capacity configuration
     MailboxCapacity {
@@ -156,7 +169,9 @@ impl std::fmt::Display for Error {
                     "Failed to downcast reply from actor {identity} to expected type '{expected_type}'"
                 )
             }
-            Error::Runtime { identity, details } => {
+            Error::Runtime {
+                identity, details, ..
+            } => {
                 write!(f, "Runtime error in actor {identity}: {details}")
             }
             Error::MailboxCapacity { message } => {
@@ -191,6 +206,10 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Join { source, .. } => Some(source.as_ref()),
+            Error::Runtime {
+                source: Some(source),
+                ..
+            } => Some(source.as_ref()),
             _ => None,
         }
     }
@@ -300,11 +319,10 @@ impl Error {
                 "This usually indicates a bug in handler implementation",
             ],
             Error::Runtime { .. } => &[
-                "Check if on_start() or on_idle() returned an error",
-                "Look for panic messages in the error details field",
-                "Use `ActorResult::is_startup_failed()` or `is_runtime_failed()` to identify failure phase",
-                "Call `ActorResult::error()` to get the underlying error details",
-                "Initialize tracing-subscriber and set RUST_LOG=debug for lifecycle diagnostics",
+                "Emitted when a blocking_* call fails to build or run its dedicated temporary runtime",
+                "Match on `Error::Runtime { source, .. }` and inspect `source` for the underlying cause (e.g. std::io::Error)",
+                "This usually indicates OS resource exhaustion (unable to spawn a thread or build a runtime)",
+                "Prefer calling blocking_* from within an existing multi-thread runtime, or use the async ask()/tell() APIs",
             ],
             Error::MailboxCapacity { .. } => &[
                 "Mailbox capacity must be greater than 0",

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant, SystemTime};
 
 use super::MetricsSnapshot;
@@ -40,8 +41,13 @@ pub(crate) struct MetricsCollector {
     max_priority_processing_nanos: AtomicU64,
     /// Last activity timestamp as milliseconds since UNIX_EPOCH
     last_activity_millis: AtomicU64,
-    /// When the actor started (for uptime calculation)
+    /// Collector construction time. Used as the uptime baseline until the actor
+    /// finishes `on_start` (see `started_at`).
     start_instant: Instant,
+    /// When the actor's `on_start` completed successfully. Set once via
+    /// [`mark_started`](Self::mark_started); until then `uptime` falls back to
+    /// `start_instant`.
+    started_at: OnceLock<Instant>,
 }
 
 impl MetricsCollector {
@@ -56,7 +62,23 @@ impl MetricsCollector {
             max_priority_processing_nanos: AtomicU64::new(0),
             last_activity_millis: AtomicU64::new(0),
             start_instant: Instant::now(),
+            started_at: OnceLock::new(),
         }
+    }
+
+    /// Marks the moment the actor's `on_start` completed successfully, which
+    /// becomes the baseline for [`uptime`](Self::uptime). Idempotent — only the
+    /// first call takes effect.
+    #[inline]
+    pub fn mark_started(&self) {
+        let _ = self.started_at.set(Instant::now());
+    }
+
+    /// Returns the instant uptime is measured from: the `on_start`-completion
+    /// time once recorded, otherwise the collector's construction time.
+    #[inline]
+    fn uptime_baseline(&self) -> Instant {
+        self.started_at.get().copied().unwrap_or(self.start_instant)
     }
 
     /// Records a completed message processing with its duration.
@@ -156,7 +178,7 @@ impl MetricsCollector {
             max_priority_processing_time: Duration::from_nanos(
                 self.max_priority_processing_nanos.load(Ordering::Relaxed),
             ),
-            uptime: self.start_instant.elapsed(),
+            uptime: self.uptime_baseline().elapsed(),
             last_activity: self.get_last_activity(),
         }
     }
@@ -212,7 +234,7 @@ impl MetricsCollector {
     /// Returns the uptime since actor start.
     #[inline]
     pub fn uptime(&self) -> Duration {
-        self.start_instant.elapsed()
+        self.uptime_baseline().elapsed()
     }
 
     /// Returns the last activity timestamp.
@@ -259,6 +281,13 @@ impl<'a> MessageProcessingGuard<'a> {
 impl Drop for MessageProcessingGuard<'_> {
     #[inline]
     fn drop(&mut self) {
+        // Only count a message whose handler returned normally. If the handler
+        // panicked, this guard is dropped while the task unwinds; recording here
+        // would inflate `message_count`, which is documented as the number of
+        // *successfully processed* messages.
+        if std::thread::panicking() {
+            return;
+        }
         self.collector.record_message(self.start.elapsed());
     }
 }
@@ -285,6 +314,11 @@ impl<'a> PriorityMessageProcessingGuard<'a> {
 impl Drop for PriorityMessageProcessingGuard<'_> {
     #[inline]
     fn drop(&mut self) {
+        // See `MessageProcessingGuard::drop`: skip recording a handler that
+        // panicked so the priority count reflects only successful processing.
+        if std::thread::panicking() {
+            return;
+        }
         self.collector.record_priority_message(self.start.elapsed());
     }
 }
@@ -339,5 +373,55 @@ mod tests {
         let uptime2 = collector.uptime();
 
         assert!(uptime2 > uptime1);
+    }
+
+    #[test]
+    fn test_mark_started_resets_uptime_baseline() {
+        let collector = MetricsCollector::new();
+        std::thread::sleep(Duration::from_millis(20));
+        let before = collector.uptime();
+        collector.mark_started();
+        let after = collector.uptime();
+
+        // After marking on_start completion, uptime is measured from ~now, so it
+        // is smaller than the pre-mark value that included the 20ms sleep.
+        assert!(
+            after < before,
+            "mark_started should reset the uptime baseline (before={before:?}, after={after:?})"
+        );
+    }
+
+    #[test]
+    fn test_guard_skips_record_on_panic() {
+        let collector = MetricsCollector::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = MessageProcessingGuard::new(&collector);
+            panic!("handler panicked");
+        }));
+
+        assert!(result.is_err(), "the closure should have panicked");
+        assert_eq!(
+            collector.message_count(),
+            0,
+            "a panicking handler must not be counted as successfully processed"
+        );
+    }
+
+    #[test]
+    fn test_priority_guard_skips_record_on_panic() {
+        let collector = MetricsCollector::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = PriorityMessageProcessingGuard::new(&collector);
+            panic!("priority handler panicked");
+        }));
+
+        assert!(result.is_err(), "the closure should have panicked");
+        assert_eq!(
+            collector.priority_message_count(),
+            0,
+            "a panicking priority handler must not be counted as successfully processed"
+        );
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! - **Message count**: Total number of messages processed
 //! - **Processing time**: Average and maximum message processing times
-//! - **Error count**: Total number of errors during message handling
+//! - **Priority messages**: Count and processing times for priority-channel messages
 //! - **Uptime**: Time elapsed since actor started
 //! - **Last activity**: Timestamp of most recent message processing
 //!

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -54,7 +54,10 @@ pub struct MetricsSnapshot {
 
     /// Time elapsed since the actor was started.
     ///
-    /// This is measured from when the actor's `on_start` completed successfully.
+    /// This is measured from when the actor's `on_start` completed successfully
+    /// (the point the actor enters its message loop). Before `on_start`
+    /// completes, the value falls back to the time since the metrics collector
+    /// was created at [`spawn`](crate::spawn).
     pub uptime: Duration,
 
     /// Timestamp of the last message processing completion.

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -673,6 +673,7 @@ async fn test_error_runtime_display_format() {
     let error = rsactor::Error::Runtime {
         identity,
         details: "Test runtime error details".to_string(),
+        source: None,
     };
 
     let display_str = format!("{error}");

--- a/tests/debugging_tools_tests.rs
+++ b/tests/debugging_tools_tests.rs
@@ -45,6 +45,7 @@ fn test_is_retryable_for_all_variants() {
     let runtime_err = Error::Runtime {
         identity,
         details: "test error".into(),
+        source: None,
     };
     assert!(!runtime_err.is_retryable());
 
@@ -80,6 +81,7 @@ fn test_all_errors_have_debugging_tips() {
         Error::Runtime {
             identity,
             details: "test".into(),
+            source: None,
         },
         Error::MailboxCapacity { message: "test" },
     ];
@@ -100,18 +102,20 @@ fn test_runtime_error_tips_are_specific() {
     let err = Error::Runtime {
         identity,
         details: "test".into(),
+        source: None,
     };
     let tips = err.debugging_tips();
 
-    // Verify tips mention specific lifecycle methods
+    // Verify tips reflect the real source of this error: a failed blocking_*
+    // temporary runtime, with a chainable `source` for the underlying cause.
     let tips_text = tips.join(" ");
     assert!(
-        tips_text.contains("on_start") || tips_text.contains("on_run"),
-        "Runtime tips should mention lifecycle methods"
+        tips_text.contains("blocking"),
+        "Runtime tips should mention the blocking_* runtime source"
     );
     assert!(
-        tips_text.contains("ActorResult"),
-        "Runtime tips should mention ActorResult"
+        tips_text.contains("source"),
+        "Runtime tips should point at the chainable source"
     );
 }
 
@@ -184,6 +188,7 @@ fn test_error_display_all_variants() {
         Error::Runtime {
             identity,
             details: "panic in handler".into(),
+            source: None,
         },
         Error::MailboxCapacity {
             message: "capacity must be > 0",
@@ -798,6 +803,7 @@ fn test_error_source_returns_none_for_non_join() {
         Error::Runtime {
             identity,
             details: "test".into(),
+            source: None,
         },
         Error::MailboxCapacity { message: "test" },
     ];
@@ -809,6 +815,27 @@ fn test_error_source_returns_none_for_non_join() {
             err
         );
     }
+}
+
+#[test]
+fn test_runtime_error_with_source_exposes_source() {
+    use std::error::Error as StdError;
+
+    let identity = Identity::new(1, "TestActor");
+    let io_err = std::io::Error::other("boom");
+    let err = Error::Runtime {
+        identity,
+        details: "Failed to build blocking runtime".into(),
+        source: Some(std::sync::Arc::new(io_err)),
+    };
+
+    let source = err
+        .source()
+        .expect("Runtime error with a cause should expose source()");
+    assert!(
+        source.to_string().contains("boom"),
+        "source() should surface the underlying io::Error message"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

A multi-perspective review of `src/` (concurrency, soundness, API/idiom, lifecycle/resources, doc-vs-impl) surfaced 13 confirmed findings after adversarial re-verification of each. This PR addresses them: mostly doc/implementation accuracy, plus three minor behavioral fixes in metrics and error handling.

## Changes

### Docs
- **metrics**: drop the non-existent **"Error count"** metric from the module docs and `ActorRef::metrics()`; mention priority message counts instead.
- **actor_ref**: correct the `blocking_*` summary (the mechanism is context-dependent — `block_in_place`/`blocking_send`/temp-runtime — not always `blocking_send`/`blocking_recv`) and document the **self-deadlock hazard** of calling `blocking_*` from within a handler (all four blocking methods).
- **actor_ref**: note that `ActorRef::is_alive()` is a heuristic that can briefly report `true` after `on_stop`, mirroring `ActorWeak::is_alive`.
- **actor**: list `spawn_with_options` as an `on_start` caller.

### Metrics
- **collector**: do not count a message whose handler **panicked** — `message_count` is documented as *successfully processed* messages, so the panic-unwind drop now skips recording.
- **collector/actor**: measure `uptime` from **`on_start` completion** via a new `mark_started()`, matching the documented contract (previously measured from `spawn` call time).

### Error
- **error/actor_ref**: route blocking temporary-runtime failures through **`Error::Runtime`** (previously the semantically-wrong `Error::Send`) and carry the underlying `io::Error` as a chainable **`source()`**. Updates the `Error::Runtime` docs/tips to reflect this real usage (it was effectively unused before).

## Breaking changes
- `Error::Runtime` gains a `source` field.
- `blocking_*` failures to build/run their temporary runtime now return `Error::Runtime` instead of `Error::Send`.

Continues the prior `refactor!: harden Error API` work. `Error` is `#[non_exhaustive]`, so callers matching with a wildcard arm are unaffected.

## Testing
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo doc --no-deps --all-features` (with `-D warnings`), and `cargo test --all-features` all pass.
- Added unit tests for the panic-skip guards, the `mark_started` uptime baseline, and `Error::Runtime` source exposure; updated one test that asserted the old (incorrect) `Error::Runtime` tip wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)