### PR TITLE
fix!: resolve verified findings from multi-perspective source review and race audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,11 @@ required-features = ["deadlock-detection"]
 [[test]]
 name = "priority_signal_tests"
 required-features = ["test-utils"]
+
+[[test]]
+name = "shutdown_discard_tests"
+required-features = ["test-utils"]
+
+[[test]]
+name = "metrics_consistency_tests"
+required-features = ["metrics"]

--- a/book/src/core_concepts/messages.md
+++ b/book/src/core_concepts/messages.md
@@ -69,6 +69,8 @@ Key components of the `Message<T>` trait implementation:
 *   **`async fn handle(&mut self, msg: T, actor_ref: &ActorRef<Self>) -> Self::Reply`**: This asynchronous method contains the logic for processing the message `msg` of type `T`.
     *   It takes a mutable reference to the actor's state (`&mut self`), allowing it to modify the actor's internal data.
     *   It also receives a reference to the actor's own `ActorRef`, which can be useful for various purposes, such as spawning child actors or sending messages to itself.
+
+        > ⚠️ When sending to itself from inside a handler, prefer `tell_with_timeout` (or send from a spawned task). A no-timeout `tell`/`stop` to the actor's own full mailbox can never be admitted — the loop that would free a slot is parked awaiting that very handler — producing a hang that even `kill()` cannot break. With the `deadlock-detection` feature this panics immediately instead.
     *   It must return a value of type `Self::Reply`.
 
 ### Message Immutability

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1053,7 +1053,9 @@ A23: Backpressure is important to prevent overwhelming actors with more messages
     let (actor_ref, handle) = spawn_with_mailbox_capacity::<MyActor>(args, mailbox_capacity);
     ```
 
-    When the mailbox is full, `ask` and `tell` operations will return an error, allowing the sender to implement backpressure strategies.
+    When the mailbox is full, the no-timeout `tell` and `ask` operations **wait for space** (admission) rather than returning an error — the bounded mailbox applies backpressure by suspending the sender. To get error-based backpressure, use `tell_with_timeout` / `ask_with_timeout` (which fail with `Error::Timeout` when admission doesn't complete in time) or the priority variants (whose timeout is mandatory).
+
+    ⚠️ **Never issue a no-timeout `tell`/`stop` to the actor's own `ActorRef` from inside one of its handlers when the mailbox may be full.** The only consumer of the mailbox is the actor's own loop, which is parked awaiting that handler — the wait can never be satisfied and `kill()` cannot interrupt it. Use `tell_with_timeout`, enlarge the mailbox, or send from a spawned task. (With the `deadlock-detection` feature enabled, this situation panics immediately instead of hanging; a full-mailbox self-`ask` is likewise detected.)
 
 2.  **Rate Limiting**:
     Implement rate limiting within the actor:

--- a/docs/deadlock_detection.md
+++ b/docs/deadlock_detection.md
@@ -235,9 +235,12 @@ let response = rx.await?;
 
 ## Limitations
 
-- **`blocking_ask`**: Runs on a separate thread for non-actor contexts. Not covered by detection since these callers can't form cycles.
-- **Concurrent asks in a handler**: Using `tokio::join!` or `tokio::select!` to send multiple `ask` calls simultaneously may miss some cycles, as the wait-for graph stores one edge per actor.
+- **`blocking_ask` from non-actor contexts**: Runs on a separate thread; not covered by detection since these callers can't form cycles. (Calls made from *inside* an actor's handler **are** tracked — the actor identity is propagated into the dedicated thread, and a cycle panics immediately.)
+- **Concurrent asks in a handler**: Fully tracked — the wait-for graph is a multiset, so `tokio::join!`-style concurrent `ask` calls each register their own edge and are all considered when searching for cycles.
+- **Stored ask futures (false-positive risk)**: An edge means "this `ask` is outstanding", and it lives as long as the ask *future*. If a handler polls an `ask` once and then stores the unresolved future in actor state (e.g. a `FuturesUnordered` driven from `on_idle`), the detector treats the actor as blocked even though it keeps processing messages — a later ask back into it can panic on a phantom cycle in a perfectly healthy system. Don't store ask futures across handler invocations; use `tell` with a callback channel instead.
 - **`tokio::spawn` inside handlers**: New tokio tasks don't inherit the `task_local` actor identity, so `ask` calls from spawned tasks are not tracked.
+
+Besides `ask` cycles, the feature also detects one `tell`-side hazard: a no-timeout `tell`/`stop`/`blocking_tell` issued to the actor's **own full mailbox** from inside one of its handlers panics immediately (the admission wait can never be satisfied — the mailbox's only consumer is parked awaiting that handler — and `kill()` cannot interrupt it). Bounded waits (`tell_with_timeout`, the priority variants) are exempt: they resolve as recoverable timeouts.
 
 ## Performance Impact
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -179,7 +179,7 @@ When the `metrics` feature is disabled, all related code is completely excluded 
 
 ### Eventual Consistency
 
-During concurrent reads/writes, individual fields are consistent, but the snapshot as a whole may not reflect exactly the same point in time. This is sufficient for monitoring purposes and is an intentional design choice to maintain lock-free performance.
+During concurrent reads/writes, each underlying counter is read atomically, but the snapshot as a whole may not reflect exactly the same point in time. Derived values (the averages) are computed from two separately-read counters and are clamped to their corresponding maxima so `avg <= max` always holds; the residual skew is bounded by a single message's duration. There is also no ordering guarantee between an `ask` reply and the metrics that recorded it — immediately after `ask().await` resolves, the counters may not yet include that message. This is sufficient for monitoring purposes and is an intentional design choice to maintain lock-free performance.
 
 ### Overflow Protection
 

--- a/examples/actor_blocking_task.rs
+++ b/examples/actor_blocking_task.rs
@@ -281,15 +281,13 @@ async fn main() -> Result<()> {
             );
             actor.task_handle.await.expect("Failed to join task handle");
         }
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
-            println!("Actor stop failed: {error}. Phase: {phase}, Killed: {killed}");
-            if let Some(actor) = actor {
+        rsactor::ActorResult::Failed { failure, killed } => {
+            println!(
+                "Actor stop failed: {}. Phase: {}, Killed: {killed}",
+                failure.error(),
+                failure.phase()
+            );
+            if let Some(actor) = failure.actor() {
                 println!(
                     "Final state: factor={:.2}, latest_value={:?}",
                     actor.factor, actor.latest_value

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -241,15 +241,13 @@ async fn main() -> Result<()> {
                 actor.factor, actor.latest_value
             );
         }
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            killed,
-            phase,
-            ..
-        } => {
-            println!("Actor stop failed: {error}. Phase: {phase}, Killed: {killed}");
-            if let Some(actor) = actor {
+        rsactor::ActorResult::Failed { failure, killed } => {
+            println!(
+                "Actor stop failed: {}. Phase: {}, Killed: {killed}",
+                failure.error(),
+                failure.phase()
+            );
+            if let Some(actor) = failure.actor() {
                 println!(
                     "Final state: factor={:.2}, latest_value={:?}",
                     actor.factor, actor.latest_value

--- a/examples/actor_with_timeout.rs
+++ b/examples/actor_with_timeout.rs
@@ -229,13 +229,12 @@ async fn main() -> Result<()> {
         rsactor::ActorResult::Completed { actor: _, killed } => {
             info!("Actor stopped successfully. Killed: {killed}");
         }
-        rsactor::ActorResult::Failed {
-            error,
-            killed,
-            phase,
-            ..
-        } => {
-            info!("Actor stop failed: {error}. Killed: {killed}, Phase: {phase}");
+        rsactor::ActorResult::Failed { failure, killed } => {
+            info!(
+                "Actor stop failed: {}. Killed: {killed}, Phase: {}",
+                failure.error(),
+                failure.phase()
+            );
         }
     }
     info!("Example finished successfully");

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -145,19 +145,13 @@ async fn main() -> Result<()> {
                 actor.count, killed
             );
         }
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             println!(
                 "Actor stop failed: {}. Phase: {}, Killed: {}. Final count: {}",
-                error,
-                phase,
+                failure.error(),
+                failure.phase(),
                 killed,
-                actor.as_ref().map(|a| a.count).unwrap_or(0)
+                failure.actor().map(|a| a.count).unwrap_or(0)
             );
         }
     }

--- a/examples/dining_philosophers.rs
+++ b/examples/dining_philosophers.rs
@@ -503,8 +503,8 @@ async fn main() -> Result<()> {
                     actor.forks
                 );
             }
-            ActorResult::Failed { error, .. } => {
-                eprintln!("Table failed to start: {error:?}");
+            ActorResult::Failed { failure, .. } => {
+                eprintln!("Table failed to start: {:?}", failure.error());
             }
         },
         Err(e) => eprintln!("Error joining table task: {e:?}"),
@@ -519,8 +519,12 @@ async fn main() -> Result<()> {
                     actor.id, actor.name, actor.eat_count
                 );
             }
-            Ok(ActorResult::Failed { error, phase, .. }) => {
-                eprintln!("Philosopher failed to phase({phase}): {error:?}");
+            Ok(ActorResult::Failed { failure, .. }) => {
+                eprintln!(
+                    "Philosopher failed to phase({}): {:?}",
+                    failure.phase(),
+                    failure.error()
+                );
             }
             Err(e) => {
                 eprintln!("Error joining philosopher task: {e:?}");

--- a/examples/kill_demo.rs
+++ b/examples/kill_demo.rs
@@ -88,22 +88,16 @@ async fn main() -> Result<()> {
         rsactor::ActorResult::Completed { actor, killed } => {
             println!("Actor '{}' completed. Killed: {}", actor.name, killed);
         }
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             println!(
                 "Actor failed: {}. Phase: {:?}, Killed: {}, Final name: {}",
-                error,
-                phase,
+                failure.error(),
+                failure.phase(),
                 killed,
-                actor
-                    .as_ref()
-                    .map(|a| &a.name)
-                    .unwrap_or(&"Unknown".to_string())
+                failure
+                    .actor()
+                    .map(|a| a.name.as_str())
+                    .unwrap_or("Unknown")
             );
         }
     }

--- a/examples/message_macro_demo.rs
+++ b/examples/message_macro_demo.rs
@@ -98,8 +98,8 @@ async fn main() -> Result<()> {
                 actor.value, killed
             );
         }
-        rsactor::ActorResult::Failed { error, .. } => {
-            println!("❌ Calculator failed: {error}");
+        rsactor::ActorResult::Failed { failure, .. } => {
+            println!("❌ Calculator failed: {}", failure.error());
         }
     }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::actor_ref::ActorRef;
-use crate::{ActorResult, ActorWeak, ControlSignal, FailurePhase, MailboxMessage};
+use crate::{ActorFailure, ActorResult, ActorWeak, ControlSignal, MailboxMessage};
 use futures::stream::{BoxStream, SelectAll, StreamExt};
 use std::{fmt::Debug, future::Future};
 use tokio::sync::mpsc;
@@ -11,6 +11,20 @@ use tracing::{debug, error, Instrument};
 /// Boxed, dynamically-typed stream of idle events delivered to an actor's [`Actor::on_idle`]
 /// handler. Subscriptions are added via [`ActorRef::subscribe_idle`].
 pub(crate) type IdleEventStream<T> = BoxStream<'static, <T as Actor>::IdleEvent>;
+
+/// Upper bound on how long the graceful-stop priority drain waits for one more
+/// message before concluding the channel is quiet.
+///
+/// The drain (see the `StopGracefully` arm in [`run_actor_lifecycle`]) must use
+/// `recv()` rather than `try_recv()` to observe sends from permits acquired
+/// before `close()`, but a bare `recv().await` can suffer a lost wakeup when a
+/// racing send is cancelled around `close()` (its briefly-held permit is
+/// released without a receiver wake). One full quiet window with no delivery
+/// means no sender is mid-send — a granted permit is pushed synchronously in
+/// the same poll — so concluding the drain after it cannot drop a deliverable
+/// message. The window is paid at most once per graceful stop, and only when
+/// the channel is already quiet or wedged by that race.
+const PRIORITY_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_millis(10);
 
 /// Wrap a future with CURRENT_ACTOR scope and await it.
 /// Used for on_start, message handler, on_stop.
@@ -30,8 +44,8 @@ macro_rules! run_with_actor_scope {
 /// Process a single Envelope from any of the message-receiving paths
 /// (regular mailbox, priority mailbox, or stop-time priority drain).
 ///
-/// Centralizes the tracing span, optional metrics guard, and dispatch boilerplate
-/// so the three call sites stay in sync.
+/// Centralizes the tracing span, optional metrics recording, and dispatch
+/// boilerplate so the three call sites stay in sync.
 macro_rules! process_envelope {
     (
         actor_id = $actor_id:expr,
@@ -40,7 +54,7 @@ macro_rules! process_envelope {
         reply_channel = $reply_channel:expr,
         actor_ref = $actor_ref:expr,
         span_name = $span_name:literal,
-        guard = $guard_type:ident $(,)?
+        record = $record_fn:ident $(,)?
     ) => {{
         #[cfg(feature = "tracing")]
         let msg_span = tracing::debug_span!($span_name);
@@ -57,7 +71,7 @@ macro_rules! process_envelope {
         #[cfg(feature = "metrics")]
         let metrics_collector = $actor_ref.metrics.clone();
         #[cfg(feature = "metrics")]
-        let _metrics_guard = crate::metrics::collector::$guard_type::new(&metrics_collector);
+        let metrics_start = std::time::Instant::now();
 
         run_with_actor_scope!(
             $actor_id,
@@ -65,6 +79,14 @@ macro_rules! process_envelope {
                 .handle_message(&mut $actor, $actor_ref, $reply_channel)
                 .instrument(msg_span)
         );
+
+        // Recorded only after the handler future returned normally. A panic
+        // unwinds past this point and a cancellation (JoinHandle::abort, runtime
+        // shutdown) drops the future at an `.await` before reaching it, so
+        // neither inflates the documented "successfully processed" counters —
+        // an RAII guard recorded cancelled messages as successes.
+        #[cfg(feature = "metrics")]
+        metrics_collector.$record_fn(metrics_start.elapsed());
 
         #[cfg(feature = "tracing")]
         debug!(
@@ -87,16 +109,16 @@ macro_rules! process_envelope {
 /// are handled depends on when they occur:
 ///
 /// 1. Errors in [`on_start`](Actor::on_start): The actor fails to initialize. The error is captured in
-///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
-///    [`FailurePhase::OnStart`](crate::FailurePhase::OnStart) and `actor` set to `None`.
+///    [`ActorResult::Failed`](crate::ActorResult::Failed) as
+///    [`ActorFailure::OnStart`](crate::ActorFailure::OnStart) — no actor instance exists.
 ///
 /// 2. Errors in [`on_idle`](Actor::on_idle): The actor terminates during runtime. The error is captured in
-///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
-///    [`FailurePhase::OnIdle`](crate::FailurePhase::OnIdle) and `actor` contains the actor instance.
+///    [`ActorResult::Failed`](crate::ActorResult::Failed) as
+///    [`ActorFailure::OnIdle`](crate::ActorFailure::OnIdle), carrying the actor instance.
 ///
 /// 3. Errors in [`on_stop`](Actor::on_stop): The actor fails during cleanup. The error is captured in
-///    [`ActorResult::Failed`](crate::ActorResult::Failed) with `phase` set to
-///    [`FailurePhase::OnStop`](crate::FailurePhase::OnStop) and `actor` contains the actor instance.
+///    [`ActorResult::Failed`](crate::ActorResult::Failed) as
+///    [`ActorFailure::OnStop`](crate::ActorFailure::OnStop), carrying the actor instance.
 ///
 /// When awaiting the completion of an actor, check the [`ActorResult`] to determine
 /// the outcome and access any errors:
@@ -215,9 +237,9 @@ pub trait Actor: Sized + Send + 'static {
     ///             // The `actor` field contains the final actor instance
     ///             // The `killed` flag indicates whether the actor was stopped or killed
     ///         }
-    ///         ActorResult::Failed { error, phase, .. } => {
-    ///             println!("Actor failed in phase {:?}: {}", phase, error);
-    ///             // The `phase` field indicates which lifecycle method caused the failure
+    ///         ActorResult::Failed { failure, .. } => {
+    ///             println!("Actor failed in phase {:?}: {}", failure.phase(), failure.error());
+    ///             // `failure.phase()` indicates which lifecycle method caused the failure
     ///             // See [`FailurePhase`](crate::FailurePhase) enum for possible values
     ///         }
     ///     }
@@ -545,12 +567,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             actor
         }
         Err(e) => {
-            error!("Actor {actor_id} on_start failed: {e:?}");
+            error!("Actor {actor_id} on_start failed: {e}");
             return ActorResult::Failed {
-                actor: None,
-                error: e,
-                secondary_error: None,
-                phase: FailurePhase::OnStart,
+                failure: ActorFailure::OnStart { error: e },
                 killed: false,
             };
         }
@@ -570,10 +589,12 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
 
     // Aggregates every stream registered via `ActorRef::subscribe_idle`. New
     // streams arrive on `idle_subscribe_receiver`; completed streams are removed
-    // automatically by `SelectAll`. The branch below is guarded so the runtime
-    // does not poll the empty set forever — `futures::stream::SelectAll::next()`
-    // on an empty set returns `Poll::Ready(None)` immediately, which would
-    // busy-loop without the guard.
+    // automatically by `SelectAll`. The branch below carries an
+    // `if !idle_streams.is_empty()` guard as an optimization: without it,
+    // `SelectAll::next()` on an empty set resolves to `Poll::Ready(None)`
+    // immediately, the `Some(event)` pattern fails to match, and `select!`
+    // disables that branch for the remainder of the call — one wasted poll per
+    // loop iteration (not a busy-loop). The guard skips even that poll.
     let mut idle_streams: SelectAll<IdleEventStream<T>> = SelectAll::new();
 
     // Drain any subscriptions queued during `on_start`. The subscribe arm in
@@ -599,14 +620,14 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             maybe_terminate = terminate_receiver.recv() => {
                 match maybe_terminate {
                     Some(_) => {
-                        // Explicit kill() was called
-                        #[cfg(feature = "tracing")]
+                        // Explicit kill() was called. Any messages still queued in
+                        // the regular and priority mailboxes are intentionally
+                        // discarded — kill() means "do not process anything else".
                         debug!("Actor termination via kill() method");
                         killed = true;
                     }
                     None => {
                         // All actor_ref instances were dropped
-                        #[cfg(feature = "tracing")]
                         debug!("Actor termination due to all actor_ref instances being dropped");
                         killed = false;
                     }
@@ -622,12 +643,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     actor_id,
                     actor.on_stop(&actor_weak, killed).instrument(on_stop_span)
                 ) {
-                    error!("Actor {actor_id} on_stop failed during termination: {e:?}");
+                    error!("Actor {actor_id} on_stop failed during termination: {e}");
                     return ActorResult::Failed {
-                        actor: Some(actor),
-                        error: e,
-                        secondary_error: None,
-                        phase: FailurePhase::OnStop,
+                        failure: ActorFailure::OnStop { actor, error: e },
                         killed,
                     };
                 }
@@ -644,7 +662,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 }
             } => {
                 match maybe_priority {
-                    Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref }) => {
+                    Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref, ask_edge: _ask_edge }) => {
                         process_envelope!(
                             actor_id = actor_id,
                             actor = actor,
@@ -652,8 +670,11 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             reply_channel = reply_channel,
                             actor_ref = actor_ref,
                             span_name = "actor_process_priority_message",
-                            guard = PriorityMessageProcessingGuard,
+                            record = record_priority_message,
                         );
+                        // `_ask_edge` (deadlock-detection token) drops here, right
+                        // after the reply was sent — removing the wait-for edge
+                        // before the next message is processed.
                     }
                     Some(MailboxMessage::StopGracefully(_)) => {
                         // Invariant: stop() only writes to the regular mailbox, never the
@@ -707,7 +728,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             // Messages can be: regular message envelopes or graceful stop signals
             maybe_message = receiver.recv() => {
                 match maybe_message {
-                    Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref }) => {
+                    Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref, ask_edge: _ask_edge }) => {
                         process_envelope!(
                             actor_id = actor_id,
                             actor = actor,
@@ -715,26 +736,54 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             reply_channel = reply_channel,
                             actor_ref = actor_ref,
                             span_name = "actor_process_message",
-                            guard = MessageProcessingGuard,
+                            record = record_message,
                         );
+                        // `_ask_edge` (deadlock-detection token) drops here, right
+                        // after the reply was sent — removing the wait-for edge
+                        // before the next message is processed.
                     }
-                    _msg @ (Some(MailboxMessage::StopGracefully(_)) | None) => {
-                        #[cfg(feature = "tracing")]
-                        match &_msg {
+                    msg @ (Some(MailboxMessage::StopGracefully(_)) | None) => {
+                        match &msg {
                             Some(_) => debug!("Actor termination: explicit graceful stop"),
                             None => debug!("Actor termination: all strong refs dropped"),
                         }
 
                         // Drain any priority messages already enqueued before stopping.
-                        // close() refuses new priority sends (they get Closed errors and
-                        // are recorded as dead letters), then try_recv() pulls everything
-                        // currently in the slot. This closes the race where a sender
-                        // pushed a priority message just before stop() arrived.
+                        // close() refuses *new* priority sends (they get Closed errors
+                        // and are recorded as dead letters), but tokio documents that a
+                        // sender which already acquired a `Permit` — and `send().await`
+                        // is reserve-then-send under the hood — can still deliver after
+                        // close(). `recv()` is the only drain that observes those
+                        // in-flight permit sends: it returns `None` only once the buffer
+                        // is empty *and* every outstanding permit has been consumed. A
+                        // `try_recv()` loop here would race with a permit holder and
+                        // silently drop its message without a dead letter.
                         if let Some(rx) = priority_receiver.as_mut() {
                             rx.close();
-                            while let Ok(msg) = rx.try_recv() {
+                            loop {
+                                // A bare `recv().await` here can park forever: a
+                                // sender whose `send().await` is cancelled (its
+                                // timeout fires) right around close() briefly
+                                // holds — then silently releases — the channel
+                                // permit, and tokio does not wake the receiver on
+                                // that release. With the caller still holding an
+                                // ActorRef (so the channel never fully closes),
+                                // the lost wakeup becomes a deadlock. The bounded
+                                // wait converts it into drain completion, which
+                                // is safe: a full quiet window with no delivery
+                                // means no sender is mid-send (a granted permit
+                                // is pushed synchronously in the same poll).
+                                let msg = match tokio::time::timeout(
+                                    PRIORITY_DRAIN_QUIET_PERIOD,
+                                    rx.recv(),
+                                )
+                                .await
+                                {
+                                    Ok(Some(msg)) => msg,
+                                    Ok(None) | Err(_) => break,
+                                };
                                 match msg {
-                                    MailboxMessage::Envelope { payload, reply_channel, actor_ref } => {
+                                    MailboxMessage::Envelope { payload, reply_channel, actor_ref, ask_edge: _ask_edge } => {
                                         process_envelope!(
                                             actor_id = actor_id,
                                             actor = actor,
@@ -742,7 +791,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                                             reply_channel = reply_channel,
                                             actor_ref = actor_ref,
                                             span_name = "actor_drain_priority_message",
-                                            guard = PriorityMessageProcessingGuard,
+                                            record = record_priority_message,
                                         );
                                     }
                                     MailboxMessage::StopGracefully(_) => {
@@ -769,12 +818,9 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             actor_id,
                             actor.on_stop(&actor_weak, false).instrument(on_stop_span)
                         ) {
-                            error!("Actor {actor_id} on_stop failed during graceful stop: {e:?}");
+                            error!("Actor {actor_id} on_stop failed during graceful stop: {e}");
                             return ActorResult::Failed {
-                                actor: Some(actor),
-                                error: e,
-                                secondary_error: None,
-                                phase: FailurePhase::OnStop,
+                                failure: ActorFailure::OnStop { actor, error: e },
                                 killed: false,
                             };
                         }
@@ -786,8 +832,12 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
 
             // Dispatch one event from the merged set of subscribed idle streams
             // to the actor's `on_idle` handler. The `if !idle_streams.is_empty()`
-            // guard is essential: `SelectAll::next()` on an empty set resolves
-            // to `Poll::Ready(None)` immediately and would busy-loop.
+            // guard is an optimization, not a correctness requirement: on an
+            // empty set `SelectAll::next()` resolves to `Poll::Ready(None)`
+            // immediately, the `Some(event)` pattern fails to match, and
+            // `select!` merely disables this branch for the remainder of the
+            // current call — costing one wasted poll per loop iteration. The
+            // guard skips that poll entirely.
             //
             // Each underlying stream is responsible for its own cancel-safety.
             // Streams that complete (return None) are removed from the set
@@ -804,7 +854,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 );
 
                 if let Err(e) = result {
-                    error!("Actor {actor_id} on_idle error: {e:?}");
+                    error!("Actor {actor_id} on_idle error: {e}");
 
                     // Call on_stop for cleanup even after on_idle failure
                     #[cfg(feature = "tracing")]
@@ -812,25 +862,29 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     #[cfg(not(feature = "tracing"))]
                     let on_stop_span = tracing::Span::none();
 
-                    let (phase, secondary_error) = match run_with_actor_scope!(
+                    let failure = match run_with_actor_scope!(
                         actor_id,
                         actor.on_stop(&actor_weak, false).instrument(on_stop_span)
                     ) {
                         Err(stop_err) => {
                             error!(
-                                "Actor {actor_id} on_stop failed during on_idle error cleanup: {stop_err:?}"
+                                "Actor {actor_id} on_stop failed during on_idle error cleanup: {stop_err}"
                             );
-                            (FailurePhase::OnIdleThenOnStop, Some(stop_err))
+                            ActorFailure::OnIdleThenOnStop {
+                                actor,
+                                error: e,
+                                stop_error: stop_err,
+                            }
                         }
-                        Ok(()) => (FailurePhase::OnIdle, None),
+                        Ok(()) => ActorFailure::OnIdle { actor, error: e },
                     };
 
+                    // `killed` is necessarily false here: the only assignment to
+                    // true happens in the terminate arm, which returns or breaks
+                    // out of the loop before this arm can run again.
                     return ActorResult::Failed {
-                        actor: Some(actor),
-                        error: e,
-                        secondary_error,
-                        phase,
-                        killed,
+                        failure,
+                        killed: false,
                     };
                 }
             }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -30,12 +30,21 @@ const PRIORITY_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::fr
 /// receiver-side dead letter for each message that was accepted into a
 /// mailbox but will never be processed.
 ///
-/// - `tell`-style envelopes (no reply channel) are the only silent case — the
-///   sender already observed `Ok` — so each gets a
+/// - `tell`-style envelopes (no reply channel) are silent losses — the sender
+///   already observed `Ok` — so each gets a
 ///   [`DeadLetterReason`](crate::DeadLetterReason)`::DiscardedAtShutdown` record.
-/// - `ask` envelopes are skipped: dropping their reply channel wakes the
-///   caller, which records its own `ReplyDropped` dead letter — recording
-///   here too would double-count.
+/// - `ask` envelopes whose caller is still waiting are skipped: dropping
+///   their reply channel wakes the caller, which records its own
+///   `ReplyDropped` dead letter — recording here too would double-count.
+/// - `ask` envelopes whose reply channel is already **closed** are recorded
+///   here: a closed reply receiver proves the asking future is gone (e.g.
+///   cancelled by a `select!` drop or an expired `*_with_timeout` deadline
+///   after admission), so dropping the reply sender wakes nobody and no
+///   caller-side `ReplyDropped` record will ever exist. Note the timeout
+///   case has already left a caller-side `Timeout` record, so such a message
+///   carries two dead-letter records — one per perspective (caller: no reply
+///   in time; receiver: accepted message never processed). A plain
+///   cancellation leaves only this receiver-side record.
 /// - Queued-but-never-installed idle subscriptions are counted and logged at
 ///   debug level; the streams' resources are released by the drop itself.
 ///
@@ -53,7 +62,8 @@ fn discard_queued_messages<T: Actor>(
     fn drain_one<T: Actor>(
         actor_id: crate::Identity,
         rx: &mut mpsc::Receiver<MailboxMessage<T>>,
-        operation: &'static str,
+        tell_op: &'static str,
+        ask_op: &'static str,
     ) {
         rx.close();
         while let Ok(msg) = rx.try_recv() {
@@ -63,7 +73,12 @@ fn discard_queued_messages<T: Actor>(
                 ..
             } = msg
             {
-                if reply_channel.is_none() {
+                let operation = match &reply_channel {
+                    None => Some(tell_op),
+                    Some(tx) if tx.is_closed() => Some(ask_op),
+                    Some(_) => None,
+                };
+                if let Some(operation) = operation {
                     crate::dead_letter::record_erased(
                         actor_id,
                         crate::dead_letter::DeadLetterReason::DiscardedAtShutdown,
@@ -75,9 +90,9 @@ fn discard_queued_messages<T: Actor>(
         }
     }
 
-    drain_one(actor_id, receiver, "tell");
+    drain_one(actor_id, receiver, "tell", "ask");
     if let Some(rx) = priority_receiver {
-        drain_one(actor_id, rx, "tell_priority");
+        drain_one(actor_id, rx, "tell_priority", "ask_priority");
     }
     if let Some(rx) = idle_subscribe_receiver {
         rx.close();
@@ -87,6 +102,52 @@ fn discard_queued_messages<T: Actor>(
         }
         if dropped > 0 {
             debug!("Actor {actor_id} dropped {dropped} idle subscription(s) queued at shutdown");
+        }
+    }
+}
+
+/// Owns every inbound channel receiver for the lifetime of the actor task and
+/// runs the final-shutdown drain ([`discard_queued_messages`]) when dropped.
+///
+/// Drop-based so the drain runs on **every** exit from
+/// [`run_actor_lifecycle`]: the normal control-flow returns, but also a panic
+/// unwinding out of a message handler or lifecycle hook, and outright task
+/// cancellation (`JoinHandle::abort`, runtime shutdown) dropping the future
+/// at an `.await`. Without the guard those abnormal exits dropped the
+/// buffered envelopes silently — violating the `DiscardedAtShutdown`
+/// guarantee that accepted-but-unprocessed `tell` messages leave a
+/// receiver-side dead-letter record (their senders already observed `Ok`).
+struct LifecycleChannels<T: Actor> {
+    actor_id: crate::Identity,
+    receiver: mpsc::Receiver<MailboxMessage<T>>,
+    priority_receiver: Option<mpsc::Receiver<MailboxMessage<T>>>,
+    terminate_receiver: mpsc::Receiver<ControlSignal>,
+    idle_subscribe_receiver: Option<mpsc::Receiver<IdleEventStream<T>>>,
+}
+
+impl<T: Actor> Drop for LifecycleChannels<T> {
+    fn drop(&mut self) {
+        // Closing the terminate channel signals shutdown completion to
+        // observers; the drain then records dead letters for everything that
+        // was accepted but never processed.
+        self.terminate_receiver.close();
+        let mut drain = std::panic::AssertUnwindSafe(|| {
+            discard_queued_messages(
+                self.actor_id,
+                &mut self.receiver,
+                self.priority_receiver.as_mut(),
+                self.idle_subscribe_receiver.as_mut(),
+            )
+        });
+        if std::thread::panicking() {
+            // The drain calls into the global tracing subscriber (dead-letter
+            // warn! records) — user code that may itself panic. During a
+            // handler-panic unwind a second panic escaping this Drop would
+            // abort the process; swallow it so the original panic surfaces
+            // through the JoinHandle instead.
+            let _ = std::panic::catch_unwind(drain);
+        } else {
+            drain.0();
         }
     }
 }
@@ -248,8 +309,18 @@ pub trait Actor: Sized + Send + 'static {
     /// # Parameters
     ///
     /// - `args`: Initialization data (of type `Self::Args`) provided when the actor is spawned
-    /// - `actor_ref`: A reference to the actor's own [`ActorRef`](crate::actor_ref::ActorRef), which can
-    ///   be stored in the actor for self-reference or for initializing child actors
+    /// - `actor_ref`: A reference to the actor's own [`ActorRef`](crate::actor_ref::ActorRef) —
+    ///   useful for handing to child actors that need a handle back to this one, or for
+    ///   subscribing idle streams. **Do not store a strong clone of it in the actor's own
+    ///   state.** The runtime task owns the actor instance, so an instance that owns a
+    ///   strong self-reference forms a permanent keep-alive cycle: the ref-drop shutdown
+    ///   documented on [`on_stop`](Actor::on_stop) can never fire, `on_stop` never runs,
+    ///   the `JoinHandle` never resolves, and once every external ref is dropped there is
+    ///   no handle left to call `stop()`/`kill()` with — the actor task leaks for the life
+    ///   of the runtime. For self-reference, store
+    ///   [`ActorRef::downgrade(actor_ref)`](crate::actor_ref::ActorRef::downgrade) (an
+    ///   [`ActorWeak`](crate::ActorWeak)) and upgrade per use — the same rule documented on
+    ///   [`subscribe_idle`](crate::ActorRef::subscribe_idle) for captured streams
     ///
     /// # Returns
     ///
@@ -605,10 +676,10 @@ pub trait Message<T: Send + 'static>: Actor {
 pub(crate) async fn run_actor_lifecycle<T: Actor>(
     args: T::Args,
     actor_ref: ActorRef<T>,
-    mut receiver: mpsc::Receiver<MailboxMessage<T>>,
-    mut priority_receiver: Option<mpsc::Receiver<MailboxMessage<T>>>,
-    mut terminate_receiver: mpsc::Receiver<ControlSignal>,
-    mut idle_subscribe_receiver: Option<mpsc::Receiver<IdleEventStream<T>>>,
+    receiver: mpsc::Receiver<MailboxMessage<T>>,
+    priority_receiver: Option<mpsc::Receiver<MailboxMessage<T>>>,
+    terminate_receiver: mpsc::Receiver<ControlSignal>,
+    idle_subscribe_receiver: Option<mpsc::Receiver<IdleEventStream<T>>>,
 ) -> ActorResult<T> {
     // The subscribe channel is `None` when the actor was spawned without
     // `SpawnOptions::with_idle()` — its select arm then resolves to `pending()`
@@ -617,6 +688,18 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     // returns None, it is replaced with `None` so the arm becomes pending and
     // does not busy-loop. Normal shutdown still propagates via the mailbox arm.
     let actor_id = actor_ref.identity();
+
+    // From here on the receivers live inside the drop guard, so the
+    // shutdown drain runs on every exit — normal returns, handler panics,
+    // and task cancellation alike. No explicit drain calls are needed (or
+    // present) on the return paths below.
+    let mut chans = LifecycleChannels {
+        actor_id,
+        receiver,
+        priority_receiver,
+        terminate_receiver,
+        idle_subscribe_receiver,
+    };
 
     #[cfg(feature = "tracing")]
     let on_start_span = tracing::debug_span!("actor_on_start");
@@ -633,13 +716,6 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
         }
         Err(e) => {
             error!("Actor {actor_id} on_start failed: {e}");
-            terminate_receiver.close();
-            discard_queued_messages(
-                actor_id,
-                &mut receiver,
-                priority_receiver.as_mut(),
-                idle_subscribe_receiver.as_mut(),
-            );
             return ActorResult::Failed {
                 failure: ActorFailure::OnStart { error: e },
                 killed: false,
@@ -655,6 +731,11 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     debug!("Actor {actor_id} runtime starting - entering main processing loop.");
 
     let actor_weak = ActorRef::downgrade(&actor_ref);
+    // Keep the collector reachable for the idle branch below (the strong
+    // actor_ref is dropped next; the envelopes carry their own refs for the
+    // message branches).
+    #[cfg(feature = "metrics")]
+    let metrics = actor_ref.metrics.clone();
     drop(actor_ref); // Drop the strong reference to allow graceful shutdown detection
 
     let mut killed = false;
@@ -674,7 +755,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
     // synchronously up front means the very first iteration can already
     // service idle events and avoids N round-trips through the select! when
     // `on_start` calls `subscribe_idle` N times.
-    if let Some(rx) = idle_subscribe_receiver.as_mut() {
+    if let Some(rx) = chans.idle_subscribe_receiver.as_mut() {
         while let Ok(stream) = rx.try_recv() {
             idle_streams.push(stream);
         }
@@ -689,7 +770,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             // This ensures that termination requests are processed immediately when available
             biased;
 
-            maybe_terminate = terminate_receiver.recv() => {
+            maybe_terminate = chans.terminate_receiver.recv() => {
                 match maybe_terminate {
                     Some(_) => {
                         // Explicit kill() was called. Any messages still queued in
@@ -710,7 +791,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 // fast with Error::Send instead of returning Ok for a stream
                 // that would be silently discarded. (A call racing this close
                 // can still slip through; the shutdown drain logs those.)
-                if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                if let Some(rx) = chans.idle_subscribe_receiver.as_mut() {
                     rx.close();
                 }
 
@@ -725,13 +806,6 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     actor.on_stop(&actor_weak, killed).instrument(on_stop_span)
                 ) {
                     error!("Actor {actor_id} on_stop failed during termination: {e}");
-                    terminate_receiver.close();
-                    discard_queued_messages(
-                        actor_id,
-                        &mut receiver,
-                        priority_receiver.as_mut(),
-                        idle_subscribe_receiver.as_mut(),
-                    );
                     return ActorResult::Failed {
                         failure: ActorFailure::OnStop { actor, error: e },
                         killed,
@@ -744,7 +818,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             // When the priority channel is disabled (`None`), this branch becomes a
             // never-ready future and is effectively skipped on every iteration.
             maybe_priority = async {
-                match priority_receiver.as_mut() {
+                match chans.priority_receiver.as_mut() {
                     Some(rx) => rx.recv().await,
                     None => std::future::pending::<Option<MailboxMessage<T>>>().await,
                 }
@@ -782,7 +856,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         // receiver — subsequent iterations hit the `None` arm of the
                         // async block above and resolve to `pending()`. The actor stays
                         // alive on the regular mailbox until normal termination.
-                        priority_receiver = None;
+                        chans.priority_receiver = None;
                     }
                 }
             }
@@ -797,7 +871,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
             // becomes pending — graceful termination then propagates via the
             // mailbox arm below.
             maybe_subscription = async {
-                match idle_subscribe_receiver.as_mut() {
+                match chans.idle_subscribe_receiver.as_mut() {
                     Some(rx) => rx.recv().await,
                     None => std::future::pending::<Option<IdleEventStream<T>>>().await,
                 }
@@ -807,14 +881,14 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         idle_streams.push(stream);
                     }
                     None => {
-                        idle_subscribe_receiver = None;
+                        chans.idle_subscribe_receiver = None;
                     }
                 }
             }
 
             // Process incoming messages from the actor's mailbox
             // Messages can be: regular message envelopes or graceful stop signals
-            maybe_message = receiver.recv() => {
+            maybe_message = chans.receiver.recv() => {
                 match maybe_message {
                     Some(MailboxMessage::Envelope { payload, reply_channel, actor_ref, ask_edge: _ask_edge }) => {
                         process_envelope!(
@@ -840,7 +914,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         // the subscribe channel now so concurrent subscribe_idle
                         // calls fail fast with Error::Send instead of returning
                         // Ok for a stream that would be silently discarded.
-                        if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                        if let Some(rx) = chans.idle_subscribe_receiver.as_mut() {
                             rx.close();
                         }
 
@@ -854,7 +928,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         // is empty *and* every outstanding permit has been consumed. A
                         // `try_recv()` loop here would race with a permit holder and
                         // silently drop its message without a dead letter.
-                        if let Some(rx) = priority_receiver.as_mut() {
+                        if let Some(rx) = chans.priority_receiver.as_mut() {
                             rx.close();
                             loop {
                                 // A bare `recv().await` here can park forever: a
@@ -915,13 +989,6 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             actor.on_stop(&actor_weak, false).instrument(on_stop_span)
                         ) {
                             error!("Actor {actor_id} on_stop failed during graceful stop: {e}");
-                            terminate_receiver.close();
-                            discard_queued_messages(
-                                actor_id,
-                                &mut receiver,
-                                priority_receiver.as_mut(),
-                                idle_subscribe_receiver.as_mut(),
-                            );
                             return ActorResult::Failed {
                                 failure: ActorFailure::OnStop { actor, error: e },
                                 killed: false,
@@ -951,10 +1018,21 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 #[cfg(not(feature = "tracing"))]
                 let on_idle_span = tracing::Span::none();
 
+                #[cfg(feature = "metrics")]
+                let metrics_start = std::time::Instant::now();
+
                 let result = run_with_actor_scope!(
                     actor_id,
                     actor.on_idle(event, &actor_weak).instrument(on_idle_span)
                 );
+
+                // Same recording discipline as process_envelope!: only after a
+                // normal Ok return, so failures and cancellations do not
+                // inflate the "successfully processed" counters.
+                #[cfg(feature = "metrics")]
+                if result.is_ok() {
+                    metrics.record_idle_event(metrics_start.elapsed());
+                }
 
                 if let Err(e) = result {
                     error!("Actor {actor_id} on_idle error: {e}");
@@ -962,7 +1040,7 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     // No further idle subscriptions will be installed: close the
                     // subscribe channel now so concurrent subscribe_idle calls
                     // fail fast instead of returning Ok for a discarded stream.
-                    if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                    if let Some(rx) = chans.idle_subscribe_receiver.as_mut() {
                         rx.close();
                     }
 
@@ -989,14 +1067,6 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         Ok(()) => ActorFailure::OnIdle { actor, error: e },
                     };
 
-                    terminate_receiver.close();
-                    discard_queued_messages(
-                        actor_id,
-                        &mut receiver,
-                        priority_receiver.as_mut(),
-                        idle_subscribe_receiver.as_mut(),
-                    );
-
                     // `killed` is necessarily false here: the only assignment to
                     // true happens in the terminate arm, which returns or breaks
                     // out of the loop before this arm can run again.
@@ -1009,16 +1079,10 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
         }
     }
 
-    // Cleanup: close every channel to signal shutdown completion and record
-    // dead letters for messages that were accepted but never processed.
-    terminate_receiver.close();
-    discard_queued_messages(
-        actor_id,
-        &mut receiver,
-        priority_receiver.as_mut(),
-        idle_subscribe_receiver.as_mut(),
-    );
-
+    // Cleanup happens in `chans`'s Drop (close the terminate channel to
+    // signal shutdown completion, then record dead letters for messages that
+    // were accepted but never processed) — shared with every early-return and
+    // unwind path above.
     debug!("Actor {actor_id} lifecycle completed - exiting runtime loop.");
 
     // Return the final actor state - successful completion

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -26,6 +26,71 @@ pub(crate) type IdleEventStream<T> = BoxStream<'static, <T as Actor>::IdleEvent>
 /// the channel is already quiet or wedged by that race.
 const PRIORITY_DRAIN_QUIET_PERIOD: std::time::Duration = std::time::Duration::from_millis(10);
 
+/// Final-shutdown drain: closes every inbound channel and records a
+/// receiver-side dead letter for each message that was accepted into a
+/// mailbox but will never be processed.
+///
+/// - `tell`-style envelopes (no reply channel) are the only silent case — the
+///   sender already observed `Ok` — so each gets a
+///   [`DeadLetterReason`](crate::DeadLetterReason)`::DiscardedAtShutdown` record.
+/// - `ask` envelopes are skipped: dropping their reply channel wakes the
+///   caller, which records its own `ReplyDropped` dead letter — recording
+///   here too would double-count.
+/// - Queued-but-never-installed idle subscriptions are counted and logged at
+///   debug level; the streams' resources are released by the drop itself.
+///
+/// Uses `try_recv`, not `recv().await`: this runs after the loop has exited,
+/// only needs what is buffered, and must not park (see the priority-drain
+/// comments for the recv-after-close lost-wakeup hazard). A send racing past
+/// the drain on an already-granted permit is missed — recording is
+/// best-effort, as documented on `DiscardedAtShutdown`.
+fn discard_queued_messages<T: Actor>(
+    actor_id: crate::Identity,
+    receiver: &mut mpsc::Receiver<MailboxMessage<T>>,
+    priority_receiver: Option<&mut mpsc::Receiver<MailboxMessage<T>>>,
+    idle_subscribe_receiver: Option<&mut mpsc::Receiver<IdleEventStream<T>>>,
+) {
+    fn drain_one<T: Actor>(
+        actor_id: crate::Identity,
+        rx: &mut mpsc::Receiver<MailboxMessage<T>>,
+        operation: &'static str,
+    ) {
+        rx.close();
+        while let Ok(msg) = rx.try_recv() {
+            if let MailboxMessage::Envelope {
+                payload,
+                reply_channel,
+                ..
+            } = msg
+            {
+                if reply_channel.is_none() {
+                    crate::dead_letter::record_erased(
+                        actor_id,
+                        crate::dead_letter::DeadLetterReason::DiscardedAtShutdown,
+                        operation,
+                        payload.message_type_name(),
+                    );
+                }
+            }
+        }
+    }
+
+    drain_one(actor_id, receiver, "tell");
+    if let Some(rx) = priority_receiver {
+        drain_one(actor_id, rx, "tell_priority");
+    }
+    if let Some(rx) = idle_subscribe_receiver {
+        rx.close();
+        let mut dropped = 0usize;
+        while rx.try_recv().is_ok() {
+            dropped += 1;
+        }
+        if dropped > 0 {
+            debug!("Actor {actor_id} dropped {dropped} idle subscription(s) queued at shutdown");
+        }
+    }
+}
+
 /// Wrap a future with CURRENT_ACTOR scope and await it.
 /// Used for on_start, message handler, on_stop.
 macro_rules! run_with_actor_scope {
@@ -568,6 +633,13 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
         }
         Err(e) => {
             error!("Actor {actor_id} on_start failed: {e}");
+            terminate_receiver.close();
+            discard_queued_messages(
+                actor_id,
+                &mut receiver,
+                priority_receiver.as_mut(),
+                idle_subscribe_receiver.as_mut(),
+            );
             return ActorResult::Failed {
                 failure: ActorFailure::OnStart { error: e },
                 killed: false,
@@ -633,6 +705,15 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     }
                 }
 
+                // No further idle subscriptions will be installed: close the
+                // subscribe channel now so concurrent subscribe_idle calls fail
+                // fast with Error::Send instead of returning Ok for a stream
+                // that would be silently discarded. (A call racing this close
+                // can still slip through; the shutdown drain logs those.)
+                if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                    rx.close();
+                }
+
                 // Call on_stop for termination scenario
                 #[cfg(feature = "tracing")]
                 let on_stop_span = tracing::debug_span!("actor_on_stop", killed);
@@ -644,6 +725,13 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                     actor.on_stop(&actor_weak, killed).instrument(on_stop_span)
                 ) {
                     error!("Actor {actor_id} on_stop failed during termination: {e}");
+                    terminate_receiver.close();
+                    discard_queued_messages(
+                        actor_id,
+                        &mut receiver,
+                        priority_receiver.as_mut(),
+                        idle_subscribe_receiver.as_mut(),
+                    );
                     return ActorResult::Failed {
                         failure: ActorFailure::OnStop { actor, error: e },
                         killed,
@@ -748,6 +836,14 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             None => debug!("Actor termination: all strong refs dropped"),
                         }
 
+                        // No further idle subscriptions will be installed: close
+                        // the subscribe channel now so concurrent subscribe_idle
+                        // calls fail fast with Error::Send instead of returning
+                        // Ok for a stream that would be silently discarded.
+                        if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                            rx.close();
+                        }
+
                         // Drain any priority messages already enqueued before stopping.
                         // close() refuses *new* priority sends (they get Closed errors
                         // and are recorded as dead letters), but tokio documents that a
@@ -819,6 +915,13 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                             actor.on_stop(&actor_weak, false).instrument(on_stop_span)
                         ) {
                             error!("Actor {actor_id} on_stop failed during graceful stop: {e}");
+                            terminate_receiver.close();
+                            discard_queued_messages(
+                                actor_id,
+                                &mut receiver,
+                                priority_receiver.as_mut(),
+                                idle_subscribe_receiver.as_mut(),
+                            );
                             return ActorResult::Failed {
                                 failure: ActorFailure::OnStop { actor, error: e },
                                 killed: false,
@@ -856,6 +959,13 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                 if let Err(e) = result {
                     error!("Actor {actor_id} on_idle error: {e}");
 
+                    // No further idle subscriptions will be installed: close the
+                    // subscribe channel now so concurrent subscribe_idle calls
+                    // fail fast instead of returning Ok for a discarded stream.
+                    if let Some(rx) = idle_subscribe_receiver.as_mut() {
+                        rx.close();
+                    }
+
                     // Call on_stop for cleanup even after on_idle failure
                     #[cfg(feature = "tracing")]
                     let on_stop_span = tracing::debug_span!("actor_on_stop", killed = false);
@@ -879,6 +989,14 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
                         Ok(()) => ActorFailure::OnIdle { actor, error: e },
                     };
 
+                    terminate_receiver.close();
+                    discard_queued_messages(
+                        actor_id,
+                        &mut receiver,
+                        priority_receiver.as_mut(),
+                        idle_subscribe_receiver.as_mut(),
+                    );
+
                     // `killed` is necessarily false here: the only assignment to
                     // true happens in the terminate arm, which returns or breaks
                     // out of the loop before this arm can run again.
@@ -891,15 +1009,15 @@ pub(crate) async fn run_actor_lifecycle<T: Actor>(
         }
     }
 
-    // Cleanup: Close channels to signal shutdown completion
-    receiver.close(); // Close the message mailbox
-    terminate_receiver.close(); // Close the termination signal channel
-    if let Some(rx) = priority_receiver.as_mut() {
-        rx.close(); // Close the optional priority channel
-    }
-    if let Some(rx) = idle_subscribe_receiver.as_mut() {
-        rx.close(); // Close the idle subscribe channel
-    }
+    // Cleanup: close every channel to signal shutdown completion and record
+    // dead letters for messages that were accepted but never processed.
+    terminate_receiver.close();
+    discard_queued_messages(
+        actor_id,
+        &mut receiver,
+        priority_receiver.as_mut(),
+        idle_subscribe_receiver.as_mut(),
+    );
 
     debug!("Actor {actor_id} lifecycle completed - exiting runtime loop.");
 

--- a/src/actor_control.rs
+++ b/src/actor_control.rs
@@ -76,12 +76,24 @@ pub trait ActorControl: Send + Sync {
     ///
     /// The returned future resolves once the stop signal is **enqueued**, not
     /// when the actor has finished stopping. To observe completion, follow up
-    /// with [`wait_stopped`](Self::wait_stopped).
+    /// with [`wait_stopped`](Self::wait_stopped). Enqueueing awaits mailbox
+    /// admission, so on a **full** mailbox the future does not resolve until a
+    /// slot frees up — and a self-stop from inside the actor's own handler on
+    /// a full mailbox can never be admitted (the loop that would free a slot
+    /// is parked awaiting that handler). With the `deadlock-detection` feature
+    /// enabled, that self-stop panics instead of hanging; see
+    /// [`ActorRef::stop`](crate::ActorRef::stop).
     fn stop(&self) -> BoxFuture<'_, ()>;
 
     /// Immediately terminates the actor.
     ///
-    /// The actor will stop without processing remaining messages.
+    /// Any messages still queued in the mailbox are discarded without being
+    /// processed (the physical drain happens after `on_stop(killed = true)`
+    /// returns). **First signal wins**: if a graceful
+    /// stop has already been dequeued, the actor completes that graceful stop
+    /// (draining its mailbox) and this kill is never observed — and a handler
+    /// already executing always runs to completion first; see
+    /// [`ActorRef::kill`](crate::ActorRef::kill) for the full semantics.
     /// Idempotent: a closed or full terminate channel is treated as
     /// "termination already in flight".
     fn kill(&self);

--- a/src/actor_control.rs
+++ b/src/actor_control.rs
@@ -73,6 +73,10 @@ pub trait ActorControl: Send + Sync {
     ///
     /// The actor will process all remaining messages in its mailbox before stopping.
     /// Idempotent: a closed mailbox is treated as "stop already in flight".
+    ///
+    /// The returned future resolves once the stop signal is **enqueued**, not
+    /// when the actor has finished stopping. To observe completion, follow up
+    /// with [`wait_stopped`](Self::wait_stopped).
     fn stop(&self) -> BoxFuture<'_, ()>;
 
     /// Immediately terminates the actor.
@@ -81,6 +85,15 @@ pub trait ActorControl: Send + Sync {
     /// Idempotent: a closed or full terminate channel is treated as
     /// "termination already in flight".
     fn kill(&self);
+
+    /// Resolves once the actor has fully stopped (its runtime loop exited and
+    /// the mailbox closed). Returns immediately if the actor already stopped.
+    ///
+    /// Type-erased counterpart of
+    /// [`ActorRef::wait_stopped`](crate::ActorRef::wait_stopped); it signals
+    /// completion only and cannot return the actor's
+    /// [`ActorResult`](crate::ActorResult).
+    fn wait_stopped(&self) -> BoxFuture<'_, ()>;
 
     /// Downgrades to a weak control reference.
     fn downgrade(&self) -> Box<dyn WeakActorControl>;
@@ -150,13 +163,18 @@ impl Clone for Box<dyn WeakActorControl> {
     }
 }
 
-impl fmt::Debug for Box<dyn ActorControl> {
+// Debug is implemented on the trait objects themselves (not on `Box<dyn ...>`)
+// so that `&dyn`, `Arc<dyn>`, and any other pointer type get Debug too, and
+// `Box<dyn ...>` picks it up through std's blanket `impl Debug for Box<T>`.
+// A manual Box impl would also collide with that blanket impl the moment a
+// dyn-level impl is added — this is the future-proof of the two shapes.
+impl fmt::Debug for dyn ActorControl + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
 }
 
-impl fmt::Debug for Box<dyn WeakActorControl> {
+impl fmt::Debug for dyn WeakActorControl + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
@@ -166,7 +184,7 @@ impl fmt::Debug for Box<dyn WeakActorControl> {
 // Blanket implementations for ActorRef
 // ============================================================================
 
-impl<T: Actor + 'static> ActorControl for ActorRef<T> {
+impl<T: Actor> ActorControl for ActorRef<T> {
     fn identity(&self) -> Identity {
         ActorRef::identity(self)
     }
@@ -181,6 +199,10 @@ impl<T: Actor + 'static> ActorControl for ActorRef<T> {
 
     fn kill(&self) {
         ActorRef::kill(self)
+    }
+
+    fn wait_stopped(&self) -> BoxFuture<'_, ()> {
+        ActorRef::wait_stopped(self).boxed()
     }
 
     fn downgrade(&self) -> Box<dyn WeakActorControl> {
@@ -203,7 +225,7 @@ impl<T: Actor + 'static> ActorControl for ActorRef<T> {
 // Blanket implementations for ActorWeak
 // ============================================================================
 
-impl<T: Actor + 'static> WeakActorControl for ActorWeak<T> {
+impl<T: Actor> WeakActorControl for ActorWeak<T> {
     fn identity(&self) -> Identity {
         ActorWeak::identity(self)
     }
@@ -233,28 +255,28 @@ impl<T: Actor + 'static> WeakActorControl for ActorWeak<T> {
 // ============================================================================
 
 // From ActorRef (ownership transfer) to Box<dyn ActorControl>
-impl<T: Actor + 'static> From<ActorRef<T>> for Box<dyn ActorControl> {
+impl<T: Actor> From<ActorRef<T>> for Box<dyn ActorControl> {
     fn from(actor_ref: ActorRef<T>) -> Self {
         Box::new(actor_ref)
     }
 }
 
 // From &ActorRef (clone) to Box<dyn ActorControl>
-impl<T: Actor + 'static> From<&ActorRef<T>> for Box<dyn ActorControl> {
+impl<T: Actor> From<&ActorRef<T>> for Box<dyn ActorControl> {
     fn from(actor_ref: &ActorRef<T>) -> Self {
         Box::new(actor_ref.clone())
     }
 }
 
 // From ActorWeak (ownership transfer) to Box<dyn WeakActorControl>
-impl<T: Actor + 'static> From<ActorWeak<T>> for Box<dyn WeakActorControl> {
+impl<T: Actor> From<ActorWeak<T>> for Box<dyn WeakActorControl> {
     fn from(actor_weak: ActorWeak<T>) -> Self {
         Box::new(actor_weak)
     }
 }
 
 // From &ActorWeak (clone) to Box<dyn WeakActorControl>
-impl<T: Actor + 'static> From<&ActorWeak<T>> for Box<dyn WeakActorControl> {
+impl<T: Actor> From<&ActorWeak<T>> for Box<dyn WeakActorControl> {
     fn from(actor_weak: &ActorWeak<T>) -> Self {
         Box::new(actor_weak.clone())
     }

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -330,6 +330,16 @@ impl<T: Actor> ActorRef<T> {
     /// branch. This is the chief reason to prefer subscriptions over open-coded
     /// idle loops.
     ///
+    /// **Do not capture a strong `ActorRef` of this same actor inside the
+    /// stream.** Because the runtime task owns the stream, a stream that owns
+    /// a strong self-reference forms a permanent keep-alive cycle: dropping
+    /// every external `ActorRef` then never terminates the actor (the
+    /// ref-drop shutdown path can't fire), and once the last external ref is
+    /// gone there is no handle left to call [`stop`](Self::stop)/[`kill`](Self::kill)
+    /// with — the task leaks for the life of the runtime. Capture an
+    /// [`ActorWeak`] (via [`downgrade`](Self::downgrade)) and upgrade per
+    /// event instead.
+    ///
     /// Subscription can be called any number of times, from any context with
     /// access to an [`ActorRef`] — typically from [`Actor::on_start`] for the
     /// initial sources, and from message handlers to attach additional sources
@@ -356,6 +366,17 @@ impl<T: Actor> ActorRef<T> {
     ///   across separate handler invocations or raise
     ///   [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY).
     /// - [`Error::Send`] when the actor is no longer alive (channel closed) — terminal.
+    ///   The subscribe channel is closed as soon as the actor *begins* stopping
+    ///   (graceful stop, kill, or an `on_idle` failure), so most termination-racing
+    ///   calls fail here rather than succeed.
+    ///
+    /// # Ok is "accepted", not "installed"
+    ///
+    /// `Ok(())` means the stream was enqueued for installation. A call that
+    /// races the very start of the actor's shutdown can still return `Ok` for
+    /// a stream that is never polled — it is discarded (and its drop runs)
+    /// when the actor finishes stopping; the shutdown drain logs the count at
+    /// debug level.
     ///
     /// # Example
     ///
@@ -394,9 +415,23 @@ impl<T: Actor> ActorRef<T> {
     /// Sends a message to the actor without awaiting a reply (fire-and-forget).
     ///
     /// The message is sent to the actor's mailbox for processing.
-    /// This method returns immediately.
+    /// This method returns once the message is admitted into the mailbox —
+    /// **when the mailbox is full, it waits for space** rather than returning
+    /// an error (use [`tell_with_timeout`](Self::tell_with_timeout) for a
+    /// bounded wait).
     ///
     /// Type safety: Only messages that the actor `T` can handle via [`Message<M>`] trait are accepted.
+    ///
+    /// # Deadlock warning (self-send)
+    ///
+    /// Calling this on the actor's **own** `ActorRef` from inside one of its
+    /// handlers or lifecycle hooks while its mailbox is full is an
+    /// unrecoverable deadlock: the only consumer of the mailbox is the actor's
+    /// runtime loop, which is parked awaiting that very handler, so admission
+    /// can never succeed and [`kill`](Self::kill) cannot interrupt the wait.
+    /// With the `deadlock-detection` feature enabled this panics immediately
+    /// instead of hanging. Prefer [`tell_with_timeout`](Self::tell_with_timeout)
+    /// (bounded, recoverable) or send from a spawned task.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_tell",
@@ -411,6 +446,27 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T: Message<M>,
     {
+        self.tell_inner(msg, true).await
+    }
+
+    /// Shared implementation of [`tell`](Self::tell) and
+    /// [`tell_with_timeout`](Self::tell_with_timeout).
+    ///
+    /// `detect_self_deadlock` arms the deadlock-detection check for unbounded
+    /// admission waits: a no-timeout tell issued from inside this actor's own
+    /// handler while its mailbox is full can never be admitted (the loop that
+    /// would free a slot is parked awaiting that very handler), so under the
+    /// `deadlock-detection` feature it panics instead of hanging forever.
+    /// `tell_with_timeout` passes `false` — its admission wait is bounded by
+    /// the caller's timeout and therefore recoverable, not a deadlock.
+    async fn tell_inner<M>(&self, msg: M, detect_self_deadlock: bool) -> Result<()>
+    where
+        M: Send + 'static,
+        T: Message<M>,
+    {
+        #[cfg(not(feature = "deadlock-detection"))]
+        let _ = detect_self_deadlock;
+
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: None,     // reply_channel is None for tell
@@ -419,6 +475,25 @@ impl<T: Actor> ActorRef<T> {
         };
 
         debug!("Sending tell message (fire-and-forget)");
+
+        // Deadlock detection: probe admission first so a full mailbox is
+        // observable before committing to an unbounded wait. `Closed` falls
+        // through to `send().await`, which fails fast on the standard error
+        // path below.
+        #[cfg(feature = "deadlock-detection")]
+        let envelope = match self.sender.try_send(envelope) {
+            Ok(()) => {
+                debug!("Tell message sent successfully");
+                return Ok(());
+            }
+            Err(mpsc::error::TrySendError::Full(env)) => {
+                if detect_self_deadlock {
+                    self.panic_if_self_send_on_full("tell");
+                }
+                env
+            }
+            Err(mpsc::error::TrySendError::Closed(env)) => env,
+        };
 
         let result = if self.sender.send(envelope).await.is_err() {
             crate::dead_letter::record::<M>(
@@ -440,6 +515,30 @@ impl<T: Actor> ActorRef<T> {
         }
 
         result
+    }
+
+    /// Deadlock-detection helper: panics when an *unbounded* admission wait on
+    /// this actor's own full mailbox is attempted from inside one of its own
+    /// handlers or lifecycle hooks. The mailbox's only consumer is the actor's
+    /// runtime loop, which is parked awaiting the very code making this call —
+    /// the wait can never be satisfied and `kill()` cannot interrupt it, so
+    /// this is a guaranteed deadlock, not a heuristic.
+    #[cfg(feature = "deadlock-detection")]
+    fn panic_if_self_send_on_full(&self, operation: &str) {
+        let is_self = crate::CURRENT_ACTOR
+            .try_with(|id| id.id == self.id.id)
+            .unwrap_or(false);
+        if is_self {
+            panic!(
+                "Deadlock detected: {operation} to self on a full mailbox from inside actor {}'s \
+                 own handler or lifecycle hook.\n\
+                 The mailbox's only consumer is this actor's runtime loop, which is parked \
+                 awaiting the current handler, so admission can never succeed and kill() cannot \
+                 interrupt the wait. Use tell_with_timeout, a larger mailbox capacity, or send \
+                 from a spawned task.",
+                self.id
+            );
+        }
     }
 
     /// Sends a message to the actor without awaiting a reply (fire-and-forget) with a timeout.
@@ -468,7 +567,10 @@ impl<T: Actor> ActorRef<T> {
             "Sending tell message with timeout"
         );
 
-        let result = tokio::time::timeout(timeout, self.tell(msg))
+        // `detect_self_deadlock = false`: a full-mailbox self-send through this
+        // method is bounded by `timeout` and resolves as a recoverable
+        // `Error::Timeout`, so it is not a deadlock.
+        let result = tokio::time::timeout(timeout, self.tell_inner(msg, false))
             .await
             .map_err(|_| {
                 crate::dead_letter::record::<M>(
@@ -1025,6 +1127,13 @@ impl<T: Actor> ActorRef<T> {
     /// `deadlock-detection` feature for `ask` cycles, and by isolating blocking work
     /// (e.g. `tokio::task::spawn_blocking` or a separate process).
     ///
+    /// **First signal wins.** If a graceful stop is already in progress — the
+    /// actor has dequeued a [`stop`](Self::stop) signal and is draining /
+    /// running `on_stop(killed = false)` — a `kill()` arriving afterwards is
+    /// enqueued but never observed: the actor completes the graceful stop and
+    /// its result reports `killed: false`. Honoring the late kill would mean
+    /// interrupting or re-running an `on_stop` that is already executing.
+    ///
     /// This method is idempotent: a `Full` or `Closed` terminate channel is treated as
     /// "termination already in flight" — the desired terminal state is met either way.
     /// Both conditions are logged via `tracing::warn!` for diagnostics.
@@ -1038,7 +1147,10 @@ impl<T: Actor> ActorRef<T> {
         // Use the dedicated terminate_sender with try_send
         match self.terminate_sender.try_send(ControlSignal::Terminate) {
             Ok(_) => {
-                info!("Kill signal sent successfully");
+                info!(
+                    "Kill signal enqueued; takes effect when the actor next polls control \
+                     signals (no effect if a graceful stop is already in progress)"
+                );
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
                 // The channel has capacity 1, so Full means a Terminate is already queued.
@@ -1060,21 +1172,47 @@ impl<T: Actor> ActorRef<T> {
     /// The returned future resolves once the stop signal is **enqueued**, not
     /// when the actor has finished stopping. Await the `JoinHandle` from
     /// [`spawn`](crate::spawn) or [`wait_stopped`](Self::wait_stopped) to
-    /// observe completion.
+    /// observe completion. When the mailbox is full, this waits for space like
+    /// [`tell`](Self::tell) does.
     ///
     /// This method is idempotent: a closed mailbox channel is treated as "stop already
     /// in flight" — the desired terminal state is met either way. The condition is
-    /// logged via `tracing::warn!` for diagnostics.
+    /// logged via `tracing::warn!` for diagnostics. Conversely, a [`kill`](Self::kill)
+    /// that arrives *after* the actor has begun this graceful stop is never observed
+    /// (first signal wins; the result reports `killed: false`).
+    ///
+    /// # Deadlock warning (self-stop)
+    ///
+    /// Calling this on the actor's **own** `ActorRef` from inside one of its
+    /// handlers or lifecycle hooks while its mailbox is full is an
+    /// unrecoverable deadlock, identical to a full-mailbox self-[`tell`](Self::tell):
+    /// the loop that would free a slot is parked awaiting that handler, and
+    /// [`kill`](Self::kill) cannot interrupt it. With the `deadlock-detection`
+    /// feature enabled this panics immediately instead of hanging.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(level = "info", name = "actor_stop", skip(self))
     )]
     pub async fn stop(&self) {
-        match self
-            .sender
-            .send(MailboxMessage::StopGracefully(self.clone()))
-            .await
-        {
+        let stop_msg = MailboxMessage::StopGracefully(self.clone());
+
+        // Deadlock detection: probe admission first; see `tell_inner`. A
+        // `Closed` result falls through to `send().await`, which fails fast on
+        // the standard already-stopped path below.
+        #[cfg(feature = "deadlock-detection")]
+        let stop_msg = match self.sender.try_send(stop_msg) {
+            Ok(()) => {
+                info!(actor_id = %self.identity(), "Actor stop signal sent successfully");
+                return;
+            }
+            Err(mpsc::error::TrySendError::Full(m)) => {
+                self.panic_if_self_send_on_full("stop");
+                m
+            }
+            Err(mpsc::error::TrySendError::Closed(m)) => m,
+        };
+
+        match self.sender.send(stop_msg).await {
             Ok(_) => {
                 info!(actor_id = %self.identity(), "Actor stop signal sent successfully");
             }
@@ -1203,7 +1341,13 @@ impl<T: Actor> ActorRef<T> {
                     details: "Mailbox channel closed",
                 });
             }
-            Err(mpsc::error::TrySendError::Full(env)) => env,
+            Err(mpsc::error::TrySendError::Full(env)) => {
+                // A timeout-less blocking self-send on a full mailbox is the
+                // same unrecoverable deadlock as the async `tell` case.
+                #[cfg(feature = "deadlock-detection")]
+                self.panic_if_self_send_on_full("blocking_tell");
+                env
+            }
         };
 
         // Inside *any* runtime context (a current_thread runtime task, or a
@@ -1592,6 +1736,16 @@ impl<T: Actor> ActorRef<T> {
     /// The [`Error::Join`] variant includes the original [`tokio::task::JoinError`]
     /// which provides detailed information about task failures, such as whether
     /// the task was cancelled or panicked.
+    ///
+    /// # Cancellation safety
+    ///
+    /// Dropping this future mid-flight (e.g. wrapping it in
+    /// [`tokio::time::timeout`]) does **not** abort the task the handler
+    /// spawned: the `JoinHandle` is merely dropped, which detaches the task —
+    /// it runs to completion in the background and its result is discarded.
+    /// If you need the spawned work to stop when the caller gives up, use a
+    /// plain [`ask`](Self::ask) to receive the `JoinHandle` and call
+    /// [`abort`](tokio::task::JoinHandle::abort) on it yourself.
     ///
     /// # Type Safety
     ///

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -9,7 +9,7 @@ use futures::stream::{Stream, StreamExt};
 use std::time::Duration;
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tokio::sync::{mpsc, oneshot};
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 /// If the calling thread is currently inside a multi-thread Tokio runtime,
 /// returns a `Handle` to it. Otherwise (no runtime, or current_thread runtime)
@@ -20,11 +20,21 @@ use tracing::warn;
 /// `block_in_place` + `Handle::block_on` and reuse the caller's runtime.
 /// `block_in_place` requires a multi-thread runtime, so current_thread is
 /// excluded here and falls back to the original "new thread + new runtime"
-/// path.
+/// path. The comparison deliberately allows *only* `MultiThread`: should tokio
+/// ever add another flavor to the `#[non_exhaustive]` enum, the safe failure
+/// mode is the slow path, not a `block_in_place` panic.
 #[inline]
 fn current_multi_thread_handle() -> Option<Handle> {
     let handle = Handle::try_current().ok()?;
     (handle.runtime_flavor() == RuntimeFlavor::MultiThread).then_some(handle)
+}
+
+/// Fast-path helper shared by every `blocking_*` API: runs `fut` to completion
+/// on the caller's own multi-thread runtime via `block_in_place` + `block_on`.
+/// No new thread or runtime is created.
+#[inline]
+fn block_on_current_runtime<R>(handle: Handle, fut: impl std::future::Future<Output = R>) -> R {
+    tokio::task::block_in_place(|| handle.block_on(fut))
 }
 
 /// Slow-path helper shared by `blocking_*` APIs: spawns a dedicated thread,
@@ -32,41 +42,83 @@ fn current_multi_thread_handle() -> Option<Handle> {
 ///
 /// Used only when the caller is *not* inside a multi-thread runtime (i.e. when
 /// the fast `block_in_place` path is unavailable). Centralizes the
-/// thread/runtime/join boilerplate so all four slow paths report errors
-/// identically.
+/// thread/runtime/join boilerplate so all slow paths report errors identically:
+/// a failure to spawn the thread or to build the temporary runtime becomes
+/// `Error::Runtime` carrying the underlying [`std::io::Error`] as its
+/// [`source`](std::error::Error::source).
 ///
-/// `panic_msg` describes the failure surfaced when the spawned thread itself
-/// panics (the `join.join()` returns `Err`); it is wrapped in `Error::Runtime`.
-/// A failure to build the temporary runtime is also reported as `Error::Runtime`,
-/// carrying the underlying [`std::io::Error`] as its [`source`](std::error::Error::source).
+/// With `deadlock-detection` enabled, the calling actor's task-local identity
+/// is captured here and re-established inside the new runtime, so `ask` cycles
+/// taken through this slow path are still detected. A deadlock panic raised on
+/// the dedicated thread is resumed on the caller's thread (preserving the
+/// documented panic-on-detection contract); any other worker-thread panic is
+/// reported as `Error::Runtime` with `panic_msg` and the panic payload in its
+/// details.
 fn run_blocking_with_runtime<F, R>(identity: Identity, panic_msg: &'static str, fut: F) -> Result<R>
 where
     F: std::future::Future<Output = Result<R>> + Send + 'static,
     R: Send + 'static,
 {
-    let join = std::thread::spawn(move || -> Result<R> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .map_err(|e| Error::Runtime {
-                identity,
-                details: "Failed to build blocking runtime".to_string(),
-                source: Some(std::sync::Arc::new(e)),
-            })?;
-        runtime.block_on(fut)
-    });
+    // Capture the current actor (if any) *before* hopping threads — tokio
+    // task-locals do not propagate to new threads or runtimes.
+    #[cfg(feature = "deadlock-detection")]
+    let caller = crate::CURRENT_ACTOR.try_with(|id| *id).ok();
 
-    join.join().unwrap_or_else(|_| {
+    let join = std::thread::Builder::new()
+        .name("rsactor-blocking".to_string())
+        .spawn(move || -> Result<R> {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .map_err(|e| Error::Runtime {
+                    identity,
+                    details: "Failed to build blocking runtime".to_string(),
+                    source: Some(std::sync::Arc::new(e)),
+                })?;
+            #[cfg(feature = "deadlock-detection")]
+            {
+                match caller {
+                    Some(id) => runtime.block_on(crate::CURRENT_ACTOR.scope(id, fut)),
+                    None => runtime.block_on(fut),
+                }
+            }
+            #[cfg(not(feature = "deadlock-detection"))]
+            {
+                runtime.block_on(fut)
+            }
+        })
+        .map_err(|e| Error::Runtime {
+            identity,
+            details: "Failed to spawn blocking thread".to_string(),
+            source: Some(std::sync::Arc::new(e)),
+        })?;
+
+    join.join().unwrap_or_else(|payload| {
+        let panic_text = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .map(str::to_owned)
+            .or_else(|| payload.downcast_ref::<String>().cloned());
+        // Deadlock detection promises an *immediate panic* on an ask cycle;
+        // swallowing it into Error::Runtime would silently downgrade that
+        // contract on the slow path.
+        #[cfg(feature = "deadlock-detection")]
+        if panic_text
+            .as_deref()
+            .is_some_and(|m| m.starts_with("Deadlock detected"))
+        {
+            std::panic::resume_unwind(payload);
+        }
         Err(Error::Runtime {
             identity,
-            details: panic_msg.to_string(),
+            details: match panic_text {
+                Some(text) => format!("{panic_msg}: {text}"),
+                None => panic_msg.to_string(),
+            },
             source: None,
         })
     })
 }
-
-#[cfg(feature = "tracing")]
-use tracing::{debug, info};
 
 #[cfg(feature = "metrics")]
 use crate::metrics::MetricsCollector;
@@ -229,16 +281,42 @@ impl<T: Actor> ActorRef<T> {
     /// and optionally upgrade back to a strong [`ActorRef<T>`] without keeping the actor alive.
     /// When the `metrics` feature is enabled, metrics are preserved via strong reference
     /// for post-mortem analysis.
-    pub fn downgrade(this: &Self) -> ActorWeak<T> {
+    ///
+    /// This is an inherent `&self` method (callable as `actor_ref.downgrade()`
+    /// or `ActorRef::downgrade(&actor_ref)`). Inherent methods win method
+    /// resolution, so the call stays unambiguous even with the
+    /// [`TellHandler`](crate::TellHandler) / [`AskHandler`](crate::AskHandler) /
+    /// [`ActorControl`](crate::ActorControl) traits in scope, all of which also
+    /// declare a `downgrade`; reach those via trait objects or fully-qualified
+    /// syntax.
+    pub fn downgrade(&self) -> ActorWeak<T> {
         ActorWeak {
-            id: this.id,
-            sender: this.sender.downgrade(),
-            priority_sender: this.priority_sender.as_ref().map(|s| s.downgrade()),
-            terminate_sender: this.terminate_sender.downgrade(),
-            idle_subscribe_sender: this.idle_subscribe_sender.as_ref().map(|s| s.downgrade()),
+            id: self.id,
+            sender: self.sender.downgrade(),
+            priority_sender: self.priority_sender.as_ref().map(|s| s.downgrade()),
+            terminate_sender: self.terminate_sender.downgrade(),
+            idle_subscribe_sender: self.idle_subscribe_sender.as_ref().map(|s| s.downgrade()),
             #[cfg(feature = "metrics")]
-            metrics: this.metrics.clone(),
+            metrics: self.metrics.clone(),
         }
+    }
+
+    /// Resolves once the actor has fully stopped — its runtime loop has exited
+    /// (after `on_stop` ran) and the mailbox channel has closed.
+    ///
+    /// Unlike awaiting the `JoinHandle` returned by [`spawn`](crate::spawn),
+    /// this works from any clone of the `ActorRef` and is type-erasable (see
+    /// [`ActorControl::wait_stopped`](crate::ActorControl::wait_stopped)), but
+    /// it only signals completion — it cannot return the
+    /// [`ActorResult`](crate::ActorResult).
+    ///
+    /// Returns immediately if the actor has already stopped. Note that holding
+    /// this `ActorRef` does not keep the actor alive forever: an actor also
+    /// stops when every *other* strong ref is dropped only if this one is
+    /// dropped too, so pair this with [`stop`](Self::stop) / [`kill`](Self::kill)
+    /// rather than waiting for ref-drop termination from a live ref.
+    pub async fn wait_stopped(&self) {
+        self.sender.closed().await
     }
 
     /// Registers a [`Stream`] of idle events to be merged into the actor's
@@ -294,7 +372,6 @@ impl<T: Actor> ActorRef<T> {
         S: Stream<Item = T::IdleEvent> + Send + 'static,
     {
         let Some(idle_subscribe_sender) = self.idle_subscribe_sender.as_ref() else {
-            #[cfg(feature = "tracing")]
             warn!("subscribe_idle called on actor without an idle channel");
             return Err(Error::IdleChannelNotEnabled {
                 identity: self.identity(),
@@ -309,7 +386,7 @@ impl<T: Actor> ActorRef<T> {
             },
             mpsc::error::TrySendError::Closed(_) => Error::Send {
                 identity: self.identity(),
-                details: "Idle subscribe channel closed (actor is no longer alive)".to_string(),
+                details: "Idle subscribe channel closed (actor is no longer alive)",
             },
         })
     }
@@ -338,9 +415,9 @@ impl<T: Actor> ActorRef<T> {
             payload: Box::new(msg),
             reply_channel: None,     // reply_channel is None for tell
             actor_ref: self.clone(), // Include the actor ref for context
+            ask_edge: Default::default(),
         };
 
-        #[cfg(feature = "tracing")]
         debug!("Sending tell message (fire-and-forget)");
 
         let result = if self.sender.send(envelope).await.is_err() {
@@ -351,13 +428,12 @@ impl<T: Actor> ActorRef<T> {
             );
             Err(Error::Send {
                 identity: self.identity(),
-                details: "Mailbox channel closed".to_string(),
+                details: "Mailbox channel closed",
             })
         } else {
             Ok(())
         };
 
-        #[cfg(feature = "tracing")]
         match &result {
             Ok(_) => debug!("Tell message sent successfully"),
             Err(e) => warn!(error = %e, "Failed to send tell message"),
@@ -387,7 +463,6 @@ impl<T: Actor> ActorRef<T> {
         T: Message<M>,
         M: Send + 'static,
     {
-        #[cfg(feature = "tracing")]
         debug!(
             timeout_ms = timeout.as_millis(),
             "Sending tell message with timeout"
@@ -408,7 +483,6 @@ impl<T: Actor> ActorRef<T> {
                 }
             })?;
 
-        #[cfg(feature = "tracing")]
         match &result {
             Ok(_) => debug!("Tell with timeout completed successfully"),
             Err(e) => warn!(error = %e, "Tell with timeout failed"),
@@ -442,18 +516,25 @@ impl<T: Actor> ActorRef<T> {
     {
         // Deadlock detection: register this `ask` as a wait-for edge and hold
         // the guard until the reply is received (or this future is dropped).
-        // Panics if it would close an ask cycle.
+        // Panics if it would close an ask cycle. The envelope carries a token
+        // so the callee removes the edge the moment it sends the reply —
+        // waiting for this future to resume would leave a stale-edge window
+        // that produces false-positive cycle panics.
         #[cfg(feature = "deadlock-detection")]
         let _guard = crate::register_ask_edge(self.identity(), "ask");
+        #[cfg(feature = "deadlock-detection")]
+        let ask_edge = _guard.as_ref().map(|g| g.token());
+        #[cfg(not(feature = "deadlock-detection"))]
+        let ask_edge = ();
 
         let (reply_tx, reply_rx) = oneshot::channel();
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: Some(reply_tx),
             actor_ref: self.clone(), // Include the actor ref for context
+            ask_edge,
         };
 
-        #[cfg(feature = "tracing")]
         debug!("Sending ask message and waiting for reply");
 
         if self.sender.send(envelope).await.is_err() {
@@ -463,12 +544,11 @@ impl<T: Actor> ActorRef<T> {
                 "ask",
             );
 
-            #[cfg(feature = "tracing")]
             warn!("Failed to send ask message: mailbox channel closed");
 
             return Err(Error::Send {
                 identity: self.identity(),
-                details: "Mailbox channel closed".to_string(),
+                details: "Mailbox channel closed",
             });
         }
 
@@ -477,12 +557,10 @@ impl<T: Actor> ActorRef<T> {
                 // Successfully received reply from actor
                 match reply_any.downcast::<T::Reply>() {
                     Ok(reply) => {
-                        #[cfg(feature = "tracing")]
                         debug!("Ask reply received successfully");
                         Ok(*reply)
                     }
                     Err(_) => {
-                        #[cfg(feature = "tracing")]
                         warn!(
                             expected_type = %std::any::type_name::<T::Reply>(),
                             "Ask reply type downcast failed"
@@ -501,11 +579,10 @@ impl<T: Actor> ActorRef<T> {
                     "ask",
                 );
 
-                #[cfg(feature = "tracing")]
                 warn!("Ask reply channel closed unexpectedly");
                 Err(Error::Receive {
                     identity: self.identity(),
-                    details: "Reply channel closed unexpectedly".to_string(),
+                    details: "Reply channel closed unexpectedly",
                 })
             }
         }
@@ -534,7 +611,6 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
-        #[cfg(feature = "tracing")]
         debug!(
             timeout_ms = timeout.as_millis(),
             "Sending ask message with timeout"
@@ -555,7 +631,6 @@ impl<T: Actor> ActorRef<T> {
                 }
             })?;
 
-        #[cfg(feature = "tracing")]
         match &result {
             Ok(_) => debug!("Ask with timeout completed successfully"),
             Err(e) => warn!(error = %e, "Ask with timeout failed"),
@@ -600,7 +675,6 @@ impl<T: Actor> ActorRef<T> {
         T: Message<M>,
     {
         let Some(priority_sender) = self.priority_sender.as_ref() else {
-            #[cfg(feature = "tracing")]
             warn!("tell_priority called on actor without a priority channel");
             return Err(Error::PriorityChannelNotEnabled {
                 identity: self.identity(),
@@ -611,9 +685,9 @@ impl<T: Actor> ActorRef<T> {
             payload: Box::new(msg),
             reply_channel: None,
             actor_ref: self.clone(),
+            ask_edge: Default::default(),
         };
 
-        #[cfg(feature = "tracing")]
         debug!(
             timeout_ms = timeout.as_millis(),
             "Sending priority tell message"
@@ -630,7 +704,7 @@ impl<T: Actor> ActorRef<T> {
                 );
                 Err(Error::Send {
                     identity: self.identity(),
-                    details: "Priority channel closed".to_string(),
+                    details: "Priority channel closed",
                 })
             }
             Err(_) => {
@@ -647,7 +721,6 @@ impl<T: Actor> ActorRef<T> {
             }
         };
 
-        #[cfg(feature = "tracing")]
         match &result {
             Ok(_) => debug!("Priority tell message sent successfully"),
             Err(e) => warn!(error = %e, "Priority tell failed"),
@@ -692,7 +765,6 @@ impl<T: Actor> ActorRef<T> {
         T::Reply: Send + 'static,
     {
         let Some(priority_sender) = self.priority_sender.as_ref() else {
-            #[cfg(feature = "tracing")]
             warn!("ask_priority called on actor without a priority channel");
             return Err(Error::PriorityChannelNotEnabled {
                 identity: self.identity(),
@@ -706,6 +778,10 @@ impl<T: Actor> ActorRef<T> {
         // the cycle is detected immediately instead of only timing out.
         #[cfg(feature = "deadlock-detection")]
         let _guard = crate::register_ask_edge(self.identity(), "ask_priority");
+        #[cfg(feature = "deadlock-detection")]
+        let ask_edge = _guard.as_ref().map(|g| g.token());
+        #[cfg(not(feature = "deadlock-detection"))]
+        let ask_edge = ();
 
         let result = tokio::time::timeout(timeout, async {
             let (reply_tx, reply_rx) = oneshot::channel();
@@ -713,6 +789,7 @@ impl<T: Actor> ActorRef<T> {
                 payload: Box::new(msg),
                 reply_channel: Some(reply_tx),
                 actor_ref: self.clone(),
+                ask_edge,
             };
 
             if priority_sender.send(envelope).await.is_err() {
@@ -723,7 +800,7 @@ impl<T: Actor> ActorRef<T> {
                 );
                 return Err(Error::Send {
                     identity: self.identity(),
-                    details: "Priority channel closed".to_string(),
+                    details: "Priority channel closed",
                 });
             }
 
@@ -743,7 +820,7 @@ impl<T: Actor> ActorRef<T> {
                     );
                     Err(Error::Receive {
                         identity: self.identity(),
-                        details: "Reply channel closed unexpectedly".to_string(),
+                        details: "Reply channel closed unexpectedly",
                     })
                 }
             }
@@ -772,7 +849,7 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Multi-thread Tokio runtime (any context, including `async fn`)**: uses
+    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
     /// - **Priority slot empty, no runtime context**: a `try_send` fast path
@@ -811,15 +888,14 @@ impl<T: Actor> ActorRef<T> {
 
         // Fast path: caller is inside a multi-thread runtime. Reuse it.
         if let Some(handle) = current_multi_thread_handle() {
-            return tokio::task::block_in_place(|| {
-                handle.block_on(self.tell_priority(msg, timeout))
-            });
+            return block_on_current_runtime(handle, self.tell_priority(msg, timeout));
         }
 
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: None,
             actor_ref: self.clone(),
+            ask_edge: Default::default(),
         };
 
         // Fast path: priority channel has capacity 1, but if it is empty we
@@ -834,7 +910,7 @@ impl<T: Actor> ActorRef<T> {
                 );
                 return Err(Error::Send {
                     identity: self.identity(),
-                    details: "Priority channel closed".to_string(),
+                    details: "Priority channel closed",
                 });
             }
             Err(mpsc::error::TrySendError::Full(env)) => env,
@@ -857,7 +933,7 @@ impl<T: Actor> ActorRef<T> {
                         );
                         Err(Error::Send {
                             identity,
-                            details: "Priority channel closed".to_string(),
+                            details: "Priority channel closed",
                         })
                     }
                     Err(_) => {
@@ -882,7 +958,7 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Multi-thread Tokio runtime (any context, including `async fn`)**: uses
+    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
     /// - **`current_thread` runtime, or no runtime context**: spawns a short-lived
@@ -922,9 +998,7 @@ impl<T: Actor> ActorRef<T> {
 
         // Fast path: caller is inside a multi-thread runtime. Reuse it.
         if let Some(handle) = current_multi_thread_handle() {
-            return tokio::task::block_in_place(|| {
-                handle.block_on(self.ask_priority(msg, timeout))
-            });
+            return block_on_current_runtime(handle, self.ask_priority(msg, timeout));
         }
 
         let self_clone = self.clone();
@@ -959,13 +1033,11 @@ impl<T: Actor> ActorRef<T> {
         tracing::instrument(level = "info", name = "actor_kill", skip(self))
     )]
     pub fn kill(&self) {
-        #[cfg(feature = "tracing")]
         info!(actor_id = %self.identity(), "Killing actor");
 
         // Use the dedicated terminate_sender with try_send
         match self.terminate_sender.try_send(ControlSignal::Terminate) {
             Ok(_) => {
-                #[cfg(feature = "tracing")]
                 info!("Kill signal sent successfully");
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
@@ -985,6 +1057,11 @@ impl<T: Actor> ActorRef<T> {
     /// New messages sent after this call might be ignored or fail.
     /// The actor's final result will indicate normal completion.
     ///
+    /// The returned future resolves once the stop signal is **enqueued**, not
+    /// when the actor has finished stopping. Await the `JoinHandle` from
+    /// [`spawn`](crate::spawn) or [`wait_stopped`](Self::wait_stopped) to
+    /// observe completion.
+    ///
     /// This method is idempotent: a closed mailbox channel is treated as "stop already
     /// in flight" — the desired terminal state is met either way. The condition is
     /// logged via `tracing::warn!` for diagnostics.
@@ -999,7 +1076,6 @@ impl<T: Actor> ActorRef<T> {
             .await
         {
             Ok(_) => {
-                #[cfg(feature = "tracing")]
                 info!(actor_id = %self.identity(), "Actor stop signal sent successfully");
             }
             Err(_) => {
@@ -1016,23 +1092,26 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Multi-thread Tokio runtime (any context, including `async fn`)**: uses
+    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **`current_thread` runtime, or no runtime context, with `timeout: None`**:
-    ///   uses Tokio's `blocking_send` directly. Most efficient, but blocks
-    ///   indefinitely if the mailbox is full.
-    /// - **`current_thread` runtime, or no runtime context, with `timeout: Some(_)`
-    ///   and mailbox empty**: a `try_send` fast path completes without spawning
-    ///   a thread.
-    /// - **`current_thread` runtime, or no runtime context, with `timeout: Some(_)`
-    ///   and mailbox full**: spawns a short-lived dedicated thread with a
-    ///   temporary single-thread runtime to await admission with the timeout.
+    /// - **Any other context, mailbox has room**: a `try_send` fast path
+    ///   completes without blocking or spawning a thread (both `timeout`
+    ///   variants).
+    /// - **Mailbox full, `timeout: Some(_)`**: spawns a short-lived dedicated
+    ///   thread with a temporary single-thread runtime to await admission with
+    ///   the timeout.
+    /// - **Mailbox full, `timeout: None`, no runtime context**: uses Tokio's
+    ///   `blocking_send` directly; blocks indefinitely until admitted.
+    /// - **Mailbox full, `timeout: None`, inside a `current_thread` runtime or
+    ///   a thread driving `Handle::block_on`**: spawns a dedicated thread (like
+    ///   the timeout path, but unbounded) — calling `blocking_send` there would
+    ///   panic. The calling runtime thread is parked for the duration.
     ///
     /// # Performance Considerations
     ///
-    /// The slow-path fallback (`current_thread` runtime or no runtime, with
-    /// timeout, mailbox full) incurs:
+    /// The slow-path fallbacks (mailbox full outside a multi-thread runtime)
+    /// incur:
     /// - **Thread creation**: ~50-200μs depending on the platform
     /// - **Tokio runtime creation**: ~1-10μs for a single-threaded runtime
     ///
@@ -1044,6 +1123,12 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`tell`](Self::tell) directly
     /// from async code where possible.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    /// running on a multi-thread runtime: the runtime handle reports
+    /// multi-thread flavor, but `block_in_place` is not permitted there.
     ///
     /// # Deadlock warning
     ///
@@ -1075,13 +1160,11 @@ impl<T: Actor> ActorRef<T> {
         // thread and runtime. Safe to call from async contexts on a
         // multi-thread runtime.
         if let Some(handle) = current_multi_thread_handle() {
-            return tokio::task::block_in_place(|| {
-                handle.block_on(async {
-                    match timeout {
-                        Some(t) => self.tell_with_timeout(msg, t).await,
-                        None => self.tell(msg).await,
-                    }
-                })
+            return block_on_current_runtime(handle, async {
+                match timeout {
+                    Some(t) => self.tell_with_timeout(msg, t).await,
+                    None => self.tell(msg).await,
+                }
             });
         }
 
@@ -1101,24 +1184,69 @@ impl<T: Actor> ActorRef<T> {
             payload: Box::new(msg),
             reply_channel: None,     // reply_channel is None for tell
             actor_ref: self.clone(), // Include the actor ref for context
+            ask_edge: Default::default(),
         };
 
-        #[cfg(feature = "tracing")]
         debug!("Sending blocking tell message (fire-and-forget)");
+
+        // Fast path: room in the mailbox — finish without blocking at all.
+        let envelope = match self.sender.try_send(envelope) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                crate::dead_letter::record::<M>(
+                    self.identity(),
+                    crate::dead_letter::DeadLetterReason::ActorStopped,
+                    "tell",
+                );
+                return Err(Error::Send {
+                    identity: self.identity(),
+                    details: "Mailbox channel closed",
+                });
+            }
+            Err(mpsc::error::TrySendError::Full(env)) => env,
+        };
+
+        // Inside *any* runtime context (a current_thread runtime task, or a
+        // thread driving `Handle::block_on`), tokio's `blocking_send` panics
+        // with "Cannot block the current thread from within a runtime". Route
+        // through the dedicated-thread slow path instead: same
+        // blocks-until-admitted semantics, no panic. The calling runtime
+        // thread is still parked for the duration — see the deadlock warning
+        // on [`blocking_tell`](Self::blocking_tell).
+        if Handle::try_current().is_ok() {
+            let identity = self.identity();
+            let sender = self.sender.clone();
+            return run_blocking_with_runtime(
+                identity,
+                "Blocking thread terminated unexpectedly",
+                async move {
+                    sender.send(envelope).await.map_err(|_| {
+                        crate::dead_letter::record::<M>(
+                            identity,
+                            crate::dead_letter::DeadLetterReason::ActorStopped,
+                            "tell",
+                        );
+                        Error::Send {
+                            identity,
+                            details: "Mailbox channel closed",
+                        }
+                    })
+                },
+            );
+        }
 
         let result = self.sender.blocking_send(envelope).map_err(|_| {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "blocking_tell",
+                "tell",
             );
             Error::Send {
                 identity: self.identity(),
-                details: "Mailbox channel closed".to_string(),
+                details: "Mailbox channel closed",
             }
         });
 
-        #[cfg(feature = "tracing")]
         match &result {
             Ok(_) => debug!("Blocking tell message sent successfully"),
             Err(e) => warn!(error = %e, "Failed to send blocking tell message"),
@@ -1137,6 +1265,7 @@ impl<T: Actor> ActorRef<T> {
             payload: Box::new(msg),
             reply_channel: None,
             actor_ref: self.clone(),
+            ask_edge: Default::default(),
         };
 
         // Fast path: if the mailbox has room, finish without spawning a
@@ -1149,11 +1278,11 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "blocking_tell",
+                    "tell",
                 );
                 return Err(Error::Send {
                     identity: self.identity(),
-                    details: "Mailbox channel closed".to_string(),
+                    details: "Mailbox channel closed",
                 });
             }
             Err(mpsc::error::TrySendError::Full(env)) => env,
@@ -1172,18 +1301,18 @@ impl<T: Actor> ActorRef<T> {
                         crate::dead_letter::record::<M>(
                             identity,
                             crate::dead_letter::DeadLetterReason::ActorStopped,
-                            "blocking_tell",
+                            "tell",
                         );
                         Err(Error::Send {
                             identity,
-                            details: "Mailbox channel closed".to_string(),
+                            details: "Mailbox channel closed",
                         })
                     }
                     Err(_) => {
                         crate::dead_letter::record::<M>(
                             identity,
                             crate::dead_letter::DeadLetterReason::Timeout,
-                            "blocking_tell",
+                            "tell",
                         );
                         Err(Error::Timeout {
                             identity,
@@ -1203,22 +1332,26 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Multi-thread Tokio runtime (any context, including `async fn`)**: uses
+    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **`current_thread` runtime, or no runtime context, with `timeout: None`**:
-    ///   uses Tokio's `blocking_send` and `blocking_recv` directly. Most
-    ///   efficient, but blocks indefinitely if the actor never responds.
-    /// - **`current_thread` runtime, or no runtime context, with `timeout: Some(_)`**:
-    ///   spawns a short-lived dedicated thread with a temporary single-thread
-    ///   runtime to await the reply with the timeout. Unlike the `tell`
-    ///   variants, no `try_send` fast path is possible because a sync
-    ///   `recv_timeout` for the reply channel is unavailable.
+    /// - **`timeout: Some(_)`, any other context**: spawns a short-lived
+    ///   dedicated thread with a temporary single-thread runtime to await the
+    ///   reply with the timeout. Unlike the `tell` variants, no `try_send`
+    ///   fast path is possible because a sync `recv_timeout` for the reply
+    ///   channel is unavailable.
+    /// - **`timeout: None`, no runtime context**: uses Tokio's `blocking_send`
+    ///   and `blocking_recv` directly; blocks indefinitely until the reply
+    ///   arrives.
+    /// - **`timeout: None`, inside a `current_thread` runtime or a thread
+    ///   driving `Handle::block_on`**: spawns a dedicated thread (like the
+    ///   timeout path, but unbounded) — calling `blocking_send`/`blocking_recv`
+    ///   there would panic. The calling runtime thread is parked for the
+    ///   duration.
     ///
     /// # Performance Considerations
     ///
-    /// The slow-path fallback (`current_thread` runtime or no runtime, with
-    /// timeout) incurs:
+    /// The slow-path fallbacks (dedicated thread + temporary runtime) incur:
     /// - **Thread creation**: ~50-200μs depending on the platform
     /// - **Tokio runtime creation**: ~1-10μs for a single-threaded runtime
     ///
@@ -1231,6 +1364,12 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`ask`](Self::ask) directly
     /// from async code where possible.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    /// running on a multi-thread runtime: the runtime handle reports
+    /// multi-thread flavor, but `block_in_place` is not permitted there.
     ///
     /// # Deadlock warning
     ///
@@ -1263,13 +1402,11 @@ impl<T: Actor> ActorRef<T> {
         // thread and runtime. Safe to call from async contexts on a
         // multi-thread runtime.
         if let Some(handle) = current_multi_thread_handle() {
-            return tokio::task::block_in_place(|| {
-                handle.block_on(async {
-                    match timeout {
-                        Some(t) => self.ask_with_timeout(msg, t).await,
-                        None => self.ask(msg).await,
-                    }
-                })
+            return block_on_current_runtime(handle, async {
+                match timeout {
+                    Some(t) => self.ask_with_timeout(msg, t).await,
+                    None => self.ask(msg).await,
+                }
             });
         }
 
@@ -1286,29 +1423,45 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
+        debug!("Sending blocking ask message and waiting for reply");
+
+        // Inside *any* runtime context (a current_thread runtime task, or a
+        // thread driving `Handle::block_on`), tokio's `blocking_send` /
+        // `blocking_recv` panic with "Cannot block the current thread from
+        // within a runtime". Route the whole ask through the dedicated-thread
+        // slow path instead: same blocks-until-replied semantics, no panic.
+        // Deadlock detection still works on this path —
+        // `run_blocking_with_runtime` re-establishes the calling actor's
+        // identity inside the temporary runtime.
+        if Handle::try_current().is_ok() {
+            let self_clone = self.clone();
+            return run_blocking_with_runtime(
+                self.identity(),
+                "Blocking thread terminated unexpectedly",
+                async move { self_clone.ask(msg).await },
+            );
+        }
+
         let (reply_tx, reply_rx) = oneshot::channel();
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: Some(reply_tx),
             actor_ref: self.clone(), // Include the actor ref for context
+            ask_edge: Default::default(),
         };
-
-        #[cfg(feature = "tracing")]
-        debug!("Sending blocking ask message and waiting for reply");
 
         self.sender.blocking_send(envelope).map_err(|_| {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "blocking_ask",
+                "ask",
             );
 
-            #[cfg(feature = "tracing")]
             warn!("Failed to send blocking ask message: mailbox channel closed");
 
             Error::Send {
                 identity: self.identity(),
-                details: "Mailbox channel closed".to_string(),
+                details: "Mailbox channel closed",
             }
         })?;
 
@@ -1317,12 +1470,10 @@ impl<T: Actor> ActorRef<T> {
                 // Successfully received reply from actor
                 match reply_any.downcast::<T::Reply>() {
                     Ok(reply) => {
-                        #[cfg(feature = "tracing")]
                         debug!("Blocking ask reply received successfully");
                         Ok(*reply)
                     }
                     Err(_) => {
-                        #[cfg(feature = "tracing")]
                         warn!(
                             expected_type = %std::any::type_name::<T::Reply>(),
                             "Blocking ask reply type downcast failed"
@@ -1338,14 +1489,13 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ReplyDropped,
-                    "blocking_ask",
+                    "ask",
                 );
 
-                #[cfg(feature = "tracing")]
                 warn!("Blocking ask reply channel closed unexpectedly");
                 Err(Error::Receive {
                     identity: self.identity(),
-                    details: "Reply channel closed unexpectedly".to_string(),
+                    details: "Reply channel closed unexpectedly",
                 })
             }
         }
@@ -1371,7 +1521,7 @@ impl<T: Actor> ActorRef<T> {
                         crate::dead_letter::record::<M>(
                             identity,
                             crate::dead_letter::DeadLetterReason::Timeout,
-                            "blocking_ask",
+                            "ask",
                         );
                         Error::Timeout {
                             identity,
@@ -1465,12 +1615,10 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         R: Send + 'static,
     {
-        #[cfg(feature = "tracing")]
         tracing::debug!("Sending ask_join message and waiting for task completion");
 
         let join_handle = self.ask(msg).await?;
 
-        #[cfg(feature = "tracing")]
         tracing::debug!("Received JoinHandle, awaiting task completion");
 
         let result = join_handle.await.map_err(|join_error| crate::Error::Join {
@@ -1478,7 +1626,6 @@ impl<T: Actor> ActorRef<T> {
             source: std::sync::Arc::new(join_error),
         })?;
 
-        #[cfg(feature = "tracing")]
         tracing::debug!("Task completed successfully");
 
         Ok(result)

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -5,7 +5,8 @@ use crate::actor::IdleEventStream;
 use crate::error::{Error, Result};
 use crate::Identity;
 use crate::{Actor, ControlSignal, MailboxMessage, MailboxSender, Message};
-use futures::stream::{Stream, StreamExt};
+use futures::stream::{BoxStream, Stream, StreamExt};
+use std::fmt;
 use std::time::Duration;
 use tokio::runtime::{Handle, RuntimeFlavor};
 use tokio::sync::{mpsc, oneshot};
@@ -37,6 +38,30 @@ fn block_on_current_runtime<R>(handle: Handle, fut: impl std::future::Future<Out
     tokio::task::block_in_place(|| handle.block_on(fut))
 }
 
+/// Guard for every `blocking_*` slow path: panics — via Tokio's own internal
+/// "can this thread block?" assertion — when the calling thread is currently
+/// driving async tasks (a `current_thread` runtime worker, or any thread
+/// inside `Handle::block_on`/`Runtime::block_on`).
+///
+/// Parking such a thread (e.g. in `join()` on a dedicated blocking thread)
+/// freezes its runtime: every task on it — including the target actor's
+/// message loop — stops being polled, so the wait can never be satisfied and
+/// even `kill()` cannot intervene. Tokio's loud panic
+/// ("Cannot block the current thread from within a runtime") is strictly
+/// better than that silent, unrecoverable hang.
+///
+/// Threads that are allowed to block — no runtime at all, or a
+/// `spawn_blocking` pool thread of any runtime — pass through untouched.
+/// Tokio does not expose this assertion as a queryable API, so a `try_send`
+/// on a fresh non-full channel is used purely for its context check: it never
+/// actually blocks and its only effect is the panic in async contexts.
+fn assert_current_thread_can_block() {
+    if Handle::try_current().is_ok() {
+        let (tx, _rx) = mpsc::channel::<()>(1);
+        let _ = tx.blocking_send(());
+    }
+}
+
 /// Slow-path helper shared by `blocking_*` APIs: spawns a dedicated thread,
 /// builds a single-thread Tokio runtime on it, and runs `fut` to completion.
 ///
@@ -48,17 +73,25 @@ fn block_on_current_runtime<R>(handle: Handle, fut: impl std::future::Future<Out
 /// [`source`](std::error::Error::source).
 ///
 /// With `deadlock-detection` enabled, the calling actor's task-local identity
-/// is captured here and re-established inside the new runtime, so `ask` cycles
-/// taken through this slow path are still detected. A deadlock panic raised on
-/// the dedicated thread is resumed on the caller's thread (preserving the
-/// documented panic-on-detection contract); any other worker-thread panic is
-/// reported as `Error::Runtime` with `panic_msg` and the panic payload in its
-/// details.
+/// is captured here and re-established inside the new runtime. This is
+/// defensive: the blockability guard below panics before any caller that is
+/// actually driving actor tasks (and could therefore see a task-local
+/// identity) reaches this point, so the capture is expected to be `None` on
+/// every surviving path — it is kept so a future change to the guard or the
+/// dispatch conditions cannot silently disable cycle detection. A deadlock
+/// panic raised on the dedicated thread is resumed on the caller's thread
+/// (preserving the documented panic-on-detection contract); any other
+/// worker-thread panic is reported as `Error::Runtime` with `panic_msg` and
+/// the panic payload in its details.
 fn run_blocking_with_runtime<F, R>(identity: Identity, panic_msg: &'static str, fut: F) -> Result<R>
 where
     F: std::future::Future<Output = Result<R>> + Send + 'static,
     R: Send + 'static,
 {
+    // `join.join()` below parks the calling thread; refuse loudly if that
+    // thread is currently driving a runtime (see the guard's docs).
+    assert_current_thread_can_block();
+
     // Capture the current actor (if any) *before* hopping threads — tokio
     // task-locals do not propagate to new threads or runtimes.
     #[cfg(feature = "deadlock-detection")]
@@ -350,21 +383,36 @@ impl<T: Actor> ActorRef<T> {
     /// runtime: at that moment the lifecycle is still awaiting `on_start`, so
     /// the subscribe channel's receiver is not yet being polled and any
     /// `.await` would block forever. The bounded buffer (capacity
-    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY))
+    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY)
+    /// by default, configurable via
+    /// [`SpawnOptions::with_idle_capacity`](crate::SpawnOptions::with_idle_capacity))
     /// absorbs bursts; an explicit `Err` is returned if it is exceeded.
     ///
     /// [`try_send`]: tokio::sync::mpsc::Sender::try_send
     ///
     /// # Errors
     ///
+    /// Every failure returns an [`IdleSubscribeError`] that hands the stream
+    /// back to the caller (via
+    /// [`take_stream`](IdleSubscribeError::take_stream) /
+    /// [`into_parts`](IdleSubscribeError::into_parts)), so an exclusive,
+    /// non-reconstructible source (e.g. the only receiver of a data channel)
+    /// is never silently destroyed.
+    /// The carried [`error`](IdleSubscribeError::error) is one of:
+    ///
     /// - [`Error::IdleChannelNotEnabled`] when the actor was spawned without
     ///   [`SpawnOptions::with_idle`](crate::SpawnOptions::with_idle). The idle channel is
     ///   **off by default**; enable it explicitly to use `on_idle`. This is a configuration
     ///   error and is terminal.
-    /// - [`Error::ChannelFull`] when the bounded subscribe buffer is at capacity. This is
-    ///   transient ([`Error::is_retryable`] returns `true`) — batch your subscriptions
-    ///   across separate handler invocations or raise
-    ///   [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY).
+    /// - [`Error::ChannelFull`] when the bounded subscribe buffer is at capacity.
+    ///   This is transient ([`Error::is_retryable`] returns `true`) **only for
+    ///   callers outside this actor** — the buffer drains exclusively between
+    ///   the actor's own handler invocations, so retrying in a loop from inside
+    ///   `on_start` or one of this actor's handlers can never succeed (see
+    ///   [`Error::ChannelFull`] for the livelock hazard). Instead, spawn with a
+    ///   larger [`with_idle_capacity`](crate::SpawnOptions::with_idle_capacity),
+    ///   merge sources into one stream before subscribing, or batch
+    ///   subscriptions across separate handler invocations.
     /// - [`Error::Send`] when the actor is no longer alive (channel closed) — terminal.
     ///   The subscribe channel is closed as soon as the actor *begins* stopping
     ///   (graceful stop, kill, or an `on_idle` failure), so most termination-racing
@@ -388,27 +436,40 @@ impl<T: Actor> ActorRef<T> {
     ///     ).map(|_| Tick)
     /// )?;
     /// ```
-    pub fn subscribe_idle<S>(&self, stream: S) -> Result<()>
+    pub fn subscribe_idle<S>(&self, stream: S) -> std::result::Result<(), IdleSubscribeError<T>>
     where
         S: Stream<Item = T::IdleEvent> + Send + 'static,
     {
+        let boxed: IdleEventStream<T> = stream.boxed();
+
         let Some(idle_subscribe_sender) = self.idle_subscribe_sender.as_ref() else {
             warn!("subscribe_idle called on actor without an idle channel");
-            return Err(Error::IdleChannelNotEnabled {
-                identity: self.identity(),
-            });
+            return Err(IdleSubscribeError::new(
+                Error::IdleChannelNotEnabled {
+                    identity: self.identity(),
+                },
+                boxed,
+            ));
         };
 
-        let boxed: IdleEventStream<T> = stream.boxed();
+        // `try_send` hands the stream back on failure; thread it through to
+        // the caller instead of dropping it — idle streams often wrap
+        // exclusive resources that cannot be reconstructed for a retry.
         idle_subscribe_sender.try_send(boxed).map_err(|e| match e {
-            mpsc::error::TrySendError::Full(_) => Error::ChannelFull {
-                identity: self.identity(),
-                channel: "idle_subscribe",
-            },
-            mpsc::error::TrySendError::Closed(_) => Error::Send {
-                identity: self.identity(),
-                details: "Idle subscribe channel closed (actor is no longer alive)",
-            },
+            mpsc::error::TrySendError::Full(stream) => IdleSubscribeError::new(
+                Error::ChannelFull {
+                    identity: self.identity(),
+                    channel: "idle_subscribe",
+                },
+                stream,
+            ),
+            mpsc::error::TrySendError::Closed(stream) => IdleSubscribeError::new(
+                Error::Send {
+                    identity: self.identity(),
+                    details: "Idle subscribe channel closed (actor is no longer alive)",
+                },
+                stream,
+            ),
         })
     }
 
@@ -616,6 +677,19 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
+        self.ask_inner(msg, "ask").await
+    }
+
+    /// Shared implementation of [`ask`](Self::ask) and the `blocking_ask`
+    /// fast path. `operation` labels dead letters, deadlock-detection edges,
+    /// and [`Error::Timeout`] so the reported operation always matches the
+    /// public API the caller actually invoked, regardless of execution path.
+    async fn ask_inner<M>(&self, msg: M, operation: &'static str) -> Result<T::Reply>
+    where
+        T: Message<M>,
+        M: Send + 'static,
+        T::Reply: Send + 'static,
+    {
         // Deadlock detection: register this `ask` as a wait-for edge and hold
         // the guard until the reply is received (or this future is dropped).
         // Panics if it would close an ask cycle. The envelope carries a token
@@ -623,7 +697,7 @@ impl<T: Actor> ActorRef<T> {
         // waiting for this future to resume would leave a stale-edge window
         // that produces false-positive cycle panics.
         #[cfg(feature = "deadlock-detection")]
-        let _guard = crate::register_ask_edge(self.identity(), "ask");
+        let _guard = crate::register_ask_edge(self.identity(), operation);
         #[cfg(feature = "deadlock-detection")]
         let ask_edge = _guard.as_ref().map(|g| g.token());
         #[cfg(not(feature = "deadlock-detection"))]
@@ -643,7 +717,7 @@ impl<T: Actor> ActorRef<T> {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "ask",
+                operation,
             );
 
             warn!("Failed to send ask message: mailbox channel closed");
@@ -678,7 +752,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ReplyDropped,
-                    "ask",
+                    operation,
                 );
 
                 warn!("Ask reply channel closed unexpectedly");
@@ -713,23 +787,40 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
+        self.ask_timeout_inner(msg, timeout, "ask").await
+    }
+
+    /// Shared implementation of [`ask_with_timeout`](Self::ask_with_timeout)
+    /// and the `blocking_ask` fast path. See [`ask_inner`](Self::ask_inner)
+    /// for the role of `operation`.
+    async fn ask_timeout_inner<M>(
+        &self,
+        msg: M,
+        timeout: Duration,
+        operation: &'static str,
+    ) -> Result<T::Reply>
+    where
+        T: Message<M>,
+        M: Send + 'static,
+        T::Reply: Send + 'static,
+    {
         debug!(
             timeout_ms = timeout.as_millis(),
             "Sending ask message with timeout"
         );
 
-        let result = tokio::time::timeout(timeout, self.ask(msg))
+        let result = tokio::time::timeout(timeout, self.ask_inner(msg, operation))
             .await
             .map_err(|_| {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    "ask",
+                    operation,
                 );
                 Error::Timeout {
                     identity: self.identity(),
                     timeout,
-                    operation: "ask",
+                    operation,
                 }
             })?;
 
@@ -866,6 +957,25 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
+        self.ask_priority_inner(msg, timeout, "ask_priority").await
+    }
+
+    /// Shared implementation of [`ask_priority`](Self::ask_priority) and
+    /// [`blocking_ask_priority`](Self::blocking_ask_priority). `operation`
+    /// labels dead letters, deadlock-detection edges, and [`Error::Timeout`]
+    /// so the reported operation always matches the public API the caller
+    /// actually invoked, regardless of execution path.
+    async fn ask_priority_inner<M>(
+        &self,
+        msg: M,
+        timeout: Duration,
+        operation: &'static str,
+    ) -> Result<T::Reply>
+    where
+        T: Message<M>,
+        M: Send + 'static,
+        T::Reply: Send + 'static,
+    {
         let Some(priority_sender) = self.priority_sender.as_ref() else {
             warn!("ask_priority called on actor without a priority channel");
             return Err(Error::PriorityChannelNotEnabled {
@@ -879,7 +989,7 @@ impl<T: Actor> ActorRef<T> {
         // Register the edge before sending and hold the guard across the wait so
         // the cycle is detected immediately instead of only timing out.
         #[cfg(feature = "deadlock-detection")]
-        let _guard = crate::register_ask_edge(self.identity(), "ask_priority");
+        let _guard = crate::register_ask_edge(self.identity(), operation);
         #[cfg(feature = "deadlock-detection")]
         let ask_edge = _guard.as_ref().map(|g| g.token());
         #[cfg(not(feature = "deadlock-detection"))]
@@ -898,7 +1008,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "ask_priority",
+                    operation,
                 );
                 return Err(Error::Send {
                     identity: self.identity(),
@@ -918,7 +1028,7 @@ impl<T: Actor> ActorRef<T> {
                     crate::dead_letter::record::<M>(
                         self.identity(),
                         crate::dead_letter::DeadLetterReason::ReplyDropped,
-                        "ask_priority",
+                        operation,
                     );
                     Err(Error::Receive {
                         identity: self.identity(),
@@ -935,12 +1045,12 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    "ask_priority",
+                    operation,
                 );
                 Err(Error::Timeout {
                     identity: self.identity(),
                     timeout,
-                    operation: "ask_priority",
+                    operation,
                 })
             }
         }
@@ -951,14 +1061,18 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
-    ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
-    ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **Priority slot empty, no runtime context**: a `try_send` fast path
-    ///   admits the message immediately without spawning a thread.
-    /// - **`current_thread` runtime, or priority slot full with no runtime**:
-    ///   spawns a short-lived dedicated thread with a temporary single-thread
-    ///   runtime to await admission with the timeout.
+    /// - **Priority slot empty (every context)**: a lock-free `try_send`
+    ///   admits the message immediately — no blocking, no thread spawn, no
+    ///   `block_in_place`.
+    /// - **Priority slot full, worker of a multi-thread Tokio runtime
+    ///   (including `async fn`)**: uses [`tokio::task::block_in_place`] +
+    ///   [`Handle::block_on`](tokio::runtime::Handle::block_on) to await
+    ///   admission on the caller's runtime. No new thread or runtime is created.
+    /// - **Priority slot full, any other context that may block** (no
+    ///   runtime, or a `spawn_blocking` thread of a `current_thread`
+    ///   runtime): spawns a short-lived dedicated thread with a temporary
+    ///   single-thread runtime to await admission with the timeout. Contexts
+    ///   that may *not* block panic instead — see [§ Panics](#panics).
     ///
     /// # Worker-pool caveat
     ///
@@ -966,6 +1080,25 @@ impl<T: Actor> ActorRef<T> {
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers; prefer [`tell_priority`](Self::tell_priority)
     /// directly from async code where possible.
+    ///
+    /// # Panics
+    ///
+    /// Both conditions below require a full priority slot — the `try_send`
+    /// hot path never blocks, so it never panics.
+    ///
+    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    ///   running on a multi-thread runtime: the runtime handle reports
+    ///   multi-thread flavor, but `block_in_place` is not permitted there.
+    /// - When called from an async context that `block_in_place` cannot
+    ///   rescue — a task on a `current_thread` runtime, or any thread driving
+    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
+    ///   (a *multi-thread* runtime's `block_on` driver takes the
+    ///   `block_in_place` path and is fine) — this panics with Tokio's
+    ///   "Cannot block the current thread from within a runtime". Parking such
+    ///   a thread would starve every actor on that runtime for the full
+    ///   timeout; the loud panic surfaces the bug instead. Call from a
+    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
+    ///   async [`tell_priority`](Self::tell_priority), instead.
     ///
     /// # Deadlock warning
     ///
@@ -988,11 +1121,6 @@ impl<T: Actor> ActorRef<T> {
             });
         };
 
-        // Fast path: caller is inside a multi-thread runtime. Reuse it.
-        if let Some(handle) = current_multi_thread_handle() {
-            return block_on_current_runtime(handle, self.tell_priority(msg, timeout));
-        }
-
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: None,
@@ -1000,16 +1128,20 @@ impl<T: Actor> ActorRef<T> {
             ask_edge: Default::default(),
         };
 
-        // Fast path: priority channel has capacity 1, but if it is empty we
-        // can finish without spawning a thread or building a runtime.
+        // Hot path (every context): the priority slot is empty — a single
+        // lock-free `try_send` completes the call. In particular this skips
+        // `block_in_place` on multi-thread-runtime workers, which migrates
+        // the whole worker loop to another thread and back even when the
+        // send itself is immediately ready.
         let envelope = match priority_sender.try_send(envelope) {
             Ok(()) => return Ok(()),
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "tell_priority",
+                    "blocking_tell_priority",
                 );
+                warn!("Failed to send blocking priority tell: priority channel closed");
                 return Err(Error::Send {
                     identity: self.identity(),
                     details: "Priority channel closed",
@@ -1018,41 +1150,57 @@ impl<T: Actor> ActorRef<T> {
             Err(mpsc::error::TrySendError::Full(env)) => env,
         };
 
+        // Priority slot occupied: await admission with the timeout.
         let identity = self.identity();
         let priority_sender = priority_sender.clone();
-
-        run_blocking_with_runtime(
-            identity,
-            "Priority blocking thread terminated unexpectedly",
-            async move {
-                match tokio::time::timeout(timeout, priority_sender.send(envelope)).await {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(_)) => {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::ActorStopped,
-                            "tell_priority",
-                        );
-                        Err(Error::Send {
-                            identity,
-                            details: "Priority channel closed",
-                        })
-                    }
-                    Err(_) => {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::Timeout,
-                            "tell_priority",
-                        );
-                        Err(Error::Timeout {
-                            identity,
-                            timeout,
-                            operation: "tell_priority",
-                        })
-                    }
+        let admit = async move {
+            match tokio::time::timeout(timeout, priority_sender.send(envelope)).await {
+                Ok(Ok(())) => {
+                    debug!("Blocking priority tell message sent successfully");
+                    Ok(())
                 }
-            },
-        )
+                Ok(Err(_)) => {
+                    crate::dead_letter::record::<M>(
+                        identity,
+                        crate::dead_letter::DeadLetterReason::ActorStopped,
+                        "blocking_tell_priority",
+                    );
+                    warn!("Failed to send blocking priority tell: priority channel closed");
+                    Err(Error::Send {
+                        identity,
+                        details: "Priority channel closed",
+                    })
+                }
+                Err(_) => {
+                    crate::dead_letter::record::<M>(
+                        identity,
+                        crate::dead_letter::DeadLetterReason::Timeout,
+                        "blocking_tell_priority",
+                    );
+                    warn!(
+                        timeout_ms = timeout.as_millis(),
+                        "Blocking priority tell timed out awaiting slot admission"
+                    );
+                    Err(Error::Timeout {
+                        identity,
+                        timeout,
+                        operation: "blocking_tell_priority",
+                    })
+                }
+            }
+        };
+
+        // On a multi-thread-runtime worker, reuse the caller's runtime;
+        // otherwise the bounded wait needs a timer, so spawn a dedicated
+        // thread with a temporary runtime.
+        match current_multi_thread_handle() {
+            Some(handle) => block_on_current_runtime(handle, admit),
+            None => run_blocking_with_runtime(
+                identity,
+                "Priority blocking thread terminated unexpectedly",
+                admit,
+            ),
+        }
     }
 
     /// Blocking equivalent of [`ask_priority`](Self::ask_priority). `timeout` is
@@ -1063,9 +1211,11 @@ impl<T: Actor> ActorRef<T> {
     /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **`current_thread` runtime, or no runtime context**: spawns a short-lived
-    ///   dedicated thread with a temporary single-thread runtime to await the
-    ///   reply with the timeout.
+    /// - **Any other context that may block** (no runtime, or a
+    ///   `spawn_blocking` thread of a `current_thread` runtime): spawns a
+    ///   short-lived dedicated thread with a temporary single-thread runtime
+    ///   to await the reply with the timeout. Contexts that may *not* block
+    ///   panic instead — see [§ Panics](#panics).
     ///
     /// Unlike the `tell` variants, `ask` cannot take a `try_send` fast path
     /// because a sync `recv_timeout` for the reply channel is unavailable.
@@ -1075,6 +1225,22 @@ impl<T: Actor> ActorRef<T> {
     /// On a multi-thread runtime the `block_in_place` path holds the calling
     /// worker thread for the duration of the call. Avoid invoking from
     /// runtimes with very few workers.
+    ///
+    /// # Panics
+    ///
+    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    ///   running on a multi-thread runtime: the runtime handle reports
+    ///   multi-thread flavor, but `block_in_place` is not permitted there.
+    /// - When called from an async context that `block_in_place` cannot
+    ///   rescue — a task on a `current_thread` runtime, or any thread driving
+    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
+    ///   (a *multi-thread* runtime's `block_on` driver takes the
+    ///   `block_in_place` path and is fine) — this panics with Tokio's
+    ///   "Cannot block the current thread from within a runtime". Parking such
+    ///   a thread would starve every actor on that runtime for the full
+    ///   timeout; the loud panic surfaces the bug instead. Call from a
+    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
+    ///   async [`ask_priority`](Self::ask_priority), instead.
     ///
     /// # Deadlock warning
     ///
@@ -1100,22 +1266,30 @@ impl<T: Actor> ActorRef<T> {
 
         // Fast path: caller is inside a multi-thread runtime. Reuse it.
         if let Some(handle) = current_multi_thread_handle() {
-            return block_on_current_runtime(handle, self.ask_priority(msg, timeout));
+            return block_on_current_runtime(
+                handle,
+                self.ask_priority_inner(msg, timeout, "blocking_ask_priority"),
+            );
         }
 
         let self_clone = self.clone();
         run_blocking_with_runtime(
             self.identity(),
             "Priority blocking thread terminated unexpectedly",
-            async move { self_clone.ask_priority(msg, timeout).await },
+            async move {
+                self_clone
+                    .ask_priority_inner(msg, timeout, "blocking_ask_priority")
+                    .await
+            },
         )
     }
 
     /// Sends an immediate termination signal to the actor.
     ///
     /// The actor stops as soon as it returns to its message loop: any messages still
-    /// queued in the mailbox are dropped, then `on_stop(killed = true)` runs and the
-    /// actor's final result indicates it was killed.
+    /// queued in the mailbox are discarded without being processed (the physical
+    /// drain — and their dead-letter records — happens after `on_stop(killed = true)`
+    /// returns), and the actor's final result indicates it was killed.
     ///
     /// **Cooperative, not preemptive.** `kill()` cannot interrupt a message handler
     /// (or [`on_idle`](crate::Actor::on_idle)) that is *already executing* — the
@@ -1123,9 +1297,16 @@ impl<T: Actor> ActorRef<T> {
     /// observed. A handler blocked forever on an `.await`, or spinning in a
     /// synchronous/CPU-bound loop, therefore blocks `kill()` as well; the terminate
     /// signal is delivered but cannot be acted on until control returns to the loop.
-    /// Guard against this with timeouts on external operations, the
-    /// `deadlock-detection` feature for `ask` cycles, and by isolating blocking work
-    /// (e.g. `tokio::task::spawn_blocking` or a separate process).
+    /// The same applies to [`on_start`](crate::Actor::on_start), only more so:
+    /// [`spawn`](crate::spawn) hands out the `ActorRef` before `on_start` runs,
+    /// but the runtime loop that observes terminate signals does not exist until
+    /// `on_start` returns — a `kill()` issued while `on_start` awaits a resource
+    /// that never arrives is enqueued yet never observed, `wait_stopped()` never
+    /// resolves, and the `JoinHandle` never completes. Bound `on_start`'s own
+    /// awaits with timeouts. Guard against all of these with timeouts on external
+    /// operations, the `deadlock-detection` feature for `ask` cycles, and by
+    /// isolating blocking work (e.g. `tokio::task::spawn_blocking` or a separate
+    /// process).
     ///
     /// **First signal wins.** If a graceful stop is already in progress — the
     /// actor has dequeued a [`stop`](Self::stop) signal and is draining /
@@ -1230,21 +1411,21 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Execution paths
     ///
-    /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
-    ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
-    ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **Any other context, mailbox has room**: a `try_send` fast path
-    ///   completes without blocking or spawning a thread (both `timeout`
-    ///   variants).
-    /// - **Mailbox full, `timeout: Some(_)`**: spawns a short-lived dedicated
-    ///   thread with a temporary single-thread runtime to await admission with
-    ///   the timeout.
-    /// - **Mailbox full, `timeout: None`, no runtime context**: uses Tokio's
-    ///   `blocking_send` directly; blocks indefinitely until admitted.
-    /// - **Mailbox full, `timeout: None`, inside a `current_thread` runtime or
-    ///   a thread driving `Handle::block_on`**: spawns a dedicated thread (like
-    ///   the timeout path, but unbounded) — calling `blocking_send` there would
-    ///   panic. The calling runtime thread is parked for the duration.
+    /// - **Mailbox has room (every context)**: a lock-free `try_send` completes
+    ///   the call immediately — no blocking, no thread spawn, no
+    ///   `block_in_place`.
+    /// - **Mailbox full, worker of a multi-thread Tokio runtime (including
+    ///   `async fn`)**: uses [`tokio::task::block_in_place`] +
+    ///   [`Handle::block_on`](tokio::runtime::Handle::block_on) to await
+    ///   admission on the caller's runtime. No new thread or runtime is created.
+    /// - **Mailbox full, `timeout: Some(_)`, any other context that may
+    ///   block** (no runtime, or a `spawn_blocking` thread of a
+    ///   `current_thread` runtime): spawns a short-lived dedicated thread with
+    ///   a temporary single-thread runtime to await admission with the
+    ///   timeout. Contexts that may *not* block panic instead — see
+    ///   [§ Panics](#panics).
+    /// - **Mailbox full, `timeout: None`, same blockable contexts**: uses
+    ///   Tokio's `blocking_send` directly; blocks indefinitely until admitted.
     ///
     /// # Performance Considerations
     ///
@@ -1264,9 +1445,24 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Panics
     ///
-    /// Panics when called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    /// running on a multi-thread runtime: the runtime handle reports
-    /// multi-thread flavor, but `block_in_place` is not permitted there.
+    /// Both conditions below require a full mailbox — the `try_send` hot path
+    /// never blocks, so it never panics.
+    ///
+    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    ///   running on a multi-thread runtime: the runtime handle reports
+    ///   multi-thread flavor, but `block_in_place` is not permitted there.
+    /// - When called from an async context that `block_in_place` cannot
+    ///   rescue — a task on a `current_thread` runtime, or any thread driving
+    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
+    ///   (a *multi-thread* runtime's `block_on` driver takes the
+    ///   `block_in_place` path and is fine) — this panics with Tokio's
+    ///   "Cannot block the current thread from within a runtime". Parking such
+    ///   a thread would freeze the only thread able to drive the target actor,
+    ///   turning the call into a silent deadlock of every actor on that
+    ///   runtime that not even `kill()` could break; the loud panic surfaces
+    ///   the bug instead. Call from a
+    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
+    ///   async [`tell`](Self::tell), instead.
     ///
     /// # Deadlock warning
     ///
@@ -1276,8 +1472,9 @@ impl<T: Actor> ActorRef<T> {
     /// parks the actor's message loop synchronously while waiting for admission
     /// that only that same loop could make room for — an unrecoverable hang that
     /// `kill()` cannot interrupt (note that `deadlock-detection` only tracks
-    /// `ask` cycles, not `tell`). Prefer the async [`tell`](Self::tell) from
-    /// handler code.
+    /// `ask` cycles, not `tell`; with that feature enabled, a timeout-less
+    /// blocking self-send on a full mailbox panics instead of hanging). Prefer
+    /// the async [`tell`](Self::tell) from handler code.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_blocking_tell",
@@ -1293,31 +1490,6 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T: Message<M>,
     {
-        // Fast path: caller is inside a multi-thread runtime. Reuse it via
-        // `block_in_place` + `Handle::block_on` instead of spawning a new
-        // thread and runtime. Safe to call from async contexts on a
-        // multi-thread runtime.
-        if let Some(handle) = current_multi_thread_handle() {
-            return block_on_current_runtime(handle, async {
-                match timeout {
-                    Some(t) => self.tell_with_timeout(msg, t).await,
-                    None => self.tell(msg).await,
-                }
-            });
-        }
-
-        match timeout {
-            Some(timeout_duration) => self.blocking_tell_with_timeout_impl(msg, timeout_duration),
-            None => self.blocking_tell_no_timeout(msg),
-        }
-    }
-
-    /// Internal implementation of blocking_tell without timeout.
-    fn blocking_tell_no_timeout<M>(&self, msg: M) -> Result<()>
-    where
-        M: Send + 'static,
-        T: Message<M>,
-    {
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
             reply_channel: None,     // reply_channel is None for tell
@@ -1327,15 +1499,23 @@ impl<T: Actor> ActorRef<T> {
 
         debug!("Sending blocking tell message (fire-and-forget)");
 
-        // Fast path: room in the mailbox — finish without blocking at all.
+        // Hot path (every context): room in the mailbox — a single lock-free
+        // `try_send` completes the call. In particular this skips
+        // `block_in_place` on multi-thread-runtime workers, which migrates
+        // the whole worker loop to another thread and back (microseconds of
+        // scheduler churn) even when the send itself is immediately ready.
         let envelope = match self.sender.try_send(envelope) {
-            Ok(()) => return Ok(()),
+            Ok(()) => {
+                debug!("Blocking tell message sent successfully");
+                return Ok(());
+            }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "tell",
+                    "blocking_tell",
                 );
+                warn!("Failed to send blocking tell message: mailbox channel closed");
                 return Err(Error::Send {
                     identity: self.identity(),
                     details: "Mailbox channel closed",
@@ -1345,128 +1525,112 @@ impl<T: Actor> ActorRef<T> {
                 // A timeout-less blocking self-send on a full mailbox is the
                 // same unrecoverable deadlock as the async `tell` case.
                 #[cfg(feature = "deadlock-detection")]
-                self.panic_if_self_send_on_full("blocking_tell");
+                if timeout.is_none() {
+                    self.panic_if_self_send_on_full("blocking_tell");
+                }
                 env
             }
         };
 
-        // Inside *any* runtime context (a current_thread runtime task, or a
-        // thread driving `Handle::block_on`), tokio's `blocking_send` panics
-        // with "Cannot block the current thread from within a runtime". Route
-        // through the dedicated-thread slow path instead: same
-        // blocks-until-admitted semantics, no panic. The calling runtime
-        // thread is still parked for the duration — see the deadlock warning
-        // on [`blocking_tell`](Self::blocking_tell).
-        if Handle::try_current().is_ok() {
-            let identity = self.identity();
-            let sender = self.sender.clone();
-            return run_blocking_with_runtime(
-                identity,
-                "Blocking thread terminated unexpectedly",
-                async move {
-                    sender.send(envelope).await.map_err(|_| {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::ActorStopped,
-                            "tell",
-                        );
-                        Error::Send {
-                            identity,
-                            details: "Mailbox channel closed",
-                        }
-                    })
-                },
-            );
-        }
-
-        let result = self.sender.blocking_send(envelope).map_err(|_| {
-            crate::dead_letter::record::<M>(
-                self.identity(),
-                crate::dead_letter::DeadLetterReason::ActorStopped,
-                "tell",
-            );
-            Error::Send {
-                identity: self.identity(),
-                details: "Mailbox channel closed",
-            }
-        });
-
-        match &result {
-            Ok(_) => debug!("Blocking tell message sent successfully"),
-            Err(e) => warn!(error = %e, "Failed to send blocking tell message"),
-        }
-
-        result
-    }
-
-    /// Internal implementation of blocking_tell with timeout using a separate thread and runtime.
-    fn blocking_tell_with_timeout_impl<M>(&self, msg: M, timeout: Duration) -> Result<()>
-    where
-        M: Send + 'static,
-        T: Message<M>,
-    {
-        let envelope = MailboxMessage::Envelope {
-            payload: Box::new(msg),
-            reply_channel: None,
-            actor_ref: self.clone(),
-            ask_edge: Default::default(),
-        };
-
-        // Fast path: if the mailbox has room, finish without spawning a
-        // thread or building a runtime. Recovers the message back via
-        // `TrySendError::Full(envelope)` and falls through to the slow path
-        // only when the mailbox is actually full.
-        let envelope = match self.sender.try_send(envelope) {
-            Ok(()) => return Ok(()),
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                crate::dead_letter::record::<M>(
-                    self.identity(),
-                    crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "tell",
-                );
-                return Err(Error::Send {
-                    identity: self.identity(),
-                    details: "Mailbox channel closed",
-                });
-            }
-            Err(mpsc::error::TrySendError::Full(env)) => env,
-        };
-
+        // Mailbox full: await admission.
         let identity = self.identity();
-        let sender = self.sender.clone();
-
-        run_blocking_with_runtime(
-            identity,
-            "Timeout thread terminated unexpectedly",
-            async move {
-                match tokio::time::timeout(timeout, sender.send(envelope)).await {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(_)) => {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::ActorStopped,
-                            "tell",
-                        );
-                        Err(Error::Send {
-                            identity,
-                            details: "Mailbox channel closed",
-                        })
+        match timeout {
+            Some(timeout) => {
+                let sender = self.sender.clone();
+                let admit = async move {
+                    match tokio::time::timeout(timeout, sender.send(envelope)).await {
+                        Ok(Ok(())) => {
+                            debug!("Blocking tell message sent successfully");
+                            Ok(())
+                        }
+                        Ok(Err(_)) => {
+                            crate::dead_letter::record::<M>(
+                                identity,
+                                crate::dead_letter::DeadLetterReason::ActorStopped,
+                                "blocking_tell",
+                            );
+                            warn!("Failed to send blocking tell message: mailbox channel closed");
+                            Err(Error::Send {
+                                identity,
+                                details: "Mailbox channel closed",
+                            })
+                        }
+                        Err(_) => {
+                            crate::dead_letter::record::<M>(
+                                identity,
+                                crate::dead_letter::DeadLetterReason::Timeout,
+                                "blocking_tell",
+                            );
+                            warn!(
+                                timeout_ms = timeout.as_millis(),
+                                "Blocking tell timed out awaiting mailbox admission"
+                            );
+                            Err(Error::Timeout {
+                                identity,
+                                timeout,
+                                operation: "blocking_tell",
+                            })
+                        }
                     }
-                    Err(_) => {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::Timeout,
-                            "tell",
-                        );
-                        Err(Error::Timeout {
-                            identity,
-                            timeout,
-                            operation: "blocking_tell",
-                        })
-                    }
+                };
+                // On a multi-thread-runtime worker, reuse the caller's runtime;
+                // otherwise the bounded wait needs a timer, so spawn a
+                // dedicated thread with a temporary runtime.
+                match current_multi_thread_handle() {
+                    Some(handle) => block_on_current_runtime(handle, admit),
+                    None => run_blocking_with_runtime(
+                        identity,
+                        "Timeout thread terminated unexpectedly",
+                        admit,
+                    ),
                 }
-            },
-        )
+            }
+            None => {
+                if let Some(handle) = current_multi_thread_handle() {
+                    return block_on_current_runtime(handle, async {
+                        self.sender.send(envelope).await.map_err(|_| {
+                            crate::dead_letter::record::<M>(
+                                identity,
+                                crate::dead_letter::DeadLetterReason::ActorStopped,
+                                "blocking_tell",
+                            );
+                            warn!("Failed to send blocking tell message: mailbox channel closed");
+                            Error::Send {
+                                identity,
+                                details: "Mailbox channel closed",
+                            }
+                        })
+                    });
+                }
+
+                // `blocking_send` carries tokio's own guard: in any async
+                // context (a `current_thread` runtime worker, or a thread
+                // driving `block_on`) it panics with "Cannot block the current
+                // thread from within a runtime" instead of parking — and
+                // thereby starving — the runtime that must drive the target
+                // actor. Do NOT route around that panic with a dedicated
+                // thread: the park would turn the loud failure into a silent,
+                // kill-proof deadlock of every actor on the caller's runtime.
+                let result = self.sender.blocking_send(envelope).map_err(|_| {
+                    crate::dead_letter::record::<M>(
+                        identity,
+                        crate::dead_letter::DeadLetterReason::ActorStopped,
+                        "blocking_tell",
+                    );
+                    Error::Send {
+                        identity,
+                        details: "Mailbox channel closed",
+                    }
+                });
+
+                match &result {
+                    Ok(_) => debug!("Blocking tell message sent successfully"),
+                    Err(e) => warn!(error = %e, "Failed to send blocking tell message"),
+                }
+
+                result
+            }
+        }
     }
 
     /// Synchronous version of [`ActorRef::ask`] that blocks until the reply is received.
@@ -1479,19 +1643,16 @@ impl<T: Actor> ActorRef<T> {
     /// - **Worker of a multi-thread Tokio runtime (including `async fn`)**: uses
     ///   [`tokio::task::block_in_place`] + [`Handle::block_on`](tokio::runtime::Handle::block_on)
     ///   to reuse the caller's runtime. No new thread or runtime is created.
-    /// - **`timeout: Some(_)`, any other context**: spawns a short-lived
-    ///   dedicated thread with a temporary single-thread runtime to await the
-    ///   reply with the timeout. Unlike the `tell` variants, no `try_send`
-    ///   fast path is possible because a sync `recv_timeout` for the reply
-    ///   channel is unavailable.
-    /// - **`timeout: None`, no runtime context**: uses Tokio's `blocking_send`
-    ///   and `blocking_recv` directly; blocks indefinitely until the reply
-    ///   arrives.
-    /// - **`timeout: None`, inside a `current_thread` runtime or a thread
-    ///   driving `Handle::block_on`**: spawns a dedicated thread (like the
-    ///   timeout path, but unbounded) — calling `blocking_send`/`blocking_recv`
-    ///   there would panic. The calling runtime thread is parked for the
-    ///   duration.
+    /// - **`timeout: Some(_)`, any other context that may block** (no
+    ///   runtime, or a `spawn_blocking` thread of a `current_thread`
+    ///   runtime): spawns a short-lived dedicated thread with a temporary
+    ///   single-thread runtime to await the reply with the timeout. Unlike
+    ///   the `tell` variants, no `try_send` fast path is possible because a
+    ///   sync `recv_timeout` for the reply channel is unavailable. Contexts
+    ///   that may *not* block panic instead — see [§ Panics](#panics).
+    /// - **`timeout: None`, same blockable contexts**: uses Tokio's
+    ///   `blocking_send` and `blocking_recv` directly; blocks indefinitely
+    ///   until the reply arrives.
     ///
     /// # Performance Considerations
     ///
@@ -1511,9 +1672,21 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Panics
     ///
-    /// Panics when called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    /// running on a multi-thread runtime: the runtime handle reports
-    /// multi-thread flavor, but `block_in_place` is not permitted there.
+    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+    ///   running on a multi-thread runtime: the runtime handle reports
+    ///   multi-thread flavor, but `block_in_place` is not permitted there.
+    /// - When called from an async context that `block_in_place` cannot
+    ///   rescue — a task on a `current_thread` runtime, or any thread driving
+    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
+    ///   (a *multi-thread* runtime's `block_on` driver takes the
+    ///   `block_in_place` path and is fine) — this panics with Tokio's
+    ///   "Cannot block the current thread from within a runtime". Parking such
+    ///   a thread would freeze the only thread able to drive the target actor,
+    ///   turning the call into a silent deadlock of every actor on that
+    ///   runtime that not even `kill()` could break; the loud panic surfaces
+    ///   the bug instead. Call from a
+    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
+    ///   async [`ask`](Self::ask), instead.
     ///
     /// # Deadlock warning
     ///
@@ -1548,8 +1721,8 @@ impl<T: Actor> ActorRef<T> {
         if let Some(handle) = current_multi_thread_handle() {
             return block_on_current_runtime(handle, async {
                 match timeout {
-                    Some(t) => self.ask_with_timeout(msg, t).await,
-                    None => self.ask(msg).await,
+                    Some(t) => self.ask_timeout_inner(msg, t, "blocking_ask").await,
+                    None => self.ask_inner(msg, "blocking_ask").await,
                 }
             });
         }
@@ -1569,23 +1742,15 @@ impl<T: Actor> ActorRef<T> {
     {
         debug!("Sending blocking ask message and waiting for reply");
 
-        // Inside *any* runtime context (a current_thread runtime task, or a
-        // thread driving `Handle::block_on`), tokio's `blocking_send` /
-        // `blocking_recv` panic with "Cannot block the current thread from
-        // within a runtime". Route the whole ask through the dedicated-thread
-        // slow path instead: same blocks-until-replied semantics, no panic.
-        // Deadlock detection still works on this path —
-        // `run_blocking_with_runtime` re-establishes the calling actor's
-        // identity inside the temporary runtime.
-        if Handle::try_current().is_ok() {
-            let self_clone = self.clone();
-            return run_blocking_with_runtime(
-                self.identity(),
-                "Blocking thread terminated unexpectedly",
-                async move { self_clone.ask(msg).await },
-            );
-        }
-
+        // `blocking_send`/`blocking_recv` carry tokio's own guard: in any
+        // async context (a `current_thread` runtime worker, or a thread
+        // driving `block_on`) they panic with "Cannot block the current
+        // thread from within a runtime" instead of parking — and thereby
+        // starving — the runtime that must drive the target actor. Do NOT
+        // route around that panic with a dedicated thread: the park would
+        // turn the loud failure into a silent, kill-proof deadlock of every
+        // actor on the caller's runtime. The panic fires before the message
+        // is admitted, so it has no side effects.
         let (reply_tx, reply_rx) = oneshot::channel();
         let envelope = MailboxMessage::Envelope {
             payload: Box::new(msg),
@@ -1598,7 +1763,7 @@ impl<T: Actor> ActorRef<T> {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "ask",
+                "blocking_ask",
             );
 
             warn!("Failed to send blocking ask message: mailbox channel closed");
@@ -1633,7 +1798,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ReplyDropped,
-                    "ask",
+                    "blocking_ask",
                 );
 
                 warn!("Blocking ask reply channel closed unexpectedly");
@@ -1659,20 +1824,9 @@ impl<T: Actor> ActorRef<T> {
             identity,
             "Timeout thread terminated unexpectedly",
             async move {
-                tokio::time::timeout(timeout, self_clone.ask(msg))
+                self_clone
+                    .ask_timeout_inner(msg, timeout, "blocking_ask")
                     .await
-                    .map_err(|_| {
-                        crate::dead_letter::record::<M>(
-                            identity,
-                            crate::dead_letter::DeadLetterReason::Timeout,
-                            "ask",
-                        );
-                        Error::Timeout {
-                            identity,
-                            timeout,
-                            operation: "blocking_ask",
-                        }
-                    })?
             },
         )
     }
@@ -1804,7 +1958,10 @@ impl<T: Actor> ActorRef<T> {
         self.metrics.snapshot()
     }
 
-    /// Returns the total number of messages processed by this actor.
+    /// Returns the number of **regular-mailbox** messages processed by this
+    /// actor. Priority messages are counted separately by
+    /// [`priority_message_count`](Self::priority_message_count); sum the two
+    /// for an all-channel total.
     #[cfg(feature = "metrics")]
     #[inline]
     pub fn message_count(&self) -> u64 {
@@ -1851,6 +2008,31 @@ impl<T: Actor> ActorRef<T> {
         self.metrics.max_priority_processing_time()
     }
 
+    /// Returns the total number of idle events dispatched to
+    /// [`Actor::on_idle`](crate::Actor::on_idle).
+    ///
+    /// Always `0` for actors spawned without
+    /// [`SpawnOptions::with_idle`](crate::SpawnOptions::with_idle).
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn idle_event_count(&self) -> u64 {
+        self.metrics.idle_event_count()
+    }
+
+    /// Returns the average `on_idle` processing time per dispatched event.
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn avg_idle_processing_time(&self) -> std::time::Duration {
+        self.metrics.avg_idle_processing_time()
+    }
+
+    /// Returns the maximum `on_idle` processing time observed.
+    #[cfg(feature = "metrics")]
+    #[inline]
+    pub fn max_idle_processing_time(&self) -> std::time::Duration {
+        self.metrics.max_idle_processing_time()
+    }
+
     /// Returns the time elapsed since the actor started.
     #[cfg(feature = "metrics")]
     #[inline]
@@ -1858,9 +2040,10 @@ impl<T: Actor> ActorRef<T> {
         self.metrics.uptime()
     }
 
-    /// Returns the timestamp of the last message processing.
+    /// Returns the timestamp of the last completed unit of work — a message
+    /// (regular or priority) or an idle event.
     ///
-    /// Returns `None` if no messages have been processed yet.
+    /// Returns `None` if no work has completed yet.
     #[cfg(feature = "metrics")]
     #[inline]
     pub fn last_activity(&self) -> Option<std::time::SystemTime> {
@@ -1880,6 +2063,103 @@ impl<T: Actor> Clone for ActorRef<T> {
             #[cfg(feature = "metrics")]
             metrics: self.metrics.clone(),
         }
+    }
+}
+
+/// Error returned by [`ActorRef::subscribe_idle`], handing the rejected
+/// stream back to the caller.
+///
+/// Idle streams frequently wrap exclusive, non-reconstructible resources —
+/// the only receiver of a data channel, a file/OS event watcher, a network
+/// subscription. Returning ownership on failure means a retryable rejection
+/// ([`Error::ChannelFull`]) can actually be retried *with the same stream*,
+/// and a terminal one ([`Error::Send`], [`Error::IdleChannelNotEnabled`])
+/// still lets the caller route the events elsewhere instead of losing the
+/// source.
+///
+/// Converts into [`Error`] (dropping the stream) via `From`, so
+/// `subscribe_idle(...)?` keeps working in functions returning
+/// [`Result`](crate::Result) or `anyhow::Result`.
+pub struct IdleSubscribeError<T: Actor> {
+    /// Why the subscription was rejected.
+    pub error: Error,
+    /// The stream that was not installed, recoverable via
+    /// [`take_stream`](Self::take_stream) / [`into_parts`](Self::into_parts).
+    /// Behind a `Mutex` purely so this error is `Sync` (a `BoxStream` is only
+    /// `Send`), which `?`-conversion into types like `anyhow::Error` requires.
+    stream: std::sync::Mutex<Option<BoxStream<'static, T::IdleEvent>>>,
+}
+
+impl<T: Actor> IdleSubscribeError<T> {
+    fn new(error: Error, stream: BoxStream<'static, T::IdleEvent>) -> Self {
+        Self {
+            error,
+            stream: std::sync::Mutex::new(Some(stream)),
+        }
+    }
+
+    /// Takes back ownership of the rejected stream for reuse (e.g. a retry,
+    /// or routing the events elsewhere). Returns `None` only if it was
+    /// already taken.
+    pub fn take_stream(&self) -> Option<BoxStream<'static, T::IdleEvent>> {
+        self.stream
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
+
+    /// Splits this into the underlying [`Error`] and the rejected stream
+    /// (`None` only if [`take_stream`](Self::take_stream) was called first).
+    pub fn into_parts(self) -> (Error, Option<BoxStream<'static, T::IdleEvent>>) {
+        let stream = self
+            .stream
+            .into_inner()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (self.error, stream)
+    }
+}
+
+impl<T: Actor> fmt::Debug for IdleSubscribeError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let taken = self
+            .stream
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_none();
+        f.debug_struct("IdleSubscribeError")
+            .field("error", &self.error)
+            .field(
+                "stream",
+                &format_args!(
+                    "{}BoxStream<{}>",
+                    if taken { "taken " } else { "" },
+                    std::any::type_name::<T::IdleEvent>()
+                ),
+            )
+            .finish()
+    }
+}
+
+impl<T: Actor> fmt::Display for IdleSubscribeError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl<T: Actor> std::error::Error for IdleSubscribeError<T> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // `Display` already delegates to `self.error`, so returning
+        // `&self.error` here would print the same message twice in chain
+        // reports (anyhow's "Caused by:"). Skip straight to the inner
+        // error's own source; `self.error` stays reachable via the public
+        // field.
+        std::error::Error::source(&self.error)
+    }
+}
+
+impl<T: Actor> From<IdleSubscribeError<T>> for Error {
+    fn from(e: IdleSubscribeError<T>) -> Self {
+        e.error
     }
 }
 
@@ -1946,12 +2226,25 @@ impl<T: Actor> ActorWeak<T> {
     /// `upgrade()` to succeed. In practice their strong-sender counts move in lockstep — every
     /// [`ActorRef`] clone owns one of each — so they live and die together; the joint check is
     /// defensive rather than restrictive.
+    ///
+    /// Besides the reference counts, this also fails once the actor's runtime
+    /// loop has exited and closed its channel receivers (graceful stop, kill,
+    /// or a lifecycle failure) — even while strong [`ActorRef`] clones still
+    /// linger in registries elsewhere. A reference to a fully stopped actor
+    /// can only fail every call, so handing one out would just defer the error
+    /// and make `upgrade()` disagree with [`ActorRef::is_alive`].
     #[inline]
     pub fn upgrade(&self) -> Option<ActorRef<T>> {
         // Try to upgrade the two primary channel senders (mailbox, terminate).
         // The priority and idle-subscribe channels, when present, are best-effort.
         let sender = self.sender.upgrade()?;
         let terminate_sender = self.terminate_sender.upgrade()?;
+        // Strong refs lingering after the runtime loop exited keep the
+        // refcounts positive, but the closed receivers reveal the actor is
+        // gone for good.
+        if sender.is_closed() || terminate_sender.is_closed() {
+            return None;
+        }
         let priority_sender = self.priority_sender.as_ref().and_then(|s| s.upgrade());
         let idle_subscribe_sender = self
             .idle_subscribe_sender
@@ -1976,21 +2269,38 @@ impl<T: Actor> ActorWeak<T> {
 
     /// Checks if the actor might still be alive.
     ///
-    /// This method returns `true` if weak references can potentially be upgraded,
-    /// but does not guarantee that a subsequent [`upgrade`](ActorWeak::upgrade) call will succeed
-    /// due to potential race conditions.
+    /// Returns `false` if the actor is definitely dead: every strong reference
+    /// has been dropped, or the actor's runtime loop has exited and closed its
+    /// channels (graceful stop, kill, or a lifecycle failure) — the latter
+    /// catches fully stopped actors whose strong [`ActorRef`] clones still
+    /// linger in registries, matching [`ActorRef::is_alive`].
     ///
-    /// Returns `false` if the actor is definitely dead (all strong references dropped).
-    ///
-    /// **Note**: This is a heuristic check. For definitive actor state, always use
+    /// **Note**: This is a heuristic check — the actor can stop between this
+    /// call and the next operation. For definitive actor state, always use
     /// [`upgrade`](ActorWeak::upgrade) and check the returned `Option`.
     #[inline]
     pub fn is_alive(&self) -> bool {
-        // Every primary sender (mailbox, terminate) must still have a strong
-        // reference for the actor to be alive. Mirror the same set checked by
-        // `upgrade()` so the two calls cannot disagree. The priority and
-        // idle-subscribe channels are secondary and intentionally not consulted.
-        self.sender.strong_count() > 0 && self.terminate_sender.strong_count() > 0
+        // Mirror the exact check `upgrade()` performs (primary senders
+        // upgradable + receivers not closed) so the two calls cannot
+        // disagree. The priority and idle-subscribe channels are secondary
+        // and intentionally not consulted.
+        match (self.sender.upgrade(), self.terminate_sender.upgrade()) {
+            (Some(sender), Some(terminate_sender)) => {
+                !sender.is_closed() && !terminate_sender.is_closed()
+            }
+            _ => false,
+        }
+    }
+
+    /// Returns a snapshot of all metrics for this actor.
+    ///
+    /// `ActorWeak` holds the metrics by strong reference precisely so they
+    /// survive the actor: this accessor keeps working after the actor has
+    /// fully stopped (when [`upgrade`](Self::upgrade) already returns `None`),
+    /// enabling post-mortem analysis from a retained weak handle.
+    #[cfg(feature = "metrics")]
+    pub fn metrics(&self) -> crate::MetricsSnapshot {
+        self.metrics.snapshot()
     }
 }
 

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -19,22 +19,146 @@ pub enum FailurePhase {
     OnStop,
     /// Actor failed during [`on_idle`](crate::Actor::on_idle), and then
     /// [`on_stop`](crate::Actor::on_stop) also failed during cleanup.
-    /// The primary `on_idle` error is exposed via [`ActorResult::error`]; the
-    /// `on_stop` error is exposed via [`ActorResult::secondary_error`].
+    /// The primary `on_idle` error is exposed via [`ActorFailure::error`]; the
+    /// `on_stop` error is exposed via [`ActorFailure::stop_error`].
     OnIdleThenOnStop,
 }
 
 /// Implements Display for FailurePhase to provide human-readable error messages.
 ///
-/// This allows `FailurePhase` to be easily converted to strings for logging,
-/// error reporting, and debugging purposes.
+/// The human-readable form is the variant name, so this delegates to the
+/// derived `Debug` impl — one source of truth when variants are added.
 impl std::fmt::Display for FailurePhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Phase-specific payload of a failed actor lifecycle.
+///
+/// Each variant carries exactly the data that can exist in that phase, so the
+/// invariants that were previously documentation-only are enforced by the type
+/// system:
+///
+/// - Only [`OnStart`](ActorFailure::OnStart) lacks an actor instance (the actor
+///   was never constructed).
+/// - Only [`OnIdleThenOnStop`](ActorFailure::OnIdleThenOnStop) carries a second
+///   error (the `on_stop` cleanup failure after the primary `on_idle` failure).
+///
+/// Use the accessors ([`phase`](Self::phase), [`error`](Self::error),
+/// [`actor`](Self::actor), [`stop_error`](Self::stop_error)) for uniform access
+/// across variants, or match directly when handling a specific phase.
+#[derive(Debug)]
+pub enum ActorFailure<T: Actor> {
+    /// [`on_start`](crate::Actor::on_start) returned an error; the actor was
+    /// never constructed, so no instance is available.
+    OnStart {
+        /// The error returned by `on_start`.
+        error: T::Error,
+    },
+    /// [`on_idle`](crate::Actor::on_idle) returned an error and the subsequent
+    /// `on_stop` cleanup succeeded.
+    OnIdle {
+        /// The actor instance, recovered for inspection or restart.
+        actor: T,
+        /// The error returned by `on_idle`.
+        error: T::Error,
+    },
+    /// [`on_stop`](crate::Actor::on_stop) returned an error during shutdown.
+    OnStop {
+        /// The actor instance, recovered for inspection or restart.
+        actor: T,
+        /// The error returned by `on_stop`.
+        error: T::Error,
+    },
+    /// [`on_idle`](crate::Actor::on_idle) returned an error, and then
+    /// [`on_stop`](crate::Actor::on_stop) also failed while cleaning up.
+    OnIdleThenOnStop {
+        /// The actor instance, recovered for inspection or restart.
+        actor: T,
+        /// The primary error returned by `on_idle`.
+        error: T::Error,
+        /// The secondary error returned by `on_stop` during cleanup.
+        stop_error: T::Error,
+    },
+}
+
+impl<T: Actor> ActorFailure<T> {
+    /// Returns the lifecycle phase this failure occurred in.
+    pub fn phase(&self) -> FailurePhase {
         match self {
-            FailurePhase::OnStart => write!(f, "OnStart"),
-            FailurePhase::OnIdle => write!(f, "OnIdle"),
-            FailurePhase::OnStop => write!(f, "OnStop"),
-            FailurePhase::OnIdleThenOnStop => write!(f, "OnIdleThenOnStop"),
+            ActorFailure::OnStart { .. } => FailurePhase::OnStart,
+            ActorFailure::OnIdle { .. } => FailurePhase::OnIdle,
+            ActorFailure::OnStop { .. } => FailurePhase::OnStop,
+            ActorFailure::OnIdleThenOnStop { .. } => FailurePhase::OnIdleThenOnStop,
+        }
+    }
+
+    /// Returns the primary error of this failure.
+    ///
+    /// For [`OnIdleThenOnStop`](Self::OnIdleThenOnStop) this is the original
+    /// `on_idle` error; the `on_stop` cleanup error is available via
+    /// [`stop_error`](Self::stop_error).
+    pub fn error(&self) -> &T::Error {
+        match self {
+            ActorFailure::OnStart { error }
+            | ActorFailure::OnIdle { error, .. }
+            | ActorFailure::OnStop { error, .. }
+            | ActorFailure::OnIdleThenOnStop { error, .. } => error,
+        }
+    }
+
+    /// Consumes the failure and returns the primary error.
+    ///
+    /// Drops the recovered actor instance (if any) and the `on_stop` cleanup
+    /// error (for [`OnIdleThenOnStop`](Self::OnIdleThenOnStop)).
+    pub fn into_error(self) -> T::Error {
+        match self {
+            ActorFailure::OnStart { error }
+            | ActorFailure::OnIdle { error, .. }
+            | ActorFailure::OnStop { error, .. }
+            | ActorFailure::OnIdleThenOnStop { error, .. } => error,
+        }
+    }
+
+    /// Returns the recovered actor instance, if one exists.
+    ///
+    /// `None` only for [`OnStart`](Self::OnStart) failures, where the actor was
+    /// never constructed.
+    pub fn actor(&self) -> Option<&T> {
+        match self {
+            ActorFailure::OnStart { .. } => None,
+            ActorFailure::OnIdle { actor, .. }
+            | ActorFailure::OnStop { actor, .. }
+            | ActorFailure::OnIdleThenOnStop { actor, .. } => Some(actor),
+        }
+    }
+
+    /// Consumes the failure and returns the recovered actor instance, if any.
+    pub fn into_actor(self) -> Option<T> {
+        match self {
+            ActorFailure::OnStart { .. } => None,
+            ActorFailure::OnIdle { actor, .. }
+            | ActorFailure::OnStop { actor, .. }
+            | ActorFailure::OnIdleThenOnStop { actor, .. } => Some(actor),
+        }
+    }
+
+    /// Returns the `on_stop` cleanup error, present only for
+    /// [`OnIdleThenOnStop`](Self::OnIdleThenOnStop).
+    pub fn stop_error(&self) -> Option<&T::Error> {
+        match self {
+            ActorFailure::OnIdleThenOnStop { stop_error, .. } => Some(stop_error),
+            _ => None,
+        }
+    }
+
+    /// Consumes the failure and returns the `on_stop` cleanup error, present
+    /// only for [`OnIdleThenOnStop`](Self::OnIdleThenOnStop).
+    pub fn into_stop_error(self) -> Option<T::Error> {
+        match self {
+            ActorFailure::OnIdleThenOnStop { stop_error, .. } => Some(stop_error),
+            _ => None,
         }
     }
 }
@@ -73,8 +197,8 @@ impl std::fmt::Display for FailurePhase {
 ///         println!("Actor completed successfully, killed: {}", killed);
 ///         // Use the recovered actor instance
 ///     }
-///     ActorResult::Failed { error, phase, .. } => {
-///         eprintln!("Actor failed in phase {:?}: {}", phase, error);
+///     ActorResult::Failed { failure, .. } => {
+///         eprintln!("Actor failed in phase {}: {}", failure.phase(), failure.error());
 ///         // Handle the error appropriately
 ///     }
 /// }
@@ -139,26 +263,11 @@ pub enum ActorResult<T: Actor> {
     },
     /// Actor failed during one of its lifecycle phases.
     ///
-    /// This variant indicates that the actor encountered an error during execution.
+    /// The phase, the error(s), and the recovered actor instance (when one
+    /// exists) live in the phase-specific [`ActorFailure`] payload.
     Failed {
-        /// The actor instance (if recoverable), or None if not recoverable.
-        /// This will be `None` specifically when the failure occurred during the [`on_start`](Actor::on_start) phase,
-        /// as the actor wasn't fully initialized.
-        actor: Option<T>,
-        /// The error that caused the failure (the primary cause).
-        ///
-        /// For [`FailurePhase::OnIdleThenOnStop`] this holds the original `on_idle` error;
-        /// the subsequent `on_stop` error is exposed via the `secondary_error` field
-        /// (or the [`ActorResult::secondary_error`] accessor).
-        error: T::Error,
-        /// Secondary error, set only when a *cleanup* hook also failed after the primary failure.
-        ///
-        /// Currently set only for [`FailurePhase::OnIdleThenOnStop`], where it carries the
-        /// `on_stop` error that was emitted while cleaning up after a failed `on_idle`.
-        /// `None` for every other phase.
-        secondary_error: Option<T::Error>,
-        /// The lifecycle phase during which the failure occurred
-        phase: FailurePhase,
+        /// What failed, where, and what could be recovered.
+        failure: ActorFailure<T>,
         /// Whether the actor was killed (`true`) or was attempting to stop gracefully (`false`)
         killed: bool,
     },
@@ -168,6 +277,11 @@ pub enum ActorResult<T: Actor> {
 ///
 /// This allows extracting both the actor instance and error (if any) in a single operation.
 /// Useful for pattern matching and destructuring in supervision contexts.
+///
+/// **Lossy**: this conversion discards the failure phase, the `killed` flag,
+/// and — for [`FailurePhase::OnIdleThenOnStop`] — the secondary `on_stop`
+/// cleanup error. Use the accessors on [`ActorResult`] / [`ActorFailure`] when
+/// any of those matter.
 ///
 /// # Example
 /// ```ignore
@@ -183,11 +297,12 @@ impl<T: Actor> From<ActorResult<T>> for (Option<T>, Option<T::Error>) {
     fn from(result: ActorResult<T>) -> Self {
         match result {
             ActorResult::Completed { actor, .. } => (Some(actor), None),
-            ActorResult::Failed {
-                actor,
-                error: cause,
-                ..
-            } => (actor, Some(cause)),
+            ActorResult::Failed { failure, .. } => match failure {
+                ActorFailure::OnStart { error } => (None, Some(error)),
+                ActorFailure::OnIdle { actor, error }
+                | ActorFailure::OnStop { actor, error }
+                | ActorFailure::OnIdleThenOnStop { actor, error, .. } => (Some(actor), Some(error)),
+            },
         }
     }
 }
@@ -221,6 +336,14 @@ impl<T: Actor> ActorResult<T> {
         matches!(self, ActorResult::Completed { killed: false, .. })
     }
 
+    /// Returns the failure phase, or `None` if the actor completed successfully.
+    pub fn phase(&self) -> Option<FailurePhase> {
+        match self {
+            ActorResult::Completed { .. } => None,
+            ActorResult::Failed { failure, .. } => Some(failure.phase()),
+        }
+    }
+
     /// Returns `true` if the actor failed to start.
     ///
     /// This indicates that the actor failed during the [`on_start`](crate::Actor::on_start) lifecycle phase,
@@ -229,7 +352,7 @@ impl<T: Actor> ActorResult<T> {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnStart,
+                failure: ActorFailure::OnStart { .. },
                 ..
             }
         )
@@ -245,7 +368,7 @@ impl<T: Actor> ActorResult<T> {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnIdle | FailurePhase::OnIdleThenOnStop,
+                failure: ActorFailure::OnIdle { .. } | ActorFailure::OnIdleThenOnStop { .. },
                 ..
             }
         )
@@ -259,21 +382,25 @@ impl<T: Actor> ActorResult<T> {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnIdleThenOnStop,
+                failure: ActorFailure::OnIdleThenOnStop { .. },
                 ..
             }
         )
     }
 
-    /// Returns `true` if the actor failed during the stop phase.
+    /// Returns `true` if [`on_stop`](crate::Actor::on_stop) failed.
     ///
-    /// This indicates that the actor encountered an error while trying to shut down
-    /// in the [`on_stop`](crate::Actor::on_stop) lifecycle phase.
+    /// This covers both a failure during a normal shutdown
+    /// ([`FailurePhase::OnStop`]) and an `on_stop` failure while cleaning up
+    /// after an `on_idle` error ([`FailurePhase::OnIdleThenOnStop`]) —
+    /// mirroring how [`is_runtime_failed()`](Self::is_runtime_failed) includes
+    /// the composite phase. Use [`is_cleanup_failed()`](Self::is_cleanup_failed)
+    /// to distinguish the composite case.
     pub fn is_stop_failed(&self) -> bool {
         matches!(
             self,
             ActorResult::Failed {
-                phase: FailurePhase::OnStop,
+                failure: ActorFailure::OnStop { .. } | ActorFailure::OnIdleThenOnStop { .. },
                 ..
             }
         )
@@ -311,7 +438,7 @@ impl<T: Actor> ActorResult<T> {
     pub fn actor(&self) -> Option<&T> {
         match self {
             ActorResult::Completed { actor, .. } => Some(actor),
-            ActorResult::Failed { actor, .. } => actor.as_ref(),
+            ActorResult::Failed { failure, .. } => failure.actor(),
         }
     }
 
@@ -342,7 +469,7 @@ impl<T: Actor> ActorResult<T> {
     pub fn into_actor(self) -> Option<T> {
         match self {
             ActorResult::Completed { actor, .. } => Some(actor),
-            ActorResult::Failed { actor, .. } => actor,
+            ActorResult::Failed { failure, .. } => failure.into_actor(),
         }
     }
 
@@ -353,7 +480,7 @@ impl<T: Actor> ActorResult<T> {
     pub fn error(&self) -> Option<&T::Error> {
         match self {
             ActorResult::Completed { .. } => None,
-            ActorResult::Failed { error: cause, .. } => Some(cause),
+            ActorResult::Failed { failure, .. } => Some(failure.error()),
         }
     }
 
@@ -364,7 +491,7 @@ impl<T: Actor> ActorResult<T> {
     pub fn into_error(self) -> Option<T::Error> {
         match self {
             ActorResult::Completed { .. } => None,
-            ActorResult::Failed { error: cause, .. } => Some(cause),
+            ActorResult::Failed { failure, .. } => Some(failure.into_error()),
         }
     }
 
@@ -376,9 +503,7 @@ impl<T: Actor> ActorResult<T> {
     /// remains accessible via [`error()`](Self::error).
     pub fn secondary_error(&self) -> Option<&T::Error> {
         match self {
-            ActorResult::Failed {
-                secondary_error, ..
-            } => secondary_error.as_ref(),
+            ActorResult::Failed { failure, .. } => failure.stop_error(),
             ActorResult::Completed { .. } => None,
         }
     }
@@ -388,9 +513,7 @@ impl<T: Actor> ActorResult<T> {
     /// See [`secondary_error()`](Self::secondary_error) for semantics.
     pub fn into_secondary_error(self) -> Option<T::Error> {
         match self {
-            ActorResult::Failed {
-                secondary_error, ..
-            } => secondary_error,
+            ActorResult::Failed { failure, .. } => failure.into_stop_error(),
             ActorResult::Completed { .. } => None,
         }
     }
@@ -415,8 +538,10 @@ impl<T: Actor> ActorResult<T> {
     /// This transforms the `ActorResult<T>` into a `Result<T, T::Error>`,
     /// which is useful for integrating with Rust's standard error handling patterns.
     ///
-    /// **Note**: This method discards information about whether the actor was killed
-    /// and the failure phase. Use the individual query methods if you need this information.
+    /// **Lossy**: this discards whether the actor was killed and the failure
+    /// phase, and on failure it also drops the recovered actor instance (when
+    /// one exists) and the secondary `on_stop` cleanup error. Use the
+    /// individual query methods if you need any of that information.
     ///
     /// # Example
     /// ```rust,no_run
@@ -430,14 +555,14 @@ impl<T: Actor> ActorResult<T> {
     /// # }
     /// # fn example(result: ActorResult<MyActor>) -> Result<MyActor, anyhow::Error> {
     /// // Convert to standard Result for use with ? operator
-    /// let actor = result.to_result()?;
+    /// let actor = result.into_result()?;
     /// Ok(actor)
     /// # }
     /// ```
-    pub fn to_result(self) -> std::result::Result<T, T::Error> {
+    pub fn into_result(self) -> std::result::Result<T, T::Error> {
         match self {
             ActorResult::Completed { actor, .. } => Ok(actor),
-            ActorResult::Failed { error: cause, .. } => Err(cause),
+            ActorResult::Failed { failure, .. } => Err(failure.into_error()),
         }
     }
 }

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -235,6 +235,11 @@ impl<T: Actor> ActorFailure<T> {
 ///             let (new_ref, new_handle) = restart_actor().await?;
 ///         }
 ///     }
+///     result if result.is_stop_failed() => {
+///         // Stopped (or killed), but on_stop cleanup failed - resources may
+///         // not have been released (flushes, connections, files)
+///         eprintln!("Cleanup failed: {}", result.error().unwrap());
+///     }
 ///     result if result.was_killed() => {
 ///         // Actor was forcefully terminated
 ///         println!("Actor was killed - no restart needed");

--- a/src/dead_letter.rs
+++ b/src/dead_letter.rs
@@ -8,10 +8,15 @@
 //!
 //! # Background
 //!
-//! Dead letters occur when a message cannot be delivered to an actor, such as:
+//! Dead letters occur when a message cannot be delivered to an actor — or,
+//! for `ask`-family operations, when its **reply** is not observed — such as:
 //! - The actor's mailbox channel has closed (actor stopped)
-//! - A send or ask operation times out
+//! - A send operation times out before admission, or an ask round-trip times
+//!   out before the reply arrives (the message itself may have been delivered
+//!   and processed; see [`DeadLetterReason::Timeout`])
 //! - The reply channel was dropped before responding
+//! - The message was accepted but the actor terminated before processing it
+//!   (see [`DeadLetterReason::DiscardedAtShutdown`])
 //!
 //! # Observability
 //!
@@ -108,10 +113,20 @@ pub enum DeadLetterReason {
 
     /// A send or ask operation exceeded its timeout.
     ///
-    /// When using [`ActorRef::tell_with_timeout`](crate::ActorRef::tell_with_timeout) or
-    /// [`ActorRef::ask_with_timeout`](crate::ActorRef::ask_with_timeout),
-    /// if the message cannot be delivered within the specified duration,
-    /// it becomes a dead letter.
+    /// Recorded by every timeout-carrying API: `tell_with_timeout`,
+    /// `ask_with_timeout`, `tell_priority`, `ask_priority`, and the
+    /// `blocking_*` variants.
+    ///
+    /// **What this means differs by family.** For `tell` operations the
+    /// deadline covers mailbox admission only, so a record means the message
+    /// was never delivered. For `ask` operations the deadline covers the whole
+    /// round-trip (admission + handler execution + reply), so a record means
+    /// **no reply was observed in time** — the message may well have been
+    /// delivered and fully processed, with any side effects applied, and only
+    /// the reply was late. Do not treat an ask-timeout dead letter (or
+    /// [`dead_letter_count`](crate::dead_letter_count)) as proof the handler
+    /// did not run — in particular, do not blindly retry non-idempotent
+    /// operations on it.
     Timeout,
 
     /// The reply channel was dropped before a response could be sent.

--- a/src/dead_letter.rs
+++ b/src/dead_letter.rs
@@ -146,7 +146,10 @@ impl std::fmt::Display for DeadLetterReason {
 ///
 /// * `identity` - The identity of the actor that failed to receive the message
 /// * `reason` - Why the message became a dead letter
-/// * `operation` - The operation that failed ("tell", "ask", "blocking_tell", etc.)
+/// * `operation` - The logical operation that failed ("tell", "ask",
+///   "tell_priority", "ask_priority"). Blocking variants record the same
+///   label as their async counterparts so the same call site aggregates to
+///   one operation regardless of which execution path it took.
 ///
 /// # Type Parameters
 ///
@@ -158,11 +161,7 @@ impl std::fmt::Display for DeadLetterReason {
 /// The `#[cold]` attribute hints to the compiler that this function is rarely
 /// called, allowing better optimization of the hot path (successful message delivery).
 #[cold]
-pub(crate) fn record<M: 'static>(
-    identity: Identity,
-    reason: DeadLetterReason,
-    operation: &'static str,
-) {
+pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation: &'static str) {
     #[cfg(any(test, feature = "test-utils"))]
     DEAD_LETTER_COUNT.fetch_add(1, Ordering::Relaxed);
 
@@ -185,10 +184,16 @@ pub fn dead_letter_count() -> u64 {
     DEAD_LETTER_COUNT.load(Ordering::Relaxed)
 }
 
-/// Resets the dead letter counter.
+/// Atomically resets the dead letter counter and returns the value it held.
+///
+/// The read-and-reset is a single atomic `swap`, so no increment can be lost
+/// *between* reading and resetting. Dead letters recorded concurrently with
+/// the call still race with it (they land in either the returned value or the
+/// fresh count) — serialize generators against this call when exact
+/// accounting matters.
 ///
 /// This function is only available when the `test-utils` feature is enabled.
 #[cfg(any(test, feature = "test-utils"))]
-pub fn reset_dead_letter_count() {
-    DEAD_LETTER_COUNT.store(0, Ordering::Relaxed);
+pub fn reset_dead_letter_count() -> u64 {
+    DEAD_LETTER_COUNT.swap(0, Ordering::Relaxed)
 }

--- a/src/dead_letter.rs
+++ b/src/dead_letter.rs
@@ -119,6 +119,17 @@ pub enum DeadLetterReason {
     /// When using [`ActorRef::ask`](crate::ActorRef::ask), the handler may fail or the message processing
     /// may be interrupted before sending a reply.
     ReplyDropped,
+
+    /// The message was accepted into the actor's mailbox but the actor
+    /// terminated before processing it.
+    ///
+    /// This covers messages still queued when the actor was killed, and
+    /// messages admitted after a graceful stop signal (which the actor does
+    /// not process). The sender observed a successful send (`Ok`), so this
+    /// receiver-side record is the only trace of the loss. Recording is
+    /// best-effort: a send racing the final shutdown drain can still slip
+    /// through unrecorded.
+    DiscardedAtShutdown,
 }
 
 impl std::fmt::Display for DeadLetterReason {
@@ -127,6 +138,7 @@ impl std::fmt::Display for DeadLetterReason {
             DeadLetterReason::ActorStopped => write!(f, "actor stopped"),
             DeadLetterReason::Timeout => write!(f, "timeout"),
             DeadLetterReason::ReplyDropped => write!(f, "reply dropped"),
+            DeadLetterReason::DiscardedAtShutdown => write!(f, "discarded at shutdown"),
         }
     }
 }
@@ -162,6 +174,20 @@ impl std::fmt::Display for DeadLetterReason {
 /// called, allowing better optimization of the hot path (successful message delivery).
 #[cold]
 pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation: &'static str) {
+    record_erased(identity, reason, operation, std::any::type_name::<M>());
+}
+
+/// Type-erased variant of [`record`] for call sites that no longer have the
+/// concrete message type — e.g. the shutdown drain, which only holds a
+/// `Box<dyn PayloadHandler>` and obtains the type name through
+/// `PayloadHandler::message_type_name`.
+#[cold]
+pub(crate) fn record_erased(
+    identity: Identity,
+    reason: DeadLetterReason,
+    operation: &'static str,
+    message_type: &'static str,
+) {
     #[cfg(any(test, feature = "test-utils"))]
     DEAD_LETTER_COUNT.fetch_add(1, Ordering::Relaxed);
 
@@ -169,7 +195,7 @@ pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation:
     tracing::warn!(
         actor.id = identity.id,
         actor.type_name = identity.name(),
-        message.type_name = std::any::type_name::<M>(),
+        message.type_name = message_type,
         dead_letter.reason = %reason,
         dead_letter.operation = operation,
         "Dead letter: message could not be delivered"

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -73,11 +73,33 @@ impl AskEdge {
     /// owners call this. Recovers a poisoned lock the same way insertion does —
     /// skipping removal on poison would leak the edge permanently and turn
     /// every later ask through these actors into a false-positive panic.
+    ///
+    /// Claiming the flag and removing the edge happen together under the graph
+    /// lock. Claiming first (flag swap outside the lock) would let the *other*
+    /// owner observe "already removed" and proceed — e.g. the callee's runtime
+    /// loop dropping its [`AskEdgeToken`] after the reply and moving on to the
+    /// next message — while the edge physically lingers in the graph until the
+    /// claiming thread wins the lock. A registration serialized into that
+    /// window (the callee's next handler asking the original caller) would DFS
+    /// over the stale edge and panic on a phantom cycle in a healthy system.
+    /// Under the lock, whichever owner runs first completes the physical
+    /// removal before returning, so the graph is consistent at every point
+    /// where a registration can observe it.
     fn remove_once(&self) {
-        if self.removed.swap(true, Ordering::AcqRel) {
+        // Relaxed pre-check so the second owner's no-op stays lock-free (every
+        // completed ask calls remove_once twice): the flag is only ever set
+        // while holding the graph lock and the physical removal completes
+        // before that lock is released, so observing `true` here means no
+        // registration can see the stale edge.
+        if self.removed.load(Ordering::Relaxed) {
             return;
         }
         let mut graph = wait_for_graph().lock().unwrap_or_else(|e| e.into_inner());
+        // Relaxed: the graph mutex provides all the ordering needed; the flag
+        // is atomic only for the pre-check above and so `AskEdge` is `Sync`.
+        if self.removed.swap(true, Ordering::Relaxed) {
+            return;
+        }
         remove_edge(&mut graph, self.caller, self.callee_id);
     }
 }

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -8,14 +8,33 @@
 //! `#[cfg(...)]` and nothing here costs anything in normal builds.
 //!
 //! Every in-flight `ask`/`ask_priority` registers a `caller -> callee` edge in a
-//! process-global wait-for graph via [`register_ask_edge`] and holds a
-//! [`WaitForGuard`] until the reply arrives (or the future is dropped). If a new
-//! edge would close a cycle, registration panics with the cycle path — the
-//! documented behavior of this feature.
+//! process-global wait-for graph via [`register_ask_edge`]. If a new edge would
+//! close a cycle, registration panics with the cycle path — the documented
+//! behavior of this feature.
+//!
+//! # Edge removal — two cooperating sides
+//!
+//! An edge `A -> B` means "A's handler cannot make progress until B replies".
+//! That statement stops being true the moment B *sends* the reply, not when A's
+//! task is next polled. Removing the edge only from the caller side (when the
+//! ask future resumes and drops its guard) leaves a stale-edge window between
+//! reply-send and caller-resume; if B's next handler asks A inside that window,
+//! the stale edge closes a phantom cycle and the detector panics on a perfectly
+//! healthy system. To close the window, every edge is removed by whichever of
+//! two owners fires first (idempotent via an atomic flag on the shared
+//! [`AskEdge`]):
+//!
+//! - [`AskEdgeToken`], carried inside the ask envelope: dropped by the callee's
+//!   runtime right after the reply was sent (or when the envelope itself is
+//!   dropped unprocessed, which also unblocks the caller).
+//! - [`WaitForGuard`], held by the caller's ask future: backstop for the paths
+//!   the token cannot see — timeout, caller-side cancellation, or a send that
+//!   never reached the mailbox.
 
 use crate::Identity;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 
 tokio::task_local! {
     /// Identity of the actor whose handler is currently running, used as the
@@ -39,19 +58,66 @@ fn wait_for_graph() -> &'static Mutex<HashMap<u64, Vec<Identity>>> {
     WAIT_FOR.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// RAII guard that removes the single wait-for edge it inserted when the
-/// corresponding `ask` future completes (reply received, timed out, or
-/// cancelled).
-pub(crate) struct WaitForGuard {
+/// One registered wait-for edge, shared between the caller-side
+/// [`WaitForGuard`] and the callee-side [`AskEdgeToken`]. The `removed` flag
+/// makes removal idempotent so the two owners cannot double-remove an edge
+/// that a concurrent identical ask re-inserted (the graph is a multiset).
+pub(crate) struct AskEdge {
     caller: u64,
     callee_id: u64,
+    removed: AtomicBool,
+}
+
+impl AskEdge {
+    /// Removes the edge from the global graph exactly once, no matter how many
+    /// owners call this. Recovers a poisoned lock the same way insertion does —
+    /// skipping removal on poison would leak the edge permanently and turn
+    /// every later ask through these actors into a false-positive panic.
+    fn remove_once(&self) {
+        if self.removed.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let mut graph = wait_for_graph().lock().unwrap_or_else(|e| e.into_inner());
+        remove_edge(&mut graph, self.caller, self.callee_id);
+    }
+}
+
+/// Caller-side RAII guard for a wait-for edge. Removes the edge when the `ask`
+/// future completes or is dropped (reply received, timed out, or cancelled),
+/// unless the callee-side [`AskEdgeToken`] already removed it at reply time.
+pub(crate) struct WaitForGuard {
+    edge: Arc<AskEdge>,
+}
+
+impl WaitForGuard {
+    /// Returns the callee-side token to embed in the ask envelope. The actor
+    /// runtime drops it right after the reply is sent, removing the edge at
+    /// the earliest moment the wait is actually over.
+    pub(crate) fn token(&self) -> AskEdgeToken {
+        AskEdgeToken {
+            edge: self.edge.clone(),
+        }
+    }
 }
 
 impl Drop for WaitForGuard {
     fn drop(&mut self) {
-        if let Ok(mut graph) = wait_for_graph().lock() {
-            remove_edge(&mut graph, self.caller, self.callee_id);
-        }
+        self.edge.remove_once();
+    }
+}
+
+/// Callee-side handle to a wait-for edge, carried inside the ask envelope.
+/// Dropping it removes the edge — the runtime lets it fall out of scope as
+/// soon as the reply has been sent. If the envelope is dropped unprocessed
+/// (actor killed before reaching it), the drop is equally correct: the reply
+/// channel closes at the same time, so the caller is no longer waiting.
+pub(crate) struct AskEdgeToken {
+    edge: Arc<AskEdge>,
+}
+
+impl Drop for AskEdgeToken {
+    fn drop(&mut self) {
+        self.edge.remove_once();
     }
 }
 
@@ -78,10 +144,17 @@ fn remove_edge(graph: &mut HashMap<u64, Vec<Identity>>, caller: u64, callee_id: 
 /// Panics (the documented deadlock-detection behavior) if adding the edge would
 /// close a cycle. Returns `None` when called outside an actor context — there is
 /// no current actor to attribute the wait to, so no cycle can form through it.
+#[must_use = "dropping the guard immediately removes the wait-for edge, disabling detection for this ask"]
 pub(crate) fn register_ask_edge(callee: Identity, operation: &str) -> Option<WaitForGuard> {
     let caller = CURRENT_ACTOR.try_with(|id| *id).ok()?;
     let mut graph = wait_for_graph().lock().unwrap_or_else(|e| e.into_inner());
-    if caller.id == callee.id || has_path(&graph, callee.id, caller.id) {
+    // The `contains_key` pre-check skips the DFS (and its two allocations) in
+    // the common case where the callee is not itself waiting on anyone: with
+    // no outgoing edge from the callee and `caller != callee`, no path back to
+    // the caller can exist.
+    if caller.id == callee.id
+        || (graph.contains_key(&callee.id) && has_path(&graph, callee.id, caller.id))
+    {
         let cycle = format_cycle_path(&graph, caller, callee);
         drop(graph);
         panic!(
@@ -92,8 +165,11 @@ pub(crate) fn register_ask_edge(callee: Identity, operation: &str) -> Option<Wai
     }
     graph.entry(caller.id).or_default().push(callee);
     Some(WaitForGuard {
-        caller: caller.id,
-        callee_id: callee.id,
+        edge: Arc::new(AskEdge {
+            caller: caller.id,
+            callee_id: callee.id,
+            removed: AtomicBool::new(false),
+        }),
     })
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,11 +35,26 @@ pub enum Error {
     /// failure — the actor is alive and the channel will drain as the runtime makes
     /// progress. [`Error::is_retryable`] returns `true` for this variant.
     ///
+    /// **Retry only from outside the target actor.** The saturated buffer is
+    /// drained by the actor's own runtime loop, which runs only *between* that
+    /// actor's handler invocations (and not at all until `on_start` returns).
+    /// A retry loop inside the actor's own `on_start` or message handler
+    /// therefore spins forever on a buffer that can never drain — and because
+    /// the loop never returns, the actor cannot even be `kill()`ed. From
+    /// inside the actor, treat this error as terminal for the current attempt:
+    /// spawn with a larger
+    /// [`SpawnOptions::with_idle_capacity`](crate::SpawnOptions::with_idle_capacity),
+    /// merge sources into one stream, or defer the work to a later handler
+    /// invocation.
+    ///
     /// Currently emitted only by
     /// [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle) when the bounded
-    /// subscribe buffer (capacity
-    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY))
-    /// is saturated.
+    /// subscribe buffer (default capacity
+    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`](crate::IDLE_SUBSCRIBE_CHANNEL_CAPACITY),
+    /// configurable per actor via
+    /// [`SpawnOptions::with_idle_capacity`](crate::SpawnOptions::with_idle_capacity))
+    /// is saturated; the rejected stream is handed back via
+    /// [`IdleSubscribeError`](crate::IdleSubscribeError) so a retry can reuse it.
     ChannelFull {
         /// ID of the actor whose channel was full
         identity: Identity,
@@ -63,7 +78,14 @@ pub enum Error {
         identity: Identity,
         /// The duration after which the request timed out
         timeout: Duration,
-        /// Type of operation that timed out (e.g., "send", "ask")
+        /// The operation family whose deadline was missed. One of `"tell"`,
+        /// `"ask"`, `"tell_priority"`, `"ask_priority"`, `"blocking_tell"`,
+        /// `"blocking_tell_priority"`, `"blocking_ask"`, or
+        /// `"blocking_ask_priority"`: [`tell_with_timeout`](crate::ActorRef::tell_with_timeout)
+        /// reports `"tell"` and [`ask_with_timeout`](crate::ActorRef::ask_with_timeout)
+        /// reports `"ask"` (the async `tell`/`ask` themselves carry no
+        /// deadline); the `*_priority` and `blocking_*` methods report their
+        /// own names, regardless of which execution path served them.
         operation: &'static str,
     },
     /// Error when downcasting a reply to the expected type
@@ -305,10 +327,14 @@ impl Error {
                 "Consider using `ActorWeak` for long-lived references",
             ],
             Error::ChannelFull { .. } => &[
-                "Transient failure - retry after a short delay or batch your sends",
-                "Bounded channels drain as the actor processes work; the actor is alive",
-                "For subscribe_idle specifically, batch subscriptions across handler invocations \
-                 or raise IDLE_SUBSCRIBE_CHANNEL_CAPACITY if you regularly fan out > 32 streams",
+                "Transient failure - the actor is alive and its runtime loop drains the buffer",
+                "Retry only from OUTSIDE the target actor: the buffer drains between handler \
+                 invocations, so a retry loop inside the actor's own on_start/handler spins \
+                 forever and cannot be kill()ed",
+                "For subscribe_idle specifically, spawn with SpawnOptions::with_idle_capacity(n) \
+                 if you regularly fan out more than 32 streams, merge sources into one stream \
+                 (futures::stream::select_all), or batch subscriptions across handler invocations",
+                "The rejected stream is returned in IdleSubscribeError - reuse it for the retry",
             ],
             Error::Receive { .. } => &[
                 "The actor dropped the reply channel before responding",

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,8 +23,11 @@ pub enum Error {
     Send {
         /// ID of the actor that failed to receive the message
         identity: Identity,
-        /// Additional context about the error
-        details: String,
+        /// Additional context about the error.
+        ///
+        /// Every emitter uses a fixed message, so this is `&'static str`
+        /// rather than `String` (no allocation on this failure path).
+        details: &'static str,
     },
     /// Error when a bounded channel is currently at capacity.
     ///
@@ -48,8 +51,11 @@ pub enum Error {
     Receive {
         /// ID of the actor that failed to send a response
         identity: Identity,
-        /// Additional context about the error
-        details: String,
+        /// Additional context about the error.
+        ///
+        /// Every emitter uses a fixed message, so this is `&'static str`
+        /// rather than `String` (no allocation on this failure path).
+        details: &'static str,
     },
     /// Error when a request times out
     Timeout {
@@ -236,9 +242,11 @@ impl Error {
     /// | `Send` | ✗ No | Actor stopped; channel permanently closed |
     /// | `Receive` | ✗ No | Reply channel dropped; cannot recover |
     /// | `Downcast` | ✗ No | Type mismatch; programming error |
-    /// | `Runtime` | ✗ No | Actor lifecycle failure |
+    /// | `Runtime` | ✗ No | Failed to spawn/build the temporary blocking runtime |
     /// | `MailboxCapacity` | ✗ No | Configuration error |
     /// | `Join` | ✗ No | Task panic or cancellation |
+    /// | `PriorityChannelNotEnabled` | ✗ No | Configuration error |
+    /// | `IdleChannelNotEnabled` | ✗ No | Configuration error |
     ///
     /// # Example
     ///

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -88,8 +88,13 @@ pub trait TellHandler<M: Send + 'static>: Send + Sync {
     ///
     /// # Panics
     ///
-    /// Panics when called from inside a `LocalSet` running on a multi-thread
-    /// runtime (see [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell)).
+    /// Panics only when the mailbox is full (the `try_send` hot path never
+    /// blocks): from inside a `LocalSet` running on a multi-thread runtime,
+    /// or from an async context that cannot block — a task on a
+    /// `current_thread` runtime or a thread driving a `current_thread`
+    /// runtime's `block_on` (see
+    /// [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell) for both
+    /// conditions).
     fn blocking_tell(&self, msg: M, timeout: Option<Duration>) -> Result<()>;
 
     /// Clone this handler into a new boxed instance.
@@ -144,7 +149,11 @@ pub trait AskHandler<M: Send + 'static, R: Send + 'static>: Send + Sync {
     /// # Panics
     ///
     /// Panics when called from inside a `LocalSet` running on a multi-thread
-    /// runtime (see [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask)).
+    /// runtime, and when called from an async context that cannot block — a
+    /// task on a `current_thread` runtime or a thread driving a
+    /// `current_thread` runtime's `block_on` (see
+    /// [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask) for both
+    /// conditions).
     fn blocking_ask(&self, msg: M, timeout: Option<Duration>) -> Result<R>;
 
     /// Clone this handler into a new boxed instance.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -80,11 +80,16 @@ pub trait TellHandler<M: Send + 'static>: Send + Sync {
 
     /// Blocking version of tell.
     ///
-    /// # Timeout Behavior
+    /// `timeout: None` blocks indefinitely until the message is admitted;
+    /// `timeout: Some(duration)` guarantees bounded waiting. The execution
+    /// mechanism (and its overhead) depends on the calling context — see
+    /// [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell) for the
+    /// authoritative "Execution paths" breakdown.
     ///
-    /// - **`timeout: None`**: Uses Tokio's `blocking_send` directly. Most efficient but blocks indefinitely.
-    /// - **`timeout: Some(duration)`**: Spawns a separate thread with a temporary runtime.
-    ///   Has overhead (~50-200μs for thread + ~1-10μs for runtime) but guarantees bounded waiting.
+    /// # Panics
+    ///
+    /// Panics when called from inside a `LocalSet` running on a multi-thread
+    /// runtime (see [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell)).
     fn blocking_tell(&self, msg: M, timeout: Option<Duration>) -> Result<()>;
 
     /// Clone this handler into a new boxed instance.
@@ -130,11 +135,16 @@ pub trait AskHandler<M: Send + 'static, R: Send + 'static>: Send + Sync {
 
     /// Blocking version of ask.
     ///
-    /// # Timeout Behavior
+    /// `timeout: None` blocks indefinitely until the reply arrives;
+    /// `timeout: Some(duration)` guarantees bounded waiting. The execution
+    /// mechanism (and its overhead) depends on the calling context — see
+    /// [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask) for the
+    /// authoritative "Execution paths" breakdown.
     ///
-    /// - **`timeout: None`**: Uses Tokio's `blocking_send`/`blocking_recv` directly. Most efficient but blocks indefinitely.
-    /// - **`timeout: Some(duration)`**: Spawns a separate thread with a temporary runtime.
-    ///   Has overhead (~50-200μs for thread + ~1-10μs for runtime) but guarantees bounded waiting.
+    /// # Panics
+    ///
+    /// Panics when called from inside a `LocalSet` running on a multi-thread
+    /// runtime (see [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask)).
     fn blocking_ask(&self, msg: M, timeout: Option<Duration>) -> Result<R>;
 
     /// Clone this handler into a new boxed instance.
@@ -246,13 +256,18 @@ impl<M: Send + 'static, R: Send + 'static> Clone for Box<dyn AskHandler<M, R>> {
     }
 }
 
-impl<M: Send + 'static> fmt::Debug for Box<dyn TellHandler<M>> {
+// Debug is implemented on the trait objects themselves (not on `Box<dyn ...>`)
+// so that `&dyn`, `Arc<dyn>`, and any other pointer type get Debug too, and
+// `Box<dyn ...>` picks it up through std's blanket `impl Debug for Box<T>`.
+// A manual Box impl would also collide with that blanket impl the moment a
+// dyn-level impl is added — this is the future-proof of the two shapes.
+impl<M: Send + 'static> fmt::Debug for dyn TellHandler<M> + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
 }
 
-impl<M: Send + 'static, R: Send + 'static> fmt::Debug for Box<dyn AskHandler<M, R>> {
+impl<M: Send + 'static, R: Send + 'static> fmt::Debug for dyn AskHandler<M, R> + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
@@ -271,13 +286,13 @@ impl<M: Send + 'static, R: Send + 'static> Clone for Box<dyn WeakAskHandler<M, R
     }
 }
 
-impl<M: Send + 'static> fmt::Debug for Box<dyn WeakTellHandler<M>> {
+impl<M: Send + 'static> fmt::Debug for dyn WeakTellHandler<M> + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
 }
 
-impl<M: Send + 'static, R: Send + 'static> fmt::Debug for Box<dyn WeakAskHandler<M, R>> {
+impl<M: Send + 'static, R: Send + 'static> fmt::Debug for dyn WeakAskHandler<M, R> + '_ {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.debug_fmt(f)
     }
@@ -289,7 +304,7 @@ impl<M: Send + 'static, R: Send + 'static> fmt::Debug for Box<dyn WeakAskHandler
 
 impl<T, M> TellHandler<M> for ActorRef<T>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn tell(&self, msg: M) -> BoxFuture<'_, Result<()>> {
@@ -326,7 +341,7 @@ where
 
 impl<T, M> AskHandler<M, <T as Message<M>>::Reply> for ActorRef<T>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {
@@ -372,7 +387,7 @@ where
 
 impl<T, M> WeakTellHandler<M> for ActorWeak<T>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn upgrade(&self) -> Option<Box<dyn TellHandler<M>>> {
@@ -397,7 +412,7 @@ where
 
 impl<T, M> WeakAskHandler<M, <T as Message<M>>::Reply> for ActorWeak<T>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {
@@ -431,7 +446,7 @@ where
 // From ActorRef (ownership transfer) to Box<dyn TellHandler<M>>
 impl<T, M> From<ActorRef<T>> for Box<dyn TellHandler<M>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn from(actor_ref: ActorRef<T>) -> Self {
@@ -442,7 +457,7 @@ where
 // From &ActorRef (clone) to Box<dyn TellHandler<M>>
 impl<T, M> From<&ActorRef<T>> for Box<dyn TellHandler<M>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn from(actor_ref: &ActorRef<T>) -> Self {
@@ -453,7 +468,7 @@ where
 // From ActorRef (ownership transfer) to Box<dyn AskHandler<M, R>>
 impl<T, M> From<ActorRef<T>> for Box<dyn AskHandler<M, <T as Message<M>>::Reply>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {
@@ -465,7 +480,7 @@ where
 // From &ActorRef (clone) to Box<dyn AskHandler<M, R>>
 impl<T, M> From<&ActorRef<T>> for Box<dyn AskHandler<M, <T as Message<M>>::Reply>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {
@@ -479,7 +494,7 @@ where
 // From ActorWeak (ownership transfer) to Box<dyn WeakTellHandler<M>>
 impl<T, M> From<ActorWeak<T>> for Box<dyn WeakTellHandler<M>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn from(actor_weak: ActorWeak<T>) -> Self {
@@ -490,7 +505,7 @@ where
 // From &ActorWeak (clone) to Box<dyn WeakTellHandler<M>>
 impl<T, M> From<&ActorWeak<T>> for Box<dyn WeakTellHandler<M>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
 {
     fn from(actor_weak: &ActorWeak<T>) -> Self {
@@ -501,7 +516,7 @@ where
 // From ActorWeak (ownership transfer) to Box<dyn WeakAskHandler<M, R>>
 impl<T, M> From<ActorWeak<T>> for Box<dyn WeakAskHandler<M, <T as Message<M>>::Reply>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {
@@ -513,7 +528,7 @@ where
 // From &ActorWeak (clone) to Box<dyn WeakAskHandler<M, R>>
 impl<T, M> From<&ActorWeak<T>> for Box<dyn WeakAskHandler<M, <T as Message<M>>::Reply>>
 where
-    T: Actor + Message<M> + 'static,
+    T: Actor + Message<M>,
     M: Send + 'static,
     <T as Message<M>>::Reply: Send + 'static,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ mod metrics;
 pub use metrics::MetricsSnapshot;
 
 mod actor_ref;
-pub use actor_ref::{ActorRef, ActorWeak};
+pub use actor_ref::{ActorRef, ActorWeak, IdleSubscribeError};
 
 mod actor_result;
 pub use actor_result::{ActorFailure, ActorResult, FailurePhase};
@@ -533,7 +533,7 @@ pub const DEFAULT_MAILBOX_CAPACITY: usize = 32;
 /// [`SpawnOptions::with_priority`] for the rationale.
 pub(crate) const PRIORITY_CHANNEL_CAPACITY: usize = 1;
 
-/// Capacity of the idle-subscribe channel used by
+/// Default capacity of the idle-subscribe channel used by
 /// [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle).
 ///
 /// Subscriptions are rare events (typically a handful per actor, established
@@ -547,8 +547,12 @@ pub(crate) const PRIORITY_CHANNEL_CAPACITY: usize = 1;
 ///
 /// `subscribe_idle` uses `try_send` and returns [`Error::ChannelFull`] when the
 /// buffer is full, so the failure mode is a loud, actionable error rather
-/// than a silent hang — callers can batch or raise this constant if it is
-/// ever hit in practice.
+/// than a silent hang. Actors that legitimately need more (e.g. one
+/// subscription per item of a large config list, all registered in
+/// `on_start`) can raise the per-actor capacity with
+/// [`SpawnOptions::with_idle_capacity`], merge sources into one stream
+/// before subscribing (e.g. [`futures::stream::select_all()`]), or batch
+/// subscriptions across separate handler invocations.
 pub const IDLE_SUBSCRIBE_CHANNEL_CAPACITY: usize = 32;
 
 /// Sets the global default buffer size for actor mailboxes.
@@ -618,6 +622,10 @@ pub struct SpawnOptions {
     /// `select!` loop, which the majority of actors (those that never use `on_idle`) would
     /// otherwise pay on every message.
     pub(crate) idle_enabled: bool,
+    /// Capacity of the idle-subscribe channel when it is enabled. Defaults to
+    /// [`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`]. Set via
+    /// [`SpawnOptions::with_idle_capacity`].
+    pub(crate) idle_capacity: usize,
 }
 
 impl SpawnOptions {
@@ -632,6 +640,7 @@ impl SpawnOptions {
             mailbox_capacity: capacity,
             priority_enabled: false,
             idle_enabled: false,
+            idle_capacity: IDLE_SUBSCRIBE_CHANNEL_CAPACITY,
         }
     }
 
@@ -658,6 +667,16 @@ impl SpawnOptions {
     /// channel, so admission resumes immediately at the next select! iteration. Callers
     /// must always pass a [`Duration`](std::time::Duration) so a wedged actor can never
     /// block a sender indefinitely.
+    ///
+    /// # Runtime requirement: time driver
+    ///
+    /// The graceful-stop path of a priority-enabled actor drains the priority
+    /// channel with a short [`tokio::time`] quiet window, so the hosting
+    /// runtime must be built with the time driver enabled (`enable_time()` or
+    /// `enable_all()`; `#[tokio::main]`/`#[tokio::test]` enable it by
+    /// default). On a runtime without timers, stopping such an actor panics
+    /// inside the actor task ("A Tokio 1.x context was found, but timers are
+    /// disabled") instead of completing `on_stop`.
     pub fn with_priority(mut self) -> Self {
         self.priority_enabled = true;
         self
@@ -676,6 +695,28 @@ impl SpawnOptions {
     /// should pay. Enable it when (and only when) the actor subscribes idle streams.
     pub fn with_idle(mut self) -> Self {
         self.idle_enabled = true;
+        self
+    }
+
+    /// Enables the idle-event channel with a custom subscribe-buffer capacity
+    /// (implies [`with_idle`](Self::with_idle)).
+    ///
+    /// The buffer must absorb every subscription made before the runtime
+    /// enters its select! loop — in particular all `subscribe_idle` calls
+    /// issued inside `on_start`, which are only drained after `on_start`
+    /// returns. Raise the capacity above the default
+    /// ([`IDLE_SUBSCRIBE_CHANNEL_CAPACITY`]) when an actor legitimately
+    /// fans out more subscriptions than that in one burst; alternatives are
+    /// merging sources into a single stream before subscribing or batching
+    /// subscriptions across separate handler invocations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n == 0`.
+    pub fn with_idle_capacity(mut self, n: usize) -> Self {
+        assert!(n > 0, "Idle-subscribe capacity must be greater than 0");
+        self.idle_enabled = true;
+        self.idle_capacity = n;
         self
     }
 }
@@ -761,7 +802,7 @@ pub fn spawn_with_options<T: Actor>(
     };
 
     let (idle_subscribe_tx, idle_subscribe_rx) = if opts.idle_enabled {
-        let (tx, rx) = mpsc::channel(IDLE_SUBSCRIBE_CHANNEL_CAPACITY);
+        let (tx, rx) = mpsc::channel(opts.idle_capacity);
         (Some(tx), Some(rx))
     } else {
         (None, None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,7 @@ mod actor_ref;
 pub use actor_ref::{ActorRef, ActorWeak};
 
 mod actor_result;
-pub use actor_result::{ActorResult, FailurePhase};
+pub use actor_result::{ActorFailure, ActorResult, FailurePhase};
 
 mod actor;
 pub use actor::{Actor, Message};
@@ -307,6 +307,16 @@ pub use actor_control::{ActorControl, WeakActorControl};
 mod deadlock;
 #[cfg(feature = "deadlock-detection")]
 pub(crate) use deadlock::{register_ask_edge, CURRENT_ACTOR};
+
+/// Slot type for the deadlock-detection token carried by ask envelopes (see
+/// [`deadlock::AskEdgeToken`]). Defined as `()` when the feature is off so
+/// envelope construction and destructuring read identically in both builds —
+/// `Default::default()` produces the empty slot either way.
+#[cfg(feature = "deadlock-detection")]
+pub(crate) type AskEdgeSlot = Option<deadlock::AskEdgeToken>;
+/// Feature-off stand-in for the deadlock-detection envelope slot.
+#[cfg(not(feature = "deadlock-detection"))]
+pub(crate) type AskEdgeSlot = ();
 
 use futures::FutureExt;
 // Re-export derive macros for convenient access
@@ -342,6 +352,19 @@ use std::{future::Future, sync::atomic::AtomicU64, sync::OnceLock};
 
 use tokio::sync::{mpsc, oneshot};
 
+/// Unique identifier of a spawned actor: a process-wide ID plus the actor's
+/// type name.
+///
+/// # Uniqueness
+///
+/// The `id` of every Identity handed out by the framework comes from a single
+/// process-global counter, so framework-issued identities never collide and
+/// internal subsystems (e.g. the `deadlock-detection` wait-for graph) key on
+/// `id` alone. [`Identity::new`] exists for constructing identities in tests
+/// and in user implementations of [`ActorControl`] — values built with it
+/// carry **no uniqueness guarantee** and can collide (`Eq`/`Hash`) with real
+/// actors; do not mix hand-built identities into maps keyed by framework
+/// identities.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Identity {
     /// Unique ID of the actor
@@ -352,6 +375,9 @@ pub struct Identity {
 
 impl Identity {
     /// Creates a new `Identity` with the given ID and type name.
+    ///
+    /// Intended for tests and custom [`ActorControl`] implementations. See the
+    /// type-level docs: identities built here carry no uniqueness guarantee.
     pub fn new(id: u64, type_name: &'static str) -> Self {
         Identity { id, type_name }
     }
@@ -400,7 +426,7 @@ pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a
 
 impl<A, T> PayloadHandler<A> for T
 where
-    A: Actor + Message<T> + 'static,
+    A: Actor + Message<T>,
     T: Send + 'static,
 {
     fn handle_message(
@@ -417,24 +443,19 @@ where
                 // the handler finished (`ask_with_timeout` elapsed, the caller's
                 // future was cancelled, a hedged request lost the race, ...). That
                 // is a normal, caller-driven outcome — not an actor fault — and the
-                // caller side already records a dead letter. So both arms log at
+                // caller side already records a dead letter. So this logs at
                 // `debug`, never `error`, to keep routine timeouts/cancellations
-                // out of error-level monitoring.
-                let send_result = channel.send(Box::new(result));
-                #[cfg(feature = "tracing")]
-                match send_result {
-                    Ok(_) => tracing::debug!(
-                        actor = %actor_ref.identity(),
-                        "Reply sent successfully"
-                    ),
-                    Err(_) => tracing::debug!(
+                // out of error-level monitoring. The success arm is deliberately
+                // silent: every delivered reply paying a tracing event would
+                // contradict the hot-path zero-overhead goal and carries no
+                // diagnostic value.
+                if channel.send(Box::new(result)).is_err() {
+                    tracing::debug!(
                         actor = %actor_ref.identity(),
                         message_type = %std::any::type_name::<T>(),
                         "Reply not delivered - receiver no longer waiting"
-                    ),
+                    );
                 }
-                #[cfg(not(feature = "tracing"))]
-                let _ = send_result;
             } else {
                 <A as Message<T>>::on_tell_result(&result, &actor_ref);
             }
@@ -450,7 +471,7 @@ where
 /// is handled through a separate dedicated channel.
 pub(crate) enum MailboxMessage<T>
 where
-    T: Actor + 'static,
+    T: Actor,
 {
     /// A user-defined message to be processed by the actor.
     Envelope {
@@ -460,6 +481,10 @@ where
         reply_channel: Option<oneshot::Sender<Box<dyn std::any::Any + Send>>>,
         /// The actor reference for potential self-messaging or context.
         actor_ref: ActorRef<T>,
+        /// Deadlock-detection slot: the callee-side edge-removal token for an
+        /// `ask`, dropped by the runtime right after the reply is sent. Empty
+        /// for `tell` envelopes; a plain `()` when the feature is off.
+        ask_edge: AskEdgeSlot,
     },
     /// A signal for the actor to stop gracefully after processing existing messages in its mailbox.
     ///
@@ -658,9 +683,11 @@ impl Default for SpawnOptions {
 /// Takes initialization arguments that will be passed to the actor's [`on_start`](crate::Actor::on_start) method.
 /// The `JoinHandle` can be used to await the actor's termination and retrieve
 /// the actor result as an [`ActorResult<T>`](crate::ActorResult).
-pub fn spawn<T: Actor + 'static>(
-    args: T::Args,
-) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
+///
+/// # Panics
+///
+/// Panics if called outside a Tokio runtime context (this uses [`tokio::spawn`]).
+pub fn spawn<T: Actor>(args: T::Args) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
     spawn_with_options(args, SpawnOptions::new())
 }
 
@@ -670,7 +697,15 @@ pub fn spawn<T: Actor + 'static>(
 /// The `JoinHandle` can be used to await the actor's termination and retrieve
 /// the actor result as an [`ActorResult<T>`](crate::ActorResult). Use this version when you need
 /// to control the actor's mailbox capacity.
-pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
+///
+/// # Panics
+///
+/// Panics if `mailbox_capacity == 0` (via
+/// [`SpawnOptions::mailbox_capacity`]), or if called outside a Tokio runtime
+/// context. Note the asymmetry with [`set_default_mailbox_capacity`], which
+/// returns an `Err` for `0`: a literal zero capacity at a spawn site is a
+/// programming error, while the global default is runtime configuration.
+pub fn spawn_with_mailbox_capacity<T: Actor>(
     args: T::Args,
     mailbox_capacity: usize,
 ) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
@@ -683,10 +718,18 @@ pub fn spawn_with_mailbox_capacity<T: Actor + 'static>(
 /// This is the most general spawn entry point. Use it when you need to enable the
 /// priority channel via [`SpawnOptions::with_priority`] or configure both mailbox
 /// capacity and priority in a single call.
-pub fn spawn_with_options<T: Actor + 'static>(
+///
+/// # Panics
+///
+/// Panics if called outside a Tokio runtime context (this uses [`tokio::spawn`]).
+pub fn spawn_with_options<T: Actor>(
     args: T::Args,
     opts: SpawnOptions,
 ) -> (ActorRef<T>, tokio::task::JoinHandle<ActorResult<T>>) {
+    // Defensive only: every public path into `SpawnOptions` already rejects 0
+    // (the builder asserts, the global-default setter returns Err), so this
+    // assert is unreachable from the public API and merely guards future
+    // internal construction paths.
     assert!(
         opts.mailbox_capacity > 0,
         "Mailbox capacity must be greater than 0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,10 @@ where
         actor_ref: ActorRef<A>,
         reply_channel: Option<oneshot::Sender<Box<dyn std::any::Any + Send>>>,
     ) -> BoxFuture<'_, ()>;
+
+    /// Type name of the erased message, for diagnostics (dead-letter records
+    /// emitted by the shutdown drain, where only the boxed handler remains).
+    fn message_type_name(&self) -> &'static str;
 }
 
 /// A boxed future that is Send and can be stored in collections.
@@ -461,6 +465,10 @@ where
             }
         }
         .boxed()
+    }
+
+    fn message_type_name(&self) -> &'static str {
+        std::any::type_name::<T>()
     }
 }
 

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -152,32 +152,38 @@ impl MetricsCollector {
 
     /// Creates an immutable snapshot of current metrics.
     ///
-    /// The snapshot is consistent for each individual field but may not
-    /// represent a single point in time across all fields when read
-    /// concurrently with message processing.
+    /// Each individual atomic is read consistently, but the snapshot as a
+    /// whole is not a single point in time: a recording that races this read
+    /// can land between the loads, so *derived* values (the averages, computed
+    /// from two separately-loaded atomics) can transiently disagree with the
+    /// other fields. The averages are clamped to their corresponding maxima so
+    /// the `avg <= max` invariant always holds in the values this returns; the
+    /// residual skew is bounded by a single message's duration.
     pub fn snapshot(&self) -> MetricsSnapshot {
         let count = self.message_count.load(Ordering::Relaxed);
         let total_nanos = self.total_processing_nanos.load(Ordering::Relaxed);
         let priority_count = self.priority_message_count.load(Ordering::Relaxed);
         let total_priority_nanos = self.total_priority_processing_nanos.load(Ordering::Relaxed);
+        let max_processing_time =
+            Duration::from_nanos(self.max_processing_nanos.load(Ordering::Relaxed));
+        let max_priority_processing_time =
+            Duration::from_nanos(self.max_priority_processing_nanos.load(Ordering::Relaxed));
 
         MetricsSnapshot {
             message_count: count,
             avg_processing_time: total_nanos
                 .checked_div(count)
                 .map(Duration::from_nanos)
-                .unwrap_or(Duration::ZERO),
-            max_processing_time: Duration::from_nanos(
-                self.max_processing_nanos.load(Ordering::Relaxed),
-            ),
+                .unwrap_or(Duration::ZERO)
+                .min(max_processing_time),
+            max_processing_time,
             priority_message_count: priority_count,
             avg_priority_processing_time: total_priority_nanos
                 .checked_div(priority_count)
                 .map(Duration::from_nanos)
-                .unwrap_or(Duration::ZERO),
-            max_priority_processing_time: Duration::from_nanos(
-                self.max_priority_processing_nanos.load(Ordering::Relaxed),
-            ),
+                .unwrap_or(Duration::ZERO)
+                .min(max_priority_processing_time),
+            max_priority_processing_time,
             uptime: self.uptime_baseline().elapsed(),
             last_activity: self.get_last_activity(),
         }
@@ -192,6 +198,10 @@ impl MetricsCollector {
     }
 
     /// Returns the average processing time per message.
+    ///
+    /// Clamped to [`max_processing_time`](Self::max_processing_time) so the
+    /// `avg <= max` invariant holds even when this read races a recording
+    /// (count/total/max are separate atomics).
     #[inline]
     pub fn avg_processing_time(&self) -> Duration {
         let count = self.message_count.load(Ordering::Relaxed);
@@ -200,6 +210,7 @@ impl MetricsCollector {
             .checked_div(count)
             .map(Duration::from_nanos)
             .unwrap_or(Duration::ZERO)
+            .min(self.max_processing_time())
     }
 
     /// Returns the maximum processing time observed.
@@ -215,6 +226,9 @@ impl MetricsCollector {
     }
 
     /// Returns the average priority message processing time.
+    ///
+    /// Clamped to [`max_priority_processing_time`](Self::max_priority_processing_time);
+    /// see [`avg_processing_time`](Self::avg_processing_time).
     #[inline]
     pub fn avg_priority_processing_time(&self) -> Duration {
         let count = self.priority_message_count.load(Ordering::Relaxed);
@@ -223,6 +237,7 @@ impl MetricsCollector {
             .checked_div(count)
             .map(Duration::from_nanos)
             .unwrap_or(Duration::ZERO)
+            .min(self.max_priority_processing_time())
     }
 
     /// Returns the maximum priority message processing time observed.

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -22,8 +22,9 @@ use super::MetricsSnapshot;
 /// # Overflow Protection
 ///
 /// - Individual durations are capped at `u64::MAX` nanoseconds (~584 years)
-/// - `total_processing_nanos` accumulates with plain atomic add; the summed
-///   total wraps only after ~584 years of processing time
+/// - The `total_*_nanos` counters (regular, priority, idle) accumulate with
+///   plain atomic add; a summed total wraps only after ~584 years of
+///   processing time
 #[derive(Debug)]
 pub(crate) struct MetricsCollector {
     /// Number of messages processed (regular mailbox only — priority messages are
@@ -39,6 +40,12 @@ pub(crate) struct MetricsCollector {
     total_priority_processing_nanos: AtomicU64,
     /// Maximum priority message processing time observed in nanoseconds
     max_priority_processing_nanos: AtomicU64,
+    /// Number of idle events dispatched to `on_idle` (successful returns only).
+    idle_event_count: AtomicU64,
+    /// Cumulative `on_idle` processing time, in nanoseconds
+    total_idle_processing_nanos: AtomicU64,
+    /// Maximum `on_idle` processing time observed in nanoseconds
+    max_idle_processing_nanos: AtomicU64,
     /// Last activity timestamp as milliseconds since UNIX_EPOCH
     last_activity_millis: AtomicU64,
     /// Collector construction time. Used as the uptime baseline until the actor
@@ -60,6 +67,9 @@ impl MetricsCollector {
             priority_message_count: AtomicU64::new(0),
             total_priority_processing_nanos: AtomicU64::new(0),
             max_priority_processing_nanos: AtomicU64::new(0),
+            idle_event_count: AtomicU64::new(0),
+            total_idle_processing_nanos: AtomicU64::new(0),
+            max_idle_processing_nanos: AtomicU64::new(0),
             last_activity_millis: AtomicU64::new(0),
             start_instant: Instant::now(),
             started_at: OnceLock::new(),
@@ -130,6 +140,30 @@ impl MetricsCollector {
         self.update_last_activity();
     }
 
+    /// Records a completed `on_idle` dispatch with its duration.
+    ///
+    /// Idle events do work with the same exclusive access to actor state as
+    /// message handlers; without these counters an actor driven purely by
+    /// subscribed idle streams would look permanently inactive
+    /// (`last_activity == None`) and a slow `on_idle` would be invisible to
+    /// the processing-time metrics.
+    #[inline]
+    pub fn record_idle_event(&self, duration: Duration) {
+        self.idle_event_count.fetch_add(1, Ordering::Relaxed);
+
+        let nanos = duration.as_nanos().min(u64::MAX as u128) as u64;
+
+        // Plain atomic add (single RMW) instead of a fetch_update CAS loop; see
+        // `record_message` for the wraparound rationale.
+        self.total_idle_processing_nanos
+            .fetch_add(nanos, Ordering::Relaxed);
+
+        self.max_idle_processing_nanos
+            .fetch_max(nanos, Ordering::Relaxed);
+
+        self.update_last_activity();
+    }
+
     /// Updates the last activity timestamp to now.
     fn update_last_activity(&self) {
         let millis = SystemTime::now()
@@ -164,10 +198,14 @@ impl MetricsCollector {
         let total_nanos = self.total_processing_nanos.load(Ordering::Relaxed);
         let priority_count = self.priority_message_count.load(Ordering::Relaxed);
         let total_priority_nanos = self.total_priority_processing_nanos.load(Ordering::Relaxed);
+        let idle_count = self.idle_event_count.load(Ordering::Relaxed);
+        let total_idle_nanos = self.total_idle_processing_nanos.load(Ordering::Relaxed);
         let max_processing_time =
             Duration::from_nanos(self.max_processing_nanos.load(Ordering::Relaxed));
         let max_priority_processing_time =
             Duration::from_nanos(self.max_priority_processing_nanos.load(Ordering::Relaxed));
+        let max_idle_processing_time =
+            Duration::from_nanos(self.max_idle_processing_nanos.load(Ordering::Relaxed));
 
         MetricsSnapshot {
             message_count: count,
@@ -184,6 +222,13 @@ impl MetricsCollector {
                 .unwrap_or(Duration::ZERO)
                 .min(max_priority_processing_time),
             max_priority_processing_time,
+            idle_event_count: idle_count,
+            avg_idle_processing_time: total_idle_nanos
+                .checked_div(idle_count)
+                .map(Duration::from_nanos)
+                .unwrap_or(Duration::ZERO)
+                .min(max_idle_processing_time),
+            max_idle_processing_time,
             uptime: self.uptime_baseline().elapsed(),
             last_activity: self.get_last_activity(),
         }
@@ -244,6 +289,33 @@ impl MetricsCollector {
     #[inline]
     pub fn max_priority_processing_time(&self) -> Duration {
         Duration::from_nanos(self.max_priority_processing_nanos.load(Ordering::Relaxed))
+    }
+
+    /// Returns the total number of idle events dispatched to `on_idle`.
+    #[inline]
+    pub fn idle_event_count(&self) -> u64 {
+        self.idle_event_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the average `on_idle` processing time.
+    ///
+    /// Clamped to [`max_idle_processing_time`](Self::max_idle_processing_time);
+    /// see [`avg_processing_time`](Self::avg_processing_time).
+    #[inline]
+    pub fn avg_idle_processing_time(&self) -> Duration {
+        let count = self.idle_event_count.load(Ordering::Relaxed);
+        let total_nanos = self.total_idle_processing_nanos.load(Ordering::Relaxed);
+        total_nanos
+            .checked_div(count)
+            .map(Duration::from_nanos)
+            .unwrap_or(Duration::ZERO)
+            .min(self.max_idle_processing_time())
+    }
+
+    /// Returns the maximum `on_idle` processing time observed.
+    #[inline]
+    pub fn max_idle_processing_time(&self) -> Duration {
+        Duration::from_nanos(self.max_idle_processing_nanos.load(Ordering::Relaxed))
     }
 
     /// Returns the uptime since actor start.

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -250,78 +250,13 @@ impl Default for MetricsCollector {
     }
 }
 
-/// RAII guard for measuring message processing time.
-///
-/// When this guard is dropped, it automatically records the elapsed time
-/// to the associated `MetricsCollector`.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// let guard = MessageProcessingGuard::new(&collector);
-/// // ... process message ...
-/// drop(guard); // Automatically records duration
-/// ```
-pub(crate) struct MessageProcessingGuard<'a> {
-    collector: &'a MetricsCollector,
-    start: Instant,
-}
-
-impl<'a> MessageProcessingGuard<'a> {
-    /// Creates a new guard that will record to the given collector.
-    #[inline]
-    pub fn new(collector: &'a MetricsCollector) -> Self {
-        Self {
-            collector,
-            start: Instant::now(),
-        }
-    }
-}
-
-impl Drop for MessageProcessingGuard<'_> {
-    #[inline]
-    fn drop(&mut self) {
-        // Only count a message whose handler returned normally. If the handler
-        // panicked, this guard is dropped while the task unwinds; recording here
-        // would inflate `message_count`, which is documented as the number of
-        // *successfully processed* messages.
-        if std::thread::panicking() {
-            return;
-        }
-        self.collector.record_message(self.start.elapsed());
-    }
-}
-
-/// RAII guard for measuring priority message processing time.
-///
-/// Mirrors [`MessageProcessingGuard`] but records into the priority counters so the two
-/// channels can be observed independently.
-pub(crate) struct PriorityMessageProcessingGuard<'a> {
-    collector: &'a MetricsCollector,
-    start: Instant,
-}
-
-impl<'a> PriorityMessageProcessingGuard<'a> {
-    #[inline]
-    pub fn new(collector: &'a MetricsCollector) -> Self {
-        Self {
-            collector,
-            start: Instant::now(),
-        }
-    }
-}
-
-impl Drop for PriorityMessageProcessingGuard<'_> {
-    #[inline]
-    fn drop(&mut self) {
-        // See `MessageProcessingGuard::drop`: skip recording a handler that
-        // panicked so the priority count reflects only successful processing.
-        if std::thread::panicking() {
-            return;
-        }
-        self.collector.record_priority_message(self.start.elapsed());
-    }
-}
+// NOTE: recording is *not* RAII-based. The runtime calls `record_message` /
+// `record_priority_message` explicitly after the handler future returns
+// normally (see `process_envelope!` in actor.rs). A drop-guard would also fire
+// when the actor task is cancelled mid-handler (`JoinHandle::abort`, runtime
+// shutdown) — a path that is neither a panic nor a success — and would record
+// a partially-processed message against the documented "successfully
+// processed" counters.
 
 #[cfg(test)]
 mod tests {
@@ -353,19 +288,6 @@ mod tests {
     }
 
     #[test]
-    fn test_guard_records_duration() {
-        let collector = MetricsCollector::new();
-
-        {
-            let _guard = MessageProcessingGuard::new(&collector);
-            std::thread::sleep(Duration::from_millis(10));
-        }
-
-        assert_eq!(collector.message_count(), 1);
-        assert!(collector.max_processing_time() >= Duration::from_millis(10));
-    }
-
-    #[test]
     fn test_uptime_increases() {
         let collector = MetricsCollector::new();
         let uptime1 = collector.uptime();
@@ -388,40 +310,6 @@ mod tests {
         assert!(
             after < before,
             "mark_started should reset the uptime baseline (before={before:?}, after={after:?})"
-        );
-    }
-
-    #[test]
-    fn test_guard_skips_record_on_panic() {
-        let collector = MetricsCollector::new();
-
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = MessageProcessingGuard::new(&collector);
-            panic!("handler panicked");
-        }));
-
-        assert!(result.is_err(), "the closure should have panicked");
-        assert_eq!(
-            collector.message_count(),
-            0,
-            "a panicking handler must not be counted as successfully processed"
-        );
-    }
-
-    #[test]
-    fn test_priority_guard_skips_record_on_panic() {
-        let collector = MetricsCollector::new();
-
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _guard = PriorityMessageProcessingGuard::new(&collector);
-            panic!("priority handler panicked");
-        }));
-
-        assert!(result.is_err(), "the closure should have panicked");
-        assert_eq!(
-            collector.priority_message_count(),
-            0,
-            "a panicking priority handler must not be counted as successfully processed"
         );
     }
 }

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -10,9 +10,18 @@ use std::time::{Duration, SystemTime};
 ///
 /// # Consistency Note
 ///
-/// When reading metrics concurrently with message processing, individual fields
-/// are consistent but the snapshot as a whole may reflect different points in time.
-/// This is acceptable for monitoring purposes where exact consistency is not required.
+/// When reading metrics concurrently with message processing, each underlying
+/// counter is read atomically but the snapshot as a whole may reflect
+/// different points in time. Derived fields (the averages) are computed from
+/// two separately-read counters and are clamped to their corresponding maxima
+/// so that `avg <= max` always holds; the residual skew is bounded by a single
+/// message's duration. This is acceptable for monitoring purposes where exact
+/// consistency is not required.
+///
+/// There is also no ordering guarantee between a reply and the metrics that
+/// recorded it: immediately after an `ask().await` resolves, the counters may
+/// not yet include that message (recording happens after the reply is sent).
+/// Tests asserting exact counts right after an `ask` should retry briefly.
 ///
 /// # Example
 ///
@@ -58,6 +67,13 @@ pub struct MetricsSnapshot {
     /// (the point the actor enters its message loop). Before `on_start`
     /// completes, the value falls back to the time since the metrics collector
     /// was created at [`spawn`](crate::spawn).
+    ///
+    /// Note: metrics outlive the actor (they remain readable through retained
+    /// `ActorRef`/`ActorWeak` handles for post-mortem analysis), and `uptime`
+    /// is wall-clock based — it keeps growing after the actor has stopped.
+    /// Combine with `last_activity` or
+    /// [`ActorRef::is_alive`](crate::ActorRef::is_alive) when deciding whether
+    /// the actor is still running.
     pub uptime: Duration,
 
     /// Timestamp of the last message processing completion.

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -34,7 +34,13 @@ use std::time::{Duration, SystemTime};
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MetricsSnapshot {
-    /// Total number of messages successfully processed by this actor.
+    /// Number of **regular-mailbox** messages successfully processed by this
+    /// actor.
+    ///
+    /// Priority messages are deliberately excluded — they are tracked in
+    /// [`priority_message_count`](Self::priority_message_count) so callers can
+    /// detect priority-channel abuse. Sum the two fields for an all-channel
+    /// total.
     pub message_count: u64,
 
     /// Average time spent processing each message.
@@ -61,6 +67,20 @@ pub struct MetricsSnapshot {
     /// Maximum time spent processing any single priority message.
     pub max_priority_processing_time: Duration,
 
+    /// Number of idle events dispatched to
+    /// [`Actor::on_idle`](crate::Actor::on_idle) (successful returns only).
+    ///
+    /// Idle-driven actors do their work here rather than in message handlers,
+    /// so this is the throughput signal for actors subscribed via
+    /// [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle).
+    pub idle_event_count: u64,
+
+    /// Average time spent in `on_idle` per dispatched event.
+    pub avg_idle_processing_time: Duration,
+
+    /// Maximum time spent in any single `on_idle` dispatch.
+    pub max_idle_processing_time: Duration,
+
     /// Time elapsed since the actor was started.
     ///
     /// This is measured from when the actor's `on_start` completed successfully
@@ -68,17 +88,21 @@ pub struct MetricsSnapshot {
     /// completes, the value falls back to the time since the metrics collector
     /// was created at [`spawn`](crate::spawn).
     ///
-    /// Note: metrics outlive the actor (they remain readable through retained
-    /// `ActorRef`/`ActorWeak` handles for post-mortem analysis), and `uptime`
-    /// is wall-clock based — it keeps growing after the actor has stopped.
+    /// Note: metrics outlive the actor — they remain readable through a
+    /// retained `ActorRef`, or through an `ActorWeak` via
+    /// [`ActorWeak::metrics`](crate::ActorWeak::metrics) (which works even
+    /// after the actor stopped and `upgrade()` fails), for post-mortem
+    /// analysis. `uptime` is wall-clock based — it keeps growing after the
+    /// actor has stopped.
     /// Combine with `last_activity` or
     /// [`ActorRef::is_alive`](crate::ActorRef::is_alive) when deciding whether
     /// the actor is still running.
     pub uptime: Duration,
 
-    /// Timestamp of the last message processing completion.
+    /// Timestamp of the last completed unit of work — a message (regular or
+    /// priority) or an idle event.
     ///
-    /// Returns `None` if no messages have been processed yet.
+    /// Returns `None` if no work has completed yet.
     pub last_activity: Option<SystemTime>,
 }
 
@@ -106,6 +130,9 @@ mod tests {
             priority_message_count: 7,
             avg_priority_processing_time: Duration::from_micros(80),
             max_priority_processing_time: Duration::from_millis(2),
+            idle_event_count: 3,
+            avg_idle_processing_time: Duration::from_micros(40),
+            max_idle_processing_time: Duration::from_millis(1),
             uptime: Duration::from_secs(60),
             last_activity: Some(SystemTime::now()),
         };
@@ -124,6 +151,9 @@ mod tests {
             cloned.max_priority_processing_time,
             Duration::from_millis(2)
         );
+        assert_eq!(cloned.idle_event_count, 3);
+        assert_eq!(cloned.avg_idle_processing_time, Duration::from_micros(40));
+        assert_eq!(cloned.max_idle_processing_time, Duration::from_millis(1));
         assert_eq!(cloned.uptime, Duration::from_secs(60));
         assert!(cloned.last_activity.is_some());
     }

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, SystemTime};
 /// println!("Messages processed: {}", metrics.message_count);
 /// println!("Average processing time: {:?}", metrics.avg_processing_time);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct MetricsSnapshot {
     /// Total number of messages successfully processed by this actor.
@@ -64,21 +64,6 @@ pub struct MetricsSnapshot {
     ///
     /// Returns `None` if no messages have been processed yet.
     pub last_activity: Option<SystemTime>,
-}
-
-impl Default for MetricsSnapshot {
-    fn default() -> Self {
-        Self {
-            message_count: 0,
-            avg_processing_time: Duration::ZERO,
-            max_processing_time: Duration::ZERO,
-            priority_message_count: 0,
-            avg_priority_processing_time: Duration::ZERO,
-            max_priority_processing_time: Duration::ZERO,
-            uptime: Duration::ZERO,
-            last_activity: None,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/tests/actor_result_tests.rs
+++ b/tests/actor_result_tests.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use futures::stream::StreamExt;
-use rsactor::{spawn, Actor, ActorRef, ActorResult, ActorWeak, FailurePhase, Message};
+use rsactor::{
+    spawn, Actor, ActorFailure, ActorRef, ActorResult, ActorWeak, FailurePhase, Message,
+};
 use tokio_stream::wrappers::IntervalStream;
 
 // Dummy message for test actors
@@ -123,7 +125,7 @@ async fn test_actor_result_completed_stopped_normally() {
     // Test error access
     assert!(result.error().is_none(), "Should not have error");
 
-    // Test to_result conversion
+    // Test into_result conversion
     let result_copy = ActorResult::Completed {
         actor: TestActor {
             id: "test_normal".to_string(),
@@ -131,7 +133,7 @@ async fn test_actor_result_completed_stopped_normally() {
         },
         killed: false,
     };
-    let std_result = result_copy.to_result();
+    let std_result = result_copy.into_result();
     assert!(std_result.is_ok(), "to_result should be Ok");
     if let Ok(actor) = std_result {
         assert_eq!(actor.id, "test_normal");
@@ -219,15 +221,14 @@ async fn test_actor_result_failed_on_start() {
         assert!(error.to_string().contains("Test failure in on_start"));
     }
 
-    // Test to_result conversion
+    // Test into_result conversion
     let result_copy = ActorResult::Failed::<FailureTestActor> {
-        actor: None,
-        error: anyhow::anyhow!("Test failure in on_start"),
-        secondary_error: None,
-        phase: FailurePhase::OnStart,
+        failure: ActorFailure::OnStart {
+            error: anyhow::anyhow!("Test failure in on_start"),
+        },
         killed: false,
     };
-    let std_result = result_copy.to_result();
+    let std_result = result_copy.into_result();
     assert!(std_result.is_err(), "to_result should be Err");
     if let Err(error) = std_result {
         assert!(error.to_string().contains("Test failure in on_start"));
@@ -412,13 +413,13 @@ async fn test_actor_result_from_completed() {
 #[tokio::test]
 async fn test_actor_result_from_failed_with_actor() {
     let result = ActorResult::Failed {
-        actor: Some(TestActor {
-            id: "test".to_string(),
-            value: 456,
-        }),
-        error: anyhow::anyhow!("test error"),
-        secondary_error: None,
-        phase: FailurePhase::OnIdle,
+        failure: ActorFailure::OnIdle {
+            actor: TestActor {
+                id: "test".to_string(),
+                value: 456,
+            },
+            error: anyhow::anyhow!("test error"),
+        },
         killed: false,
     };
 
@@ -440,10 +441,9 @@ async fn test_actor_result_from_failed_with_actor() {
 #[tokio::test]
 async fn test_actor_result_from_failed_without_actor() {
     let result = ActorResult::Failed::<TestActor> {
-        actor: None,
-        error: anyhow::anyhow!("startup error"),
-        secondary_error: None,
-        phase: FailurePhase::OnStart,
+        failure: ActorFailure::OnStart {
+            error: anyhow::anyhow!("startup error"),
+        },
         killed: false,
     };
 
@@ -479,10 +479,9 @@ async fn test_actor_result_into_error_completed() {
 #[tokio::test]
 async fn test_actor_result_into_error_failed() {
     let result = ActorResult::Failed::<TestActor> {
-        actor: None,
-        error: anyhow::anyhow!("test into_error"),
-        secondary_error: None,
-        phase: FailurePhase::OnStart,
+        failure: ActorFailure::OnStart {
+            error: anyhow::anyhow!("test into_error"),
+        },
         killed: false,
     };
 
@@ -513,10 +512,9 @@ async fn test_actor_result_debug_format() {
     );
 
     let failed_result = ActorResult::Failed::<TestActor> {
-        actor: None,
-        error: anyhow::anyhow!("debug error"),
-        secondary_error: None,
-        phase: FailurePhase::OnStart,
+        failure: ActorFailure::OnStart {
+            error: anyhow::anyhow!("debug error"),
+        },
         killed: false,
     };
     let debug_str = format!("{failed_result:?}");
@@ -552,49 +550,48 @@ async fn test_all_boolean_combinations() {
 
     // Failed OnStart, not killed
     let result3 = ActorResult::Failed::<TestActor> {
-        actor: None,
-        error: anyhow::anyhow!("error3"),
-        secondary_error: None,
-        phase: FailurePhase::OnStart,
+        failure: ActorFailure::OnStart {
+            error: anyhow::anyhow!("error3"),
+        },
         killed: false,
     };
     assert!(!result3.is_completed() && !result3.was_killed() && result3.is_startup_failed());
 
     // Failed OnRun, not killed
     let result4 = ActorResult::Failed {
-        actor: Some(TestActor {
-            id: "test4".to_string(),
-            value: 4,
-        }),
-        error: anyhow::anyhow!("error4"),
-        secondary_error: None,
-        phase: FailurePhase::OnIdle,
+        failure: ActorFailure::OnIdle {
+            actor: TestActor {
+                id: "test4".to_string(),
+                value: 4,
+            },
+            error: anyhow::anyhow!("error4"),
+        },
         killed: false,
     };
     assert!(!result4.is_completed() && !result4.was_killed() && result4.is_runtime_failed());
 
     // Failed OnStop, not killed
     let result5 = ActorResult::Failed {
-        actor: Some(TestActor {
-            id: "test5".to_string(),
-            value: 5,
-        }),
-        error: anyhow::anyhow!("error5"),
-        secondary_error: None,
-        phase: FailurePhase::OnStop,
+        failure: ActorFailure::OnStop {
+            actor: TestActor {
+                id: "test5".to_string(),
+                value: 5,
+            },
+            error: anyhow::anyhow!("error5"),
+        },
         killed: false,
     };
     assert!(!result5.is_completed() && !result5.was_killed() && result5.is_stop_failed());
 
     // Failed OnStop, killed
     let result6 = ActorResult::Failed {
-        actor: Some(TestActor {
-            id: "test6".to_string(),
-            value: 6,
-        }),
-        error: anyhow::anyhow!("error6"),
-        secondary_error: None,
-        phase: FailurePhase::OnStop,
+        failure: ActorFailure::OnStop {
+            actor: TestActor {
+                id: "test6".to_string(),
+                value: 6,
+            },
+            error: anyhow::anyhow!("error6"),
+        },
         killed: true,
     };
     assert!(!result6.is_completed() && result6.was_killed() && result6.is_stop_failed());

--- a/tests/coverage_improvement_tests.rs
+++ b/tests/coverage_improvement_tests.rs
@@ -431,8 +431,8 @@ mod on_run_error_tests {
 
         // Phase should be OnIdleThenOnStop since both on_idle and on_stop failed
         match &result {
-            rsactor::ActorResult::Failed { phase, .. } => {
-                assert_eq!(*phase, rsactor::FailurePhase::OnIdleThenOnStop);
+            rsactor::ActorResult::Failed { failure, .. } => {
+                assert_eq!(failure.phase(), rsactor::FailurePhase::OnIdleThenOnStop);
             }
             _ => panic!("Expected Failed result"),
         }
@@ -1096,8 +1096,8 @@ mod actor_result_methods_tests {
         actor_ref.stop().await;
         let result = handle.await.unwrap();
 
-        // Use to_result() for conversion
-        let std_result = result.to_result();
+        // Use into_result() for conversion
+        let std_result = result.into_result();
         assert!(std_result.is_ok());
         assert_eq!(std_result.unwrap().data, "test");
     }
@@ -1120,8 +1120,8 @@ mod actor_result_methods_tests {
         let (_, handle) = spawn::<FailActor>(());
         let result = handle.await.unwrap();
 
-        // Use to_result() for conversion
-        let std_result = result.to_result();
+        // Use into_result() for conversion
+        let std_result = result.into_result();
         assert!(std_result.is_err());
         assert_eq!(std_result.unwrap_err(), "failed");
     }

--- a/tests/deadlock_detection_tests.rs
+++ b/tests/deadlock_detection_tests.rs
@@ -541,3 +541,154 @@ async fn test_blocking_slow_path_self_cycle_panics_immediately() {
         "detection must be immediate, not the 5s blocking timeout"
     );
 }
+
+// ============================================================
+// Self-send on a full mailbox: unbounded waits panic, bounded
+// waits stay recoverable
+// ============================================================
+
+#[derive(Debug)]
+struct SelfSendActor {
+    entered: std::sync::Arc<tokio::sync::Notify>,
+    proceed: std::sync::Arc<tokio::sync::Notify>,
+}
+
+#[derive(Debug)]
+struct Padding;
+#[derive(Debug)]
+struct TriggerSelfTell;
+#[derive(Debug)]
+struct TriggerSelfStop;
+#[derive(Debug)]
+struct TriggerTimedSelfTell;
+
+impl Actor for SelfSendActor {
+    type Args = (
+        std::sync::Arc<tokio::sync::Notify>,
+        std::sync::Arc<tokio::sync::Notify>,
+    );
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(
+        (entered, proceed): Self::Args,
+        _: &ActorRef<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(SelfSendActor { entered, proceed })
+    }
+}
+
+impl Message<Padding> for SelfSendActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: Padding, _: &ActorRef<Self>) {}
+}
+
+impl Message<TriggerSelfTell> for SelfSendActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerSelfTell, actor_ref: &ActorRef<Self>) {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        // The test has filled the capacity-1 mailbox: this unbounded self-send
+        // can never be admitted (the loop is parked awaiting this handler) and
+        // must panic under deadlock-detection instead of hanging.
+        let _ = actor_ref.tell(Padding).await;
+    }
+}
+
+impl Message<TriggerSelfStop> for SelfSendActor {
+    type Reply = ();
+
+    async fn handle(&mut self, _: TriggerSelfStop, actor_ref: &ActorRef<Self>) {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        // Same hazard through stop(): StopGracefully travels the regular
+        // mailbox, so a full-mailbox self-stop is equally unrecoverable.
+        actor_ref.stop().await;
+    }
+}
+
+impl Message<TriggerTimedSelfTell> for SelfSendActor {
+    type Reply = bool;
+
+    async fn handle(&mut self, _: TriggerTimedSelfTell, actor_ref: &ActorRef<Self>) -> bool {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        // Bounded variant: must NOT panic — it resolves as a recoverable
+        // Error::Timeout once the 50ms admission window elapses.
+        actor_ref
+            .tell_with_timeout(Padding, std::time::Duration::from_millis(50))
+            .await
+            .is_err()
+    }
+}
+
+async fn run_self_send_panic_case<M>(msg: M) -> Result<(), tokio::task::JoinError>
+where
+    SelfSendActor: Message<M>,
+    M: Send + 'static,
+{
+    let entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let proceed = std::sync::Arc::new(tokio::sync::Notify::new());
+    let (actor_ref, handle) = rsactor::spawn_with_mailbox_capacity::<SelfSendActor>(
+        (entered.clone(), proceed.clone()),
+        1,
+    );
+
+    actor_ref.tell(msg).await.unwrap();
+    entered.notified().await;
+    // Fill the capacity-1 mailbox while the handler is parked.
+    actor_ref.tell::<Padding>(Padding).await.unwrap();
+    proceed.notify_one();
+
+    handle.await.map(|_| ())
+}
+
+#[tokio::test]
+async fn test_self_tell_on_full_mailbox_panics() {
+    let res = run_self_send_panic_case(TriggerSelfTell).await;
+    assert!(
+        res.is_err() && res.unwrap_err().is_panic(),
+        "unbounded self-tell on a full mailbox must panic under deadlock-detection"
+    );
+}
+
+#[tokio::test]
+async fn test_self_stop_on_full_mailbox_panics() {
+    let res = run_self_send_panic_case(TriggerSelfStop).await;
+    assert!(
+        res.is_err() && res.unwrap_err().is_panic(),
+        "self-stop on a full mailbox must panic under deadlock-detection"
+    );
+}
+
+#[tokio::test]
+async fn test_timed_self_tell_on_full_mailbox_times_out_without_panic() {
+    let entered = std::sync::Arc::new(tokio::sync::Notify::new());
+    let proceed = std::sync::Arc::new(tokio::sync::Notify::new());
+    let (actor_ref, handle) = rsactor::spawn_with_mailbox_capacity::<SelfSendActor>(
+        (entered.clone(), proceed.clone()),
+        1,
+    );
+
+    let asker = actor_ref.clone();
+    let ask_task = tokio::spawn(async move { asker.ask(TriggerTimedSelfTell).await });
+
+    entered.notified().await;
+    actor_ref.tell(Padding).await.unwrap();
+    proceed.notify_one();
+
+    let timed_out = ask_task
+        .await
+        .expect("ask task must not panic")
+        .expect("ask must succeed");
+    assert!(
+        timed_out,
+        "bounded self-tell must resolve as a recoverable timeout, not a panic"
+    );
+
+    actor_ref.stop().await;
+    let result = handle.await.expect("actor task must not panic");
+    assert!(result.is_completed());
+}

--- a/tests/deadlock_detection_tests.rs
+++ b/tests/deadlock_detection_tests.rs
@@ -369,3 +369,175 @@ async fn test_sequential_ask_no_false_positive() {
     let _ = b_handle.await;
     let _ = c_handle.await;
 }
+
+// ============================================================
+// Reply-time edge removal: no false positive in the window
+// between B sending its reply and A's ask future resuming
+// ============================================================
+
+#[derive(Debug)]
+struct FpA;
+#[derive(Debug)]
+struct FpB;
+
+#[derive(Debug)]
+struct FpPing;
+struct FpTrigger(ActorRef<FpB>);
+struct FpMsg1(ActorRef<FpA>);
+struct FpMsg2(ActorRef<FpA>);
+
+impl Actor for FpA {
+    type Args = ();
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(FpA)
+    }
+}
+
+impl Actor for FpB {
+    type Args = ();
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(FpB)
+    }
+}
+
+impl Message<FpPing> for FpA {
+    type Reply = u32;
+
+    async fn handle(&mut self, _: FpPing, _: &ActorRef<Self>) -> u32 {
+        7
+    }
+}
+
+impl Message<FpTrigger> for FpA {
+    type Reply = u32;
+
+    async fn handle(&mut self, msg: FpTrigger, actor_ref: &ActorRef<Self>) -> u32 {
+        // A asks B from inside a handler → edge A->B registered.
+        msg.0.ask(FpMsg1(actor_ref.clone())).await.unwrap()
+    }
+}
+
+impl Message<FpMsg1> for FpB {
+    type Reply = u32;
+
+    async fn handle(&mut self, msg: FpMsg1, actor_ref: &ActorRef<Self>) -> u32 {
+        // Queue FpMsg2 before replying; the reply to A is sent when this
+        // handler returns, and B's very next message asks back into A.
+        actor_ref.tell(FpMsg2(msg.0)).await.unwrap();
+        1
+    }
+}
+
+impl Message<FpMsg2> for FpB {
+    type Reply = u32;
+
+    async fn handle(&mut self, msg: FpMsg2, _: &ActorRef<Self>) -> u32 {
+        // Regression: with caller-side-only edge removal, the stale A->B edge
+        // was still in the wait-for graph here (A's ask future had not been
+        // polled yet), so this ask closed a phantom cycle and panicked even
+        // though A was already runnable. Reply-time edge removal (the token
+        // carried in the ask envelope) must make this succeed.
+        msg.0.ask(FpPing).await.unwrap()
+    }
+}
+
+#[tokio::test]
+async fn test_reply_send_window_has_no_false_positive() {
+    let (a_ref, a_handle) = spawn::<FpA>(());
+    let (b_ref, b_handle) = spawn::<FpB>(());
+
+    let r = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        a_ref.ask(FpTrigger(b_ref.clone())),
+    )
+    .await
+    .expect("must not hang")
+    .expect("must not error");
+    assert_eq!(r, 1);
+
+    // Let B process FpMsg2 — its ask back into A must not panic.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(
+        b_ref.is_alive(),
+        "B must survive: the ask issued right after replying to A must not \
+         trip a false-positive deadlock panic"
+    );
+
+    drop(a_ref);
+    drop(b_ref);
+    let _ = a_handle.await;
+    let _ = b_handle.await;
+}
+
+// ============================================================
+// Slow-path detection: blocking_ask from a current_thread
+// runtime handler still panics immediately on a self-cycle
+// ============================================================
+
+#[derive(Debug)]
+struct SlowPathActor;
+
+#[derive(Debug)]
+struct PlainPing;
+#[derive(Debug)]
+struct BlockingSelfAsk;
+
+impl Actor for SlowPathActor {
+    type Args = ();
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(_: (), _: &ActorRef<Self>) -> Result<Self, Self::Error> {
+        Ok(SlowPathActor)
+    }
+}
+
+impl Message<PlainPing> for SlowPathActor {
+    type Reply = u32;
+
+    async fn handle(&mut self, _: PlainPing, _: &ActorRef<Self>) -> u32 {
+        1
+    }
+}
+
+impl Message<BlockingSelfAsk> for SlowPathActor {
+    type Reply = u32;
+
+    async fn handle(&mut self, _: BlockingSelfAsk, actor_ref: &ActorRef<Self>) -> u32 {
+        // On a current_thread runtime the blocking_* call takes the
+        // dedicated-thread slow path. Regression: the CURRENT_ACTOR
+        // task-local did not propagate to that thread, so this self-cycle
+        // silently hung until the timeout instead of panicking.
+        actor_ref
+            .blocking_ask(PlainPing, Some(std::time::Duration::from_secs(5)))
+            .unwrap_or(0)
+    }
+}
+
+#[tokio::test]
+async fn test_blocking_slow_path_self_cycle_panics_immediately() {
+    let (actor_ref, handle) = spawn::<SlowPathActor>(());
+
+    let start = std::time::Instant::now();
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        actor_ref.ask(BlockingSelfAsk),
+    )
+    .await;
+
+    let res = handle.await;
+    assert!(
+        res.is_err() && res.unwrap_err().is_panic(),
+        "self ask cycle through the blocking slow path must panic via deadlock detection"
+    );
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(4),
+        "detection must be immediate, not the 5s blocking timeout"
+    );
+}

--- a/tests/debugging_tools_tests.rs
+++ b/tests/debugging_tools_tests.rs
@@ -26,13 +26,13 @@ fn test_is_retryable_for_all_variants() {
     // All others are NOT retryable
     let send_err = Error::Send {
         identity,
-        details: "channel closed".into(),
+        details: "channel closed",
     };
     assert!(!send_err.is_retryable());
 
     let receive_err = Error::Receive {
         identity,
-        details: "channel closed".into(),
+        details: "channel closed",
     };
     assert!(!receive_err.is_retryable());
 
@@ -63,11 +63,11 @@ fn test_all_errors_have_debugging_tips() {
     let errors: Vec<Error> = vec![
         Error::Send {
             identity,
-            details: "test".into(),
+            details: "test",
         },
         Error::Receive {
             identity,
-            details: "test".into(),
+            details: "test",
         },
         Error::Timeout {
             identity,
@@ -170,11 +170,11 @@ fn test_error_display_all_variants() {
     let errors = vec![
         Error::Send {
             identity,
-            details: "channel closed".into(),
+            details: "channel closed",
         },
         Error::Receive {
             identity,
-            details: "reply dropped".into(),
+            details: "reply dropped",
         },
         Error::Timeout {
             identity,
@@ -785,11 +785,11 @@ fn test_error_source_returns_none_for_non_join() {
     let errors: Vec<Error> = vec![
         Error::Send {
             identity,
-            details: "test".into(),
+            details: "test",
         },
         Error::Receive {
             identity,
-            details: "test".into(),
+            details: "test",
         },
         Error::Timeout {
             identity,

--- a/tests/metrics_consistency_tests.rs
+++ b/tests/metrics_consistency_tests.rs
@@ -1,0 +1,96 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stress test for metrics snapshot consistency.
+//!
+//! The collector's counters are separate Relaxed atomics, so a reader racing
+//! a recording can observe a torn (count, total, max) combination — most
+//! visibly on an actor's *first* messages, where count/total are already
+//! updated but the max is not yet, yielding `avg > max == 0`. Before the
+//! clamp in `snapshot()` and the avg accessors this reproduced within a few
+//! thousand rounds of the loop below. The test asserts the documented
+//! `avg <= max` invariant never breaks.
+
+use rsactor::{message_handlers, spawn, Actor, ActorRef};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+#[derive(Actor, Debug)]
+struct Worker;
+
+#[derive(Debug)]
+struct Work;
+
+#[message_handlers]
+impl Worker {
+    #[handler]
+    async fn handle_work(&mut self, _: Work, _: &ActorRef<Self>) {
+        // A short spin keeps recorded durations non-zero.
+        let start = std::time::Instant::now();
+        while start.elapsed() < std::time::Duration::from_micros(2) {
+            std::hint::spin_loop();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn snapshot_avg_never_exceeds_max() {
+    const ROUNDS: usize = 4_000;
+    const MESSAGES_PER_ROUND: u64 = 4;
+
+    let mut violations = 0u64;
+    let mut reads = 0u64;
+
+    // Fresh actor per round: tearing is only observable while the counters
+    // are small (a single torn message shifts the derived avg by a large
+    // fraction), so a long-lived actor would mask the race.
+    for _ in 0..ROUNDS {
+        let (actor_ref, handle) = spawn::<Worker>(Worker);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = stop.clone();
+        let reader_ref = actor_ref.clone();
+        let reader = tokio::spawn(async move {
+            let mut v = 0u64;
+            let mut r = 0u64;
+            while !reader_stop.load(Ordering::Relaxed) {
+                let s = reader_ref.metrics();
+                if s.message_count > 0 && s.avg_processing_time > s.max_processing_time {
+                    v += 1;
+                }
+                // The direct accessors read the atomics independently of
+                // snapshot(); exercise their clamp too.
+                if reader_ref.message_count() > 0
+                    && reader_ref.avg_processing_time() > reader_ref.max_processing_time()
+                {
+                    v += 1;
+                }
+                r += 2;
+                tokio::task::yield_now().await;
+            }
+            (v, r)
+        });
+
+        for _ in 0..MESSAGES_PER_ROUND {
+            actor_ref.tell(Work).await.unwrap();
+        }
+        while actor_ref.message_count() < MESSAGES_PER_ROUND {
+            tokio::task::yield_now().await;
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        let (v, r) = reader.await.unwrap();
+        violations += v;
+        reads += r;
+
+        actor_ref.stop().await;
+        let _ = handle.await;
+    }
+
+    assert!(reads > 0, "reader must have raced the writer");
+    assert_eq!(
+        violations, 0,
+        "avg_processing_time must never exceed max_processing_time \
+         (clamped in snapshot() and the accessors); {reads} racing reads"
+    );
+}

--- a/tests/shutdown_discard_tests.rs
+++ b/tests/shutdown_discard_tests.rs
@@ -1,0 +1,264 @@
+// Copyright 2022 Jeff Kim <hiking90@gmail.com>
+// SPDX-License-Identifier: Apache-2.0
+
+//! Receiver-side accounting at shutdown.
+//!
+//! Verifies that messages accepted into a mailbox but never processed —
+//! queued behind a graceful-stop signal, or pending at `kill()` — are
+//! recorded as `DiscardedAtShutdown` dead letters, that `ask` envelopes are
+//! not double-counted (their callers already record `ReplyDropped`), and that
+//! `subscribe_idle` fails fast once the actor has begun stopping.
+//!
+//! Reads the process-global dead-letter counter, so the counter-reading tests
+//! serialize on a local mutex and fully join their actors before releasing it.
+
+use rsactor::{
+    dead_letter_count, message_handlers, spawn_with_mailbox_capacity, spawn_with_options, Actor,
+    ActorRef, SpawnOptions,
+};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+
+fn serial_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(Debug)]
+struct WedgeActor {
+    entered: Arc<Notify>,
+    proceed: Arc<Notify>,
+}
+
+#[derive(Debug)]
+struct Block;
+#[derive(Debug)]
+struct Note;
+#[derive(Debug)]
+struct Query;
+
+impl Actor for WedgeActor {
+    type Args = (Arc<Notify>, Arc<Notify>);
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(
+        (entered, proceed): Self::Args,
+        _: &ActorRef<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(WedgeActor { entered, proceed })
+    }
+}
+
+#[message_handlers]
+impl WedgeActor {
+    #[handler]
+    async fn handle_block(&mut self, _: Block, _: &ActorRef<Self>) {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+    }
+
+    #[handler]
+    async fn handle_note(&mut self, _: Note, _: &ActorRef<Self>) {}
+
+    #[handler]
+    async fn handle_query(&mut self, _: Query, _: &ActorRef<Self>) -> u32 {
+        1
+    }
+}
+
+fn spawn_wedged() -> (
+    Arc<Notify>,
+    Arc<Notify>,
+    ActorRef<WedgeActor>,
+    tokio::task::JoinHandle<rsactor::ActorResult<WedgeActor>>,
+) {
+    let entered = Arc::new(Notify::new());
+    let proceed = Arc::new(Notify::new());
+    let (actor_ref, handle) =
+        spawn_with_mailbox_capacity::<WedgeActor>((entered.clone(), proceed.clone()), 16);
+    (entered, proceed, actor_ref, handle)
+}
+
+#[tokio::test]
+async fn tells_discarded_after_stop_are_recorded_and_asks_not_double_counted() {
+    let _serial = serial_lock().lock().await;
+
+    let (entered, proceed, actor_ref, handle) = spawn_wedged();
+
+    // Wedge the actor, queue the stop marker, then queue messages behind it.
+    actor_ref.tell(Block).await.unwrap();
+    entered.notified().await;
+    actor_ref.stop().await;
+    for _ in 0..5 {
+        actor_ref.tell(Note).await.unwrap(); // accepted: sender sees Ok
+    }
+    let asker = actor_ref.clone();
+    let ask_task = tokio::spawn(async move { asker.ask(Query).await });
+    // Let the ask envelope reach the mailbox before measuring.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let before = dead_letter_count();
+    proceed.notify_one();
+
+    let result = handle.await.unwrap();
+    assert!(result.is_completed(), "graceful stop must complete");
+
+    let ask_res = ask_task.await.unwrap();
+    assert!(
+        matches!(ask_res, Err(rsactor::Error::Receive { .. })),
+        "ask queued behind stop must fail with Receive, got {ask_res:?}"
+    );
+
+    let delta = dead_letter_count() - before;
+    assert_eq!(
+        delta, 6,
+        "expected 5 DiscardedAtShutdown tells + 1 caller-side ReplyDropped ask \
+         (no receiver-side double count for the ask)"
+    );
+}
+
+#[tokio::test]
+async fn tells_pending_at_kill_are_recorded() {
+    let _serial = serial_lock().lock().await;
+
+    let (entered, proceed, actor_ref, handle) = spawn_wedged();
+
+    actor_ref.tell(Block).await.unwrap();
+    entered.notified().await;
+    for _ in 0..4 {
+        actor_ref.tell(Note).await.unwrap();
+    }
+
+    let before = dead_letter_count();
+    actor_ref.kill();
+    proceed.notify_one();
+
+    let result = handle.await.unwrap();
+    assert!(result.was_killed());
+
+    let delta = dead_letter_count() - before;
+    assert_eq!(
+        delta, 4,
+        "all tells pending at kill() must be recorded as DiscardedAtShutdown"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// subscribe_idle fails fast once the actor has begun stopping
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct SlowStopActor {
+    entered: Arc<Notify>,
+    proceed: Arc<Notify>,
+}
+
+impl Actor for SlowStopActor {
+    type Args = (Arc<Notify>, Arc<Notify>);
+    type Error = anyhow::Error;
+    type IdleEvent = ();
+
+    async fn on_start(
+        (entered, proceed): Self::Args,
+        _: &ActorRef<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(SlowStopActor { entered, proceed })
+    }
+
+    async fn on_stop(
+        &mut self,
+        _: &rsactor::ActorWeak<Self>,
+        _killed: bool,
+    ) -> Result<(), Self::Error> {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        Ok(())
+    }
+}
+
+#[message_handlers]
+impl SlowStopActor {}
+
+#[tokio::test]
+async fn subscribe_idle_fails_once_stop_began() {
+    let _serial = serial_lock().lock().await;
+
+    let entered = Arc::new(Notify::new());
+    let proceed = Arc::new(Notify::new());
+    let opts = SpawnOptions::new().with_idle();
+    let (actor_ref, handle) =
+        spawn_with_options::<SlowStopActor>((entered.clone(), proceed.clone()), opts);
+
+    actor_ref.stop().await;
+    // on_stop has started: the idle-subscribe channel is closed by then.
+    entered.notified().await;
+
+    let res = actor_ref.subscribe_idle(futures::stream::pending::<()>());
+    assert!(
+        matches!(res, Err(rsactor::Error::Send { .. })),
+        "subscribe_idle during shutdown must fail fast, got {res:?}"
+    );
+
+    proceed.notify_one();
+    handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn subscribe_idle_fails_once_kill_began() {
+    let _serial = serial_lock().lock().await;
+
+    let entered = Arc::new(Notify::new());
+    let proceed = Arc::new(Notify::new());
+    let opts = SpawnOptions::new().with_idle();
+    let (actor_ref, handle) =
+        spawn_with_options::<SlowStopActor>((entered.clone(), proceed.clone()), opts);
+
+    actor_ref.kill();
+    // on_stop has started: the idle-subscribe channel is closed by then.
+    entered.notified().await;
+
+    let res = actor_ref.subscribe_idle(futures::stream::pending::<()>());
+    assert!(
+        matches!(res, Err(rsactor::Error::Send { .. })),
+        "subscribe_idle during kill shutdown must fail fast, got {res:?}"
+    );
+
+    proceed.notify_one();
+    let result = handle.await.unwrap();
+    assert!(result.was_killed());
+}
+
+// ---------------------------------------------------------------------------
+// First signal wins: a kill() arriving after a graceful stop began is not
+// observed — the actor completes the graceful stop with killed = false.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn kill_after_stop_began_keeps_graceful_result() {
+    let _serial = serial_lock().lock().await;
+
+    let entered = Arc::new(Notify::new());
+    let proceed = Arc::new(Notify::new());
+    let (actor_ref, handle) = spawn_with_options::<SlowStopActor>(
+        (entered.clone(), proceed.clone()),
+        SpawnOptions::new(),
+    );
+
+    actor_ref.stop().await;
+    // The actor dequeued StopGracefully and is inside on_stop(killed = false).
+    entered.notified().await;
+
+    // Late kill: enqueued but never observed (first signal wins).
+    actor_ref.kill();
+    proceed.notify_one();
+
+    let result = handle.await.unwrap();
+    assert!(result.is_completed(), "graceful stop must complete");
+    assert!(
+        !result.was_killed(),
+        "a kill() arriving after the graceful stop began must not flip the \
+         result to killed=true (first signal wins)"
+    );
+}

--- a/tests/shutdown_discard_tests.rs
+++ b/tests/shutdown_discard_tests.rs
@@ -197,7 +197,10 @@ async fn subscribe_idle_fails_once_stop_began() {
 
     let res = actor_ref.subscribe_idle(futures::stream::pending::<()>());
     assert!(
-        matches!(res, Err(rsactor::Error::Send { .. })),
+        matches!(
+            res.as_ref().map_err(|e| &e.error),
+            Err(rsactor::Error::Send { .. })
+        ),
         "subscribe_idle during shutdown must fail fast, got {res:?}"
     );
 
@@ -221,7 +224,10 @@ async fn subscribe_idle_fails_once_kill_began() {
 
     let res = actor_ref.subscribe_idle(futures::stream::pending::<()>());
     assert!(
-        matches!(res, Err(rsactor::Error::Send { .. })),
+        matches!(
+            res.as_ref().map_err(|e| &e.error),
+            Err(rsactor::Error::Send { .. })
+        ),
         "subscribe_idle during kill shutdown must fail fast, got {res:?}"
     );
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -416,9 +416,12 @@ async fn test_actor_fail_on_run() {
     );
 
     match result {
-        rsactor::ActorResult::Failed { actor, error, .. } => {
-            assert!(error.to_string().contains("simulated on_idle failure"));
-            if let Some(actor) = actor {
+        rsactor::ActorResult::Failed { failure, .. } => {
+            assert!(failure
+                .error()
+                .to_string()
+                .contains("simulated on_idle failure"));
+            if let Some(actor) = failure.actor() {
                 assert!(*actor.on_start_attempted.lock().await);
                 assert!(*actor.on_run_attempted.lock().await);
                 // on_stop is now called even when on_run fails (for cleanup)
@@ -953,22 +956,19 @@ async fn test_actor_fail_on_stop_during_graceful_stop() {
     assert!(!result.was_killed(), "Actor should not have been killed");
 
     match result {
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             assert_eq!(
-                phase,
+                failure.phase(),
                 rsactor::FailurePhase::OnStop,
                 "Should fail in OnStop phase"
             );
             assert!(!killed, "Should not be marked as killed for graceful stop");
-            assert!(error.to_string().contains("simulated on_stop failure"));
+            assert!(failure
+                .error()
+                .to_string()
+                .contains("simulated on_stop failure"));
 
-            if let Some(actor) = actor {
+            if let Some(actor) = failure.actor() {
                 assert!(
                     *actor.on_start_attempted.lock().await,
                     "on_start should have been called"
@@ -1017,22 +1017,19 @@ async fn test_actor_fail_on_stop_during_kill() {
     assert!(result.was_killed(), "Actor should be marked as killed");
 
     match result {
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             assert_eq!(
-                phase,
+                failure.phase(),
                 rsactor::FailurePhase::OnStop,
                 "Should fail in OnStop phase"
             );
             assert!(killed, "Should be marked as killed for kill operation");
-            assert!(error.to_string().contains("simulated on_stop failure"));
+            assert!(failure
+                .error()
+                .to_string()
+                .contains("simulated on_stop failure"));
 
-            if let Some(actor) = actor {
+            if let Some(actor) = failure.actor() {
                 assert!(
                     *actor.on_start_attempted.lock().await,
                     "on_start should have been called"
@@ -1077,15 +1074,9 @@ async fn test_actor_fail_on_stop_after_on_run_failure() {
     );
 
     match result {
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             assert_eq!(
-                phase,
+                failure.phase(),
                 rsactor::FailurePhase::OnIdleThenOnStop,
                 "Should fail in OnRunThenOnStop phase when both on_run and on_stop fail"
             );
@@ -1094,9 +1085,12 @@ async fn test_actor_fail_on_stop_after_on_run_failure() {
                 "Should not be marked as killed for on_run failure scenario"
             );
             // The error should be from on_run, not on_stop
-            assert!(error.to_string().contains("simulated on_idle failure"));
+            assert!(failure
+                .error()
+                .to_string()
+                .contains("simulated on_idle failure"));
 
-            if let Some(actor) = actor {
+            if let Some(actor) = failure.actor() {
                 assert!(
                     *actor.on_start_attempted.lock().await,
                     "on_start should have been called"
@@ -1142,15 +1136,9 @@ async fn test_actor_on_stop_success_after_on_run_failure() {
     );
 
     match result {
-        rsactor::ActorResult::Failed {
-            actor,
-            error,
-            phase,
-            killed,
-            ..
-        } => {
+        rsactor::ActorResult::Failed { failure, killed } => {
             assert_eq!(
-                phase,
+                failure.phase(),
                 rsactor::FailurePhase::OnIdle,
                 "Should fail in OnRun phase"
             );
@@ -1158,9 +1146,12 @@ async fn test_actor_on_stop_success_after_on_run_failure() {
                 !killed,
                 "Should not be marked as killed for on_run failure scenario"
             );
-            assert!(error.to_string().contains("simulated on_idle failure"));
+            assert!(failure
+                .error()
+                .to_string()
+                .contains("simulated on_idle failure"));
 
-            if let Some(actor) = actor {
+            if let Some(actor) = failure.actor() {
                 assert!(
                     *actor.on_start_attempted.lock().await,
                     "on_start should have been called"


### PR DESCRIPTION
## Summary

Three rounds of verified fixes from a multi-agent source review of `src/` (30 reviewers across 3 perspectives per file, each finding adversarially verified before fixing), a follow-up race audit, and a `review-rust` pass over the fixes themselves.

### Behavioral fixes
- **`blocking_*` on `current_thread` runtimes**: calling from an async context that cannot block now hits tokio's loud "Cannot block the current thread from within a runtime" panic instead of silently freezing the runtime in a kill-proof deadlock (the old slow path parked the runtime's only worker thread). Supported contexts (no runtime, `spawn_blocking` threads, multi-thread workers via `block_in_place`) are unchanged. **Breaking**
- **`blocking_tell`/`blocking_tell_priority`**: lock-free `try_send` hot path skips `block_in_place`'s worker-core handoff when the mailbox has room
- **Dead-letter/`Error::Timeout` operation labels** now always match the public API invoked (`"blocking_tell"`, `"blocking_ask_priority"`, …) instead of varying by execution path. **Breaking**
- **`subscribe_idle`** returns the rejected stream back via the new `IdleSubscribeError` (`take_stream()`/`into_parts()`), so the documented-retryable `ChannelFull` is actually retryable and exclusive sources are never silently destroyed; `From<IdleSubscribeError> for Error` keeps `?` working. **Breaking signature change**
- **Shutdown drain** now runs from a drop guard (`LifecycleChannels`), so handler panics and task aborts still record `DiscardedAtShutdown` dead letters; cancelled-ask envelopes (closed reply channel) are recorded too; drain is double-panic-safe during unwind
- **deadlock-detection**: ask edges are claimed and physically removed under the graph lock, closing a stale-edge window that produced phantom-cycle panics on healthy systems; cheap lock-free no-op for the second owner preserved
- **`ActorWeak::is_alive`/`upgrade`** detect fully stopped actors via channel closure (previously reported alive forever while any strong ref lingered); new `ActorWeak::metrics()` enables the documented post-mortem metrics access
- **`SpawnOptions::with_idle_capacity(n)`** makes the idle-subscribe buffer configurable (docs previously advised raising a non-configurable const)
- **Metrics**: `on_idle` work is now visible (`idle_event_count`, avg/max idle processing time, `last_activity`); idle-driven actors no longer look permanently inactive

### Documentation corrections
`kill()` vs hung `on_start`, strong self-`ActorRef` keep-alive cycle in `on_start`, `ChannelFull` in-actor retry livelock, ask-timeout dead letters not implying non-delivery, `ActorControl::stop`/`kill` contracts, supervision example missing `is_stop_failed()` arm, `blocking_*` execution-path/panic sections, time-driver requirement for priority-enabled actors.

## Test plan
- `cargo test --all-features` (432 tests) and default-feature suite: all green
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo doc --no-deps --all-features`: no warnings
- New behaviors verified by standalone probes (current_thread panic restoration, canary guard context matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)