### PR TITLE
fix!: align documented contracts with implementation from source review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+A follow-up review pass over `src/`. Almost every finding was a documentation
+contract that disagreed with the implementation — this crate specifies panic
+conditions, deadlock-vs-stall semantics and dead-letter labels in rustdoc, and
+none of that is checked by `fmt`/`clippy`/`rustdoc`/tests. Two enums gain
+`#[non_exhaustive]`; the rest is prose brought back in line with the code, plus
+one internal type change that makes a doc promise compiler-enforced.
+
+### ⚠️ BREAKING CHANGES
+
+- **`FailurePhase` and `ActorFailure` are now `#[non_exhaustive]`.** A match in
+  a downstream crate must add a `_` arm. This lets a future release report a new
+  lifecycle phase without a breaking change. Note the attribute is applied at the
+  *enum* level only: unlike `Error`, these variants stay externally constructible
+  so downstream tests can still build an `ActorResult` by hand.
+- **`Error::Join`'s `Display` no longer embeds its own source.** It now reads
+  `Failed to join spawned task from actor Worker(#3)`; the `JoinError` (and the
+  panic message inside it) is reachable only through `source()`. A `Display` that
+  repeats its source makes chain-walking reporters print it twice. Code that
+  logged `{err}` and relied on seeing the panic text must walk the chain — see
+  the updated example on `Error::debugging_tips`.
+- **`Operation`, `Channel` and `FailurePhase` `Display` now honor format
+  specifiers.** They pad and align as expected (`{:>24}`), but a *precision*
+  now truncates (`{:.10}` renders both `BlockingAsk` and `BlockingAskPriority`
+  as `blocking_a`). Use `as_str()` where an unabridged label is required.
+
+### Added
+
+- **`FailurePhase::as_str()`** — the stable label, replacing the previous
+  delegation to the derived `Debug` as the single source of truth.
+
+### Changed
+
+- `Cargo.toml` now sets `exclude`, so developer tooling and working notes
+  (`plan/`, `book/`, `skills/`, `.github/`, `.claude/`, `.vscode/`) no longer
+  ship in the published `.crate`.
+- The dead-letter recorder takes a typed `Operation` instead of a `&'static str`,
+  so the emitted label and `Error::Timeout`'s operation can no longer drift.
+  Internal only — `record` is `pub(crate)`.
+
+### Fixed
+
+- **`ask` / `ask_with_timeout` documented no self-ask hazard at all**, while
+  every sibling API did. A self-`ask` deadlocks even on an empty mailbox (the
+  runtime loop that would produce the reply is parked awaiting the caller), and
+  panics under `deadlock-detection` — neither was documented. `ask_with_timeout`
+  is a bounded stall rather than a deadlock, and it can panic on a runtime built
+  without a time driver; both are now stated.
+- **`blocking_ask` and `blocking_ask_priority` rendered their `# Panics` twice**,
+  with the two copies contradicting each other, and one copy claimed
+  `blocking_ask(msg, None)` panics on a timerless runtime (it does not — the
+  timeout-less path never arms a timer).
+- **`blocking_*` panic conditions are now single-sourced** via
+  `include_str!`, having drifted across three of the six methods. The shared text
+  distinguishes a bounded stall (mandatory `timeout`) from an unbounded hang
+  (`timeout: None`), which the unified wording had previously flattened.
+- **`Actor::on_stop`'s contract was wrong**: a message handler returning `Err`
+  does *not* terminate the actor, so `on_stop` still runs. Task cancellation,
+  which does skip `on_stop`, was missing from the list.
+- **The dead-letter `operation` contract ignored the shutdown drain**, which
+  cannot know the sending API and records `"tell"`/`"ask"` for everything —
+  including messages enqueued by `blocking_tell`.
+- **`register_ask_edge` claimed no cycle can form outside an actor context.** It
+  is a detection blind spot, not a proof: `tokio::spawn`, `spawn_blocking` (the
+  pattern `blocking_ask` itself recommends) and hand-rolled threads do not
+  inherit the task-local, so even a self-`ask` from there hangs silently.
+- **`MetricsCollector` reported an active actor as idle** when the wall clock sat
+  at or before `UNIX_EPOCH`: `0` doubled as the "no activity yet" sentinel.
+  Timestamps are now stored biased by one, keeping the type's all-`Relaxed`
+  contract intact.
+- The `ActorResult` supervision example discarded the `on_stop` cleanup error and
+  restarted the actor, because `is_runtime_failed()` matches the composite
+  `OnIdleThenOnStop` phase before `is_stop_failed()` can see it.
+- `BoxFuture`'s rationale claimed it keeps `futures` out of the public API;
+  `subscribe_idle` and `IdleSubscribeError` already expose `futures` types, so a
+  semver-breaking `futures` release is breaking for this crate too.
+- `error_display_all_variants` asserted only that messages were non-empty, and
+  skipped `PriorityChannelNotEnabled`/`IdleChannelNotEnabled` entirely — two
+  near-identical messages where a copy-paste swap was undetectable.
+
 ## [0.18.0] - 2026-07-11
 
 A focused API-hardening follow-up from a second source-review pass. It

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,18 @@ homepage.workspace = true
 license.workspace = true
 readme.workspace = true
 keywords.workspace = true
+# Keep the published .crate to the library and its reference docs. These are
+# developer tooling / scratch space and would otherwise ship to crates.io —
+# `plan/` in particular is working notes, not documentation.
+# NOTE: `src/doc/` must stay included; `include_str!` pulls it into rustdoc.
+exclude = [
+    "/.claude",
+    "/.github",
+    "/.vscode",
+    "/book",
+    "/plan",
+    "/skills",
+]
 
 [features]
 default = []

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -67,8 +67,8 @@ fn discard_queued_messages<T: Actor>(
     fn drain_one<T: Actor>(
         actor_id: crate::Identity,
         rx: &mut mpsc::Receiver<MailboxMessage<T>>,
-        tell_op: &'static str,
-        ask_op: &'static str,
+        tell_op: crate::Operation,
+        ask_op: crate::Operation,
     ) {
         rx.close();
         while let Ok(msg) = rx.try_recv() {
@@ -95,9 +95,19 @@ fn discard_queued_messages<T: Actor>(
         }
     }
 
-    drain_one(actor_id, receiver, "tell", "ask");
+    drain_one(
+        actor_id,
+        receiver,
+        crate::Operation::Tell,
+        crate::Operation::Ask,
+    );
     if let Some(rx) = priority_receiver {
-        drain_one(actor_id, rx, "tell_priority", "ask_priority");
+        drain_one(
+            actor_id,
+            rx,
+            crate::Operation::TellPriority,
+            crate::Operation::AskPriority,
+        );
     }
     if let Some(rx) = idle_subscribe_receiver {
         rx.close();
@@ -495,7 +505,19 @@ pub trait Actor: Sized + Send + 'static {
     ///   dropped (treated as graceful termination, so `killed = false`)
     /// - Cleanup after an [`on_idle`](Actor::on_idle) error
     ///
-    /// It is **not** called if the actor fails during message processing (handler panic/error).
+    /// It is **not** called when the actor task unwinds out of a message handler or
+    /// lifecycle hook (a panic), nor when the task itself is cancelled
+    /// ([`JoinHandle::abort`](tokio::task::JoinHandle::abort), runtime shutdown) and the
+    /// future is dropped at an `.await`.
+    ///
+    /// A **message** handler that merely *returns* `Err` does **not** terminate the
+    /// actor: the error is surfaced through the `ask` reply, or through
+    /// [`Message::on_tell_result`](crate::Message::on_tell_result) for a `tell`, and the
+    /// runtime loop continues to the next message — so `on_stop` still runs at the
+    /// eventual stop/kill. This does **not** extend to
+    /// [`on_idle`](Actor::on_idle), whose `Err` does stop the actor (and then runs
+    /// `on_stop`, reported as [`FailurePhase::OnIdle`](crate::FailurePhase::OnIdle)).
+    ///
     /// The result of this method affects the final [`ActorResult`](crate::ActorResult) returned when awaiting the join handle.
     ///
     /// The `killed` parameter indicates how the actor is being stopped:

--- a/src/actor_ref.rs
+++ b/src/actor_ref.rs
@@ -577,7 +577,7 @@ impl<T: Actor> ActorRef<T> {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "tell",
+                Operation::Tell,
             );
             Err(Error::Send {
                 identity: self.identity(),
@@ -655,7 +655,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    "tell",
+                    Operation::Tell,
                 );
                 Error::Timeout {
                     identity: self.identity(),
@@ -679,6 +679,24 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// Type safety: The return type `R` is automatically inferred from the [`Message<M>`] trait
     /// implementation, ensuring compile-time type safety for replies.
+    ///
+    /// # Deadlock warning (self-ask)
+    ///
+    /// Calling this on the actor's **own** `ActorRef` from inside one of its
+    /// handlers or lifecycle hooks is an unrecoverable deadlock — and unlike a
+    /// self-[`tell`](Self::tell), which only deadlocks on a *full* mailbox,
+    /// this one deadlocks **even when the mailbox is empty**. The envelope is
+    /// admitted fine, but the only thing that could dequeue it and produce the
+    /// reply is the actor's runtime loop, which is parked awaiting the very
+    /// handler making this call. [`kill`](Self::kill) cannot interrupt it
+    /// either: the terminate signal is only polled once control returns to that
+    /// loop. Use [`tell`](Self::tell), or send from a spawned task.
+    ///
+    /// # Panics
+    ///
+    /// With the `deadlock-detection` feature enabled, a self-ask (and any
+    /// `ask` cycle that routes back into the calling actor) panics immediately
+    /// instead of hanging. Without the feature this method never panics.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_ask",
@@ -708,11 +726,6 @@ impl<T: Actor> ActorRef<T> {
         M: Send + 'static,
         T::Reply: Send + 'static,
     {
-        // `operation` only labels the deadlock-detection edge and dead-letter
-        // records here (this helper never builds `Error::Timeout`), so reduce
-        // it to its string form once.
-        let operation = operation.as_str();
-
         // Deadlock detection: register this `ask` as a wait-for edge and hold
         // the guard until the reply is received (or this future is dropped).
         // Panics if it would close an ask cycle. The envelope carries a token
@@ -720,7 +733,7 @@ impl<T: Actor> ActorRef<T> {
         // waiting for this future to resume would leave a stale-edge window
         // that produces false-positive cycle panics.
         #[cfg(feature = "deadlock-detection")]
-        let _guard = crate::register_ask_edge(self.identity(), operation);
+        let _guard = crate::register_ask_edge(self.identity(), operation.as_str());
         #[cfg(feature = "deadlock-detection")]
         let ask_edge = _guard.as_ref().map(|g| g.token());
         #[cfg(not(feature = "deadlock-detection"))]
@@ -793,6 +806,36 @@ impl<T: Actor> ActorRef<T> {
     /// The message is sent to the actor's mailbox, and this method will wait for
     /// the actor to process the message and send a reply, or timeout if the reply
     /// doesn't arrive within the specified duration.
+    ///
+    /// # Self-ask stalls for the whole timeout
+    ///
+    /// Calling this on the actor's **own** `ActorRef` from inside one of its
+    /// handlers or lifecycle hooks wedges the actor for the entire `timeout` —
+    /// and unlike a self-[`tell_with_timeout`](Self::tell_with_timeout), which
+    /// only stalls on a *full* mailbox, this one stalls **even when the mailbox
+    /// is empty**. The envelope is admitted fine, but the only thing that could
+    /// dequeue it and produce the reply is the actor's runtime loop, which is
+    /// parked awaiting the very handler making this call, so nothing can make
+    /// progress until the deadline elapses. [`kill`](Self::kill) is likewise
+    /// only observed once control returns to that loop.
+    ///
+    /// Unlike a plain self-[`ask`](Self::ask) this is *not* a deadlock: the
+    /// deadline fires, the handler gets [`Error::Timeout`] and returns, and the
+    /// loop resumes — matching how [`tell_with_timeout`](Self::tell_with_timeout)
+    /// treats a bounded self-send. Prefer
+    /// [`tell_with_timeout`](Self::tell_with_timeout), or send from a spawned
+    /// task, to avoid the stall entirely.
+    ///
+    /// # Panics
+    ///
+    /// - With the `deadlock-detection` feature enabled, a self-ask (and any
+    ///   `ask` cycle that routes back into the calling actor) panics
+    ///   immediately instead of stalling.
+    /// - Independently of that feature, when the current runtime was built
+    ///   **without a time driver** (no `enable_time()` / `enable_all()`):
+    ///   this method arms a [`tokio::time::timeout`], which panics when no
+    ///   timer is available. Spawning and driving actors does not itself
+    ///   require the time driver, so a runtime can reach this call without one.
     #[cfg_attr(feature = "tracing", tracing::instrument(
         level = "debug",
         name = "actor_ask_with_timeout",
@@ -838,7 +881,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    operation.as_str(),
+                    operation,
                 );
                 Error::Timeout {
                     identity: self.identity(),
@@ -916,7 +959,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "tell_priority",
+                    Operation::TellPriority,
                 );
                 Err(Error::Send {
                     identity: self.identity(),
@@ -927,7 +970,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    "tell_priority",
+                    Operation::TellPriority,
                 );
                 Err(Error::Timeout {
                     identity: self.identity(),
@@ -1007,17 +1050,13 @@ impl<T: Actor> ActorRef<T> {
             });
         };
 
-        // String label for the deadlock-detection edge and dead-letter records;
-        // the typed `operation` is kept for the `Error::Timeout` below.
-        let operation_label = operation.as_str();
-
         // Deadlock detection: a priority ask still parks the calling actor's
         // message loop while it awaits the reply, so a cycle through the priority
         // channel stalls just like a regular `ask` (here bounded by `timeout`).
         // Register the edge before sending and hold the guard across the wait so
         // the cycle is detected immediately instead of only timing out.
         #[cfg(feature = "deadlock-detection")]
-        let _guard = crate::register_ask_edge(self.identity(), operation_label);
+        let _guard = crate::register_ask_edge(self.identity(), operation.as_str());
         #[cfg(feature = "deadlock-detection")]
         let ask_edge = _guard.as_ref().map(|g| g.token());
         #[cfg(not(feature = "deadlock-detection"))]
@@ -1036,7 +1075,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    operation_label,
+                    operation,
                 );
                 return Err(Error::Send {
                     identity: self.identity(),
@@ -1056,7 +1095,7 @@ impl<T: Actor> ActorRef<T> {
                     crate::dead_letter::record::<M>(
                         self.identity(),
                         crate::dead_letter::DeadLetterReason::ReplyDropped,
-                        operation_label,
+                        operation,
                     );
                     Err(Error::Receive {
                         identity: self.identity(),
@@ -1073,7 +1112,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::Timeout,
-                    operation_label,
+                    operation,
                 );
                 Err(Error::Timeout {
                     identity: self.identity(),
@@ -1112,26 +1151,10 @@ impl<T: Actor> ActorRef<T> {
     /// # Panics
     ///
     /// The conditions below require a full priority slot — the `try_send`
-    /// hot path never blocks, so it never panics.
+    /// hot path never blocks, so it never panics. The async counterpart is
+    /// [`tell_priority`](Self::tell_priority).
     ///
-    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    ///   running on a multi-thread runtime: the runtime handle reports
-    ///   multi-thread flavor, but `block_in_place` is not permitted there.
-    /// - When called from an async context that `block_in_place` cannot
-    ///   rescue — a task on a `current_thread` runtime, or any thread driving
-    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
-    ///   (a *multi-thread* runtime's `block_on` driver takes the
-    ///   `block_in_place` path and is fine) — this panics with Tokio's
-    ///   "Cannot block the current thread from within a runtime". Parking such
-    ///   a thread would starve every actor on that runtime for the full
-    ///   timeout; the loud panic surfaces the bug instead. Call from a
-    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
-    ///   async [`tell_priority`](Self::tell_priority), instead.
-    /// - When the caller's own multi-thread runtime was built **without a time
-    ///   driver** (no `enable_time()` / `enable_all()`): the fast path awaits
-    ///   the admission timeout on that runtime, so `tokio::time::timeout`
-    ///   panics because no timer is available. The slow-path temporary runtime
-    ///   always enables timers, so only the caller's own runtime is affected.
+    #[doc = include_str!("doc/blocking_panics.md")]
     ///
     /// # Deadlock warning
     ///
@@ -1172,7 +1195,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "blocking_tell_priority",
+                    Operation::BlockingTellPriority,
                 );
                 warn!("Failed to send blocking priority tell: priority channel closed");
                 return Err(Error::Send {
@@ -1196,7 +1219,7 @@ impl<T: Actor> ActorRef<T> {
                     crate::dead_letter::record::<M>(
                         identity,
                         crate::dead_letter::DeadLetterReason::ActorStopped,
-                        "blocking_tell_priority",
+                        Operation::BlockingTellPriority,
                     );
                     warn!("Failed to send blocking priority tell: priority channel closed");
                     Err(Error::Send {
@@ -1208,7 +1231,7 @@ impl<T: Actor> ActorRef<T> {
                     crate::dead_letter::record::<M>(
                         identity,
                         crate::dead_letter::DeadLetterReason::Timeout,
-                        "blocking_tell_priority",
+                        Operation::BlockingTellPriority,
                     );
                     warn!(
                         timeout_ms = timeout.as_millis(),
@@ -1261,19 +1284,12 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Panics
     ///
-    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    ///   running on a multi-thread runtime: the runtime handle reports
-    ///   multi-thread flavor, but `block_in_place` is not permitted there.
-    /// - When called from an async context that `block_in_place` cannot
-    ///   rescue — a task on a `current_thread` runtime, or any thread driving
-    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
-    ///   (a *multi-thread* runtime's `block_on` driver takes the
-    ///   `block_in_place` path and is fine) — this panics with Tokio's
-    ///   "Cannot block the current thread from within a runtime". Parking such
-    ///   a thread would starve every actor on that runtime for the full
-    ///   timeout; the loud panic surfaces the bug instead. Call from a
-    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
-    ///   async [`ask_priority`](Self::ask_priority), instead.
+    /// These apply even when the priority slot has room — unlike the `tell`
+    /// family there is no non-blocking fast path, because the reply must always
+    /// be awaited. The async counterpart is
+    /// [`ask_priority`](Self::ask_priority).
+    ///
+    #[doc = include_str!("doc/blocking_panics.md")]
     ///
     /// # Deadlock warning
     ///
@@ -1479,29 +1495,10 @@ impl<T: Actor> ActorRef<T> {
     /// # Panics
     ///
     /// The conditions below require a full mailbox — the `try_send` hot path
-    /// never blocks, so it never panics.
+    /// never blocks, so it never panics. The async counterpart is
+    /// [`tell`](Self::tell).
     ///
-    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    ///   running on a multi-thread runtime: the runtime handle reports
-    ///   multi-thread flavor, but `block_in_place` is not permitted there.
-    /// - When called from an async context that `block_in_place` cannot
-    ///   rescue — a task on a `current_thread` runtime, or any thread driving
-    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
-    ///   (a *multi-thread* runtime's `block_on` driver takes the
-    ///   `block_in_place` path and is fine) — this panics with Tokio's
-    ///   "Cannot block the current thread from within a runtime". Parking such
-    ///   a thread would freeze the only thread able to drive the target actor,
-    ///   turning the call into a silent deadlock of every actor on that
-    ///   runtime that not even `kill()` could break; the loud panic surfaces
-    ///   the bug instead. Call from a
-    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
-    ///   async [`tell`](Self::tell), instead.
-    /// - When a timeout is supplied and the caller's own multi-thread runtime
-    ///   was built **without a time driver** (no `enable_time()` /
-    ///   `enable_all()`): the fast path awaits the admission timeout on that
-    ///   runtime, so `tokio::time::timeout` panics because no timer is
-    ///   available. The timeout-less path and the slow-path temporary runtime
-    ///   are unaffected.
+    #[doc = include_str!("doc/blocking_panics.md")]
     ///
     /// # Deadlock warning
     ///
@@ -1552,7 +1549,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ActorStopped,
-                    "blocking_tell",
+                    Operation::BlockingTell,
                 );
                 warn!("Failed to send blocking tell message: mailbox channel closed");
                 return Err(Error::Send {
@@ -1586,7 +1583,7 @@ impl<T: Actor> ActorRef<T> {
                             crate::dead_letter::record::<M>(
                                 identity,
                                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                                "blocking_tell",
+                                Operation::BlockingTell,
                             );
                             warn!("Failed to send blocking tell message: mailbox channel closed");
                             Err(Error::Send {
@@ -1598,7 +1595,7 @@ impl<T: Actor> ActorRef<T> {
                             crate::dead_letter::record::<M>(
                                 identity,
                                 crate::dead_letter::DeadLetterReason::Timeout,
-                                "blocking_tell",
+                                Operation::BlockingTell,
                             );
                             warn!(
                                 timeout_ms = timeout.as_millis(),
@@ -1631,7 +1628,7 @@ impl<T: Actor> ActorRef<T> {
                             crate::dead_letter::record::<M>(
                                 identity,
                                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                                "blocking_tell",
+                                Operation::BlockingTell,
                             );
                             warn!("Failed to send blocking tell message: mailbox channel closed");
                             Error::Send {
@@ -1654,7 +1651,7 @@ impl<T: Actor> ActorRef<T> {
                     crate::dead_letter::record::<M>(
                         identity,
                         crate::dead_letter::DeadLetterReason::ActorStopped,
-                        "blocking_tell",
+                        Operation::BlockingTell,
                     );
                     Error::Send {
                         identity,
@@ -1711,26 +1708,11 @@ impl<T: Actor> ActorRef<T> {
     ///
     /// # Panics
     ///
-    /// - When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
-    ///   running on a multi-thread runtime: the runtime handle reports
-    ///   multi-thread flavor, but `block_in_place` is not permitted there.
-    /// - When called from an async context that `block_in_place` cannot
-    ///   rescue — a task on a `current_thread` runtime, or any thread driving
-    ///   a `current_thread` runtime's `Runtime::block_on`/`Handle::block_on`
-    ///   (a *multi-thread* runtime's `block_on` driver takes the
-    ///   `block_in_place` path and is fine) — this panics with Tokio's
-    ///   "Cannot block the current thread from within a runtime". Parking such
-    ///   a thread would freeze the only thread able to drive the target actor,
-    ///   turning the call into a silent deadlock of every actor on that
-    ///   runtime that not even `kill()` could break; the loud panic surfaces
-    ///   the bug instead. Call from a
-    ///   [`spawn_blocking`](tokio::task::spawn_blocking) thread, or use the
-    ///   async [`ask`](Self::ask), instead.
-    /// - When the caller's own multi-thread runtime was built **without a time
-    ///   driver** (no `enable_time()` / `enable_all()`): the fast path awaits
-    ///   the admission timeout on that runtime, so `tokio::time::timeout`
-    ///   panics because no timer is available. The slow-path temporary runtime
-    ///   always enables timers, so only the caller's own runtime is affected.
+    /// These apply even when the mailbox has room — unlike the `tell` family
+    /// there is no non-blocking fast path, because the reply must always be
+    /// awaited. The async counterpart is [`ask`](Self::ask).
+    ///
+    #[doc = include_str!("doc/blocking_panics.md")]
     ///
     /// # Deadlock warning
     ///
@@ -1807,7 +1789,7 @@ impl<T: Actor> ActorRef<T> {
             crate::dead_letter::record::<M>(
                 self.identity(),
                 crate::dead_letter::DeadLetterReason::ActorStopped,
-                "blocking_ask",
+                Operation::BlockingAsk,
             );
 
             warn!("Failed to send blocking ask message: mailbox channel closed");
@@ -1842,7 +1824,7 @@ impl<T: Actor> ActorRef<T> {
                 crate::dead_letter::record::<M>(
                     self.identity(),
                     crate::dead_letter::DeadLetterReason::ReplyDropped,
-                    "blocking_ask",
+                    Operation::BlockingAsk,
                 );
 
                 warn!("Blocking ask reply channel closed unexpectedly");

--- a/src/actor_result.rs
+++ b/src/actor_result.rs
@@ -9,7 +9,11 @@ use std::fmt::Debug;
 /// This enum is used to identify which lifecycle method of an actor
 /// caused a failure, enabling more precise error handling and debugging.
 /// Each phase corresponds to a specific method in the [`Actor`](crate::Actor) trait.
+///
+/// Marked `#[non_exhaustive]` so a future lifecycle phase can be reported
+/// without breaking exhaustive matches — include a `_` arm when matching.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FailurePhase {
     /// Actor failed during the [`on_start`](crate::Actor::on_start) lifecycle hook.
     OnStart,
@@ -24,13 +28,28 @@ pub enum FailurePhase {
     OnIdleThenOnStop,
 }
 
+impl FailurePhase {
+    /// Returns the stable string label for this phase (e.g. `"OnStart"`).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            FailurePhase::OnStart => "OnStart",
+            FailurePhase::OnIdle => "OnIdle",
+            FailurePhase::OnStop => "OnStop",
+            FailurePhase::OnIdleThenOnStop => "OnIdleThenOnStop",
+        }
+    }
+}
+
 /// Implements Display for FailurePhase to provide human-readable error messages.
 ///
-/// The human-readable form is the variant name, so this delegates to the
-/// derived `Debug` impl — one source of truth when variants are added.
+/// Goes through [`Formatter::pad`](std::fmt::Formatter::pad) rather than
+/// delegating to `Debug`: the derived `Debug` writes unit variants with
+/// `write_str`, which silently ignores width/alignment/fill specifiers, so
+/// `{:>20}` on a phase would not pad.
 impl std::fmt::Display for FailurePhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
+        f.pad(self.as_str())
     }
 }
 
@@ -48,7 +67,12 @@ impl std::fmt::Display for FailurePhase {
 /// Use the accessors ([`phase`](Self::phase), [`error`](Self::error),
 /// [`actor`](Self::actor), [`stop_error`](Self::stop_error)) for uniform access
 /// across variants, or match directly when handling a specific phase.
+///
+/// Marked `#[non_exhaustive]` (like [`FailurePhase`]) so a future lifecycle
+/// phase can be reported without breaking exhaustive matches — prefer the
+/// accessors above, or include a `_` arm when matching.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ActorFailure<T: Actor> {
     /// [`on_start`](crate::Actor::on_start) returned an error; the actor was
     /// never constructed, so no instance is available.
@@ -228,6 +252,15 @@ impl<T: Actor> ActorFailure<T> {
 ///         // Actor failed to start - may need different initialization
 ///         eprintln!("Startup failed, checking configuration...");
 ///     }
+///     result if result.is_cleanup_failed() => {
+///         // on_idle failed AND the on_stop cleanup then failed too. Handled
+///         // before is_runtime_failed(), which also matches this phase and
+///         // would otherwise restart the actor while discarding the cleanup
+///         // error - leaving resources (flushes, connections, files) unreleased
+///         // with no warning.
+///         eprintln!("Runtime failure: {}", result.error().unwrap());
+///         eprintln!("Cleanup also failed: {}", result.secondary_error().unwrap());
+///     }
 ///     result if result.is_runtime_failed() => {
 ///         // Runtime failure - restart the actor
 ///         if let Some(actor) = result.into_actor() {
@@ -236,8 +269,8 @@ impl<T: Actor> ActorFailure<T> {
 ///         }
 ///     }
 ///     result if result.is_stop_failed() => {
-///         // Stopped (or killed), but on_stop cleanup failed - resources may
-///         // not have been released (flushes, connections, files)
+///         // Only `OnStop` reaches here - `OnIdleThenOnStop` is handled above -
+///         // so `error()` is the on_stop cleanup error.
 ///         eprintln!("Cleanup failed: {}", result.error().unwrap());
 ///     }
 ///     result if result.was_killed() => {
@@ -584,6 +617,52 @@ impl<T: Actor> ActorResult<T> {
                 | ActorFailure::OnStop { actor, error }
                 | ActorFailure::OnIdleThenOnStop { actor, error, .. } => (Some(actor), Some(error)),
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_phase_display_honors_format_specifiers() {
+        // Delegating to the derived `Debug` wrote unit variants via
+        // `Formatter::write_str`, which silently ignores width/alignment/fill.
+        // `Display` now pads, so phases line up in tabular log output.
+        assert_eq!(format!("{}", FailurePhase::OnStart), "OnStart");
+        assert_eq!(format!("{:>10}|", FailurePhase::OnStart), "   OnStart|");
+        assert_eq!(format!("{:<10}|", FailurePhase::OnStart), "OnStart   |");
+        assert_eq!(
+            format!("{:>20}|", FailurePhase::OnIdleThenOnStop),
+            "    OnIdleThenOnStop|"
+        );
+    }
+
+    #[test]
+    fn failure_phase_as_str_matches_debug() {
+        // Tripwire: adding a variant breaks this match, forcing the array
+        // below to grow. Without it a new variant with a typo'd label would
+        // slip through, since the array is hand-written.
+        fn _all_covered(p: FailurePhase) {
+            match p {
+                FailurePhase::OnStart
+                | FailurePhase::OnIdle
+                | FailurePhase::OnStop
+                | FailurePhase::OnIdleThenOnStop => {}
+            }
+        }
+
+        // `as_str` replaced the `Debug` delegation as the source of truth for
+        // the human-readable name; keep the two spellings in lockstep.
+        for phase in [
+            FailurePhase::OnStart,
+            FailurePhase::OnIdle,
+            FailurePhase::OnStop,
+            FailurePhase::OnIdleThenOnStop,
+        ] {
+            assert_eq!(phase.as_str(), format!("{phase:?}"));
+            assert_eq!(phase.to_string(), format!("{phase:?}"));
         }
     }
 }

--- a/src/dead_letter.rs
+++ b/src/dead_letter.rs
@@ -96,7 +96,7 @@
 //!
 //! For production observability, rely on the structured `tracing::warn!` logs instead.
 
-use crate::Identity;
+use crate::{Identity, Operation};
 
 #[cfg(any(test, feature = "test-utils"))]
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -180,10 +180,30 @@ impl std::fmt::Display for DeadLetterReason {
 ///
 /// * `identity` - The identity of the actor that failed to receive the message
 /// * `reason` - Why the message became a dead letter
-/// * `operation` - The logical operation that failed ("tell", "ask",
-///   "tell_priority", "ask_priority"). Blocking variants record the same
-///   label as their async counterparts so the same call site aggregates to
-///   one operation regardless of which execution path it took.
+/// * `operation` - Which operation the record is attributed to. Logged as
+///   [`Operation::as_str`](crate::Operation::as_str), so the emitted label and
+///   the [`Error::Timeout`](crate::Error::Timeout) variant can never drift.
+///
+///   **Caller-side records** ([`DeadLetterReason::ActorStopped`],
+///   [`DeadLetterReason::Timeout`], [`DeadLetterReason::ReplyDropped`]) name
+///   the exact public API that failed, so the `blocking_*` variants keep their
+///   own labels instead of folding into their async counterparts and a
+///   dashboard can tell a blocking call site from an async one; a query that
+///   wants both must match either spelling. The `*_with_timeout` methods carry
+///   no separate label — they aggregate under their base operation
+///   (`tell_with_timeout` records [`Operation::Tell`](crate::Operation::Tell)),
+///   because the deadline is a parameter of the same API, not a different one.
+///
+///   **Receiver-side [`DeadLetterReason::DiscardedAtShutdown`] records are the
+///   exception.** The shutdown drain runs after the sender is long gone and
+///   sees only which mailbox the envelope sat in and whether it carried a reply
+///   channel, so it can only report [`Operation::Tell`](crate::Operation::Tell) /
+///   [`Operation::Ask`](crate::Operation::Ask) for the regular mailbox and
+///   [`Operation::TellPriority`](crate::Operation::TellPriority) /
+///   [`Operation::AskPriority`](crate::Operation::AskPriority) for the priority
+///   channel. A message enqueued by `blocking_tell` is recorded as
+///   `"tell"` there — filtering shutdown records by a `blocking_*` label finds
+///   nothing.
 ///
 /// # Type Parameters
 ///
@@ -195,7 +215,7 @@ impl std::fmt::Display for DeadLetterReason {
 /// The `#[cold]` attribute hints to the compiler that this function is rarely
 /// called, allowing better optimization of the hot path (successful message delivery).
 #[cold]
-pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation: &'static str) {
+pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation: Operation) {
     record_erased(identity, reason, operation, std::any::type_name::<M>());
 }
 
@@ -207,7 +227,7 @@ pub(crate) fn record<M>(identity: Identity, reason: DeadLetterReason, operation:
 pub(crate) fn record_erased(
     identity: Identity,
     reason: DeadLetterReason,
-    operation: &'static str,
+    operation: Operation,
     message_type: &'static str,
 ) {
     #[cfg(any(test, feature = "test-utils"))]
@@ -219,7 +239,7 @@ pub(crate) fn record_erased(
         actor.type_name = identity.name(),
         message.type_name = message_type,
         dead_letter.reason = %reason,
-        dead_letter.operation = operation,
+        dead_letter.operation = operation.as_str(),
         "Dead letter: message could not be delivered"
     );
 }

--- a/src/deadlock.rs
+++ b/src/deadlock.rs
@@ -174,8 +174,22 @@ fn remove_edge(graph: &mut HashMap<u64, Vec<Identity>>, caller: u64, callee_id: 
 /// returns a guard that removes it on drop.
 ///
 /// Panics (the documented deadlock-detection behavior) if adding the edge would
-/// close a cycle. Returns `None` when called outside an actor context — there is
-/// no current actor to attribute the wait to, so no cycle can form through it.
+/// close a cycle.
+///
+/// Returns `None` when called outside an actor context — there is no current
+/// actor to attribute the wait to, so the edge cannot be placed in the graph.
+/// This includes any code that runs *off* the actor's task, because tokio
+/// task-locals are not inherited: a task created by `tokio::spawn` inside a
+/// handler, a [`tokio::task::spawn_blocking`] closure (including the
+/// `blocking_ask` pattern that
+/// [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask) itself recommends),
+/// and any hand-rolled thread. In all of them [`CURRENT_ACTOR`] is unset, so
+/// even an `ask` an actor makes to *itself* from there hangs silently instead of
+/// panicking.
+///
+/// Such an `ask` is left untracked, which is a known **detection blind spot**,
+/// not a proof that no cycle exists. See `docs/deadlock_detection.md`
+/// ("Limitations").
 #[must_use = "dropping the guard immediately removes the wait-for edge, disabling detection for this ask"]
 pub(crate) fn register_ask_edge(callee: Identity, operation: &str) -> Option<WaitForGuard> {
     let caller = CURRENT_ACTOR.try_with(|id| *id).ok()?;

--- a/src/doc/blocking_panics.md
+++ b/src/doc/blocking_panics.md
@@ -1,0 +1,21 @@
+- When called from inside a [`LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html)
+  running on a multi-thread runtime: the runtime handle reports multi-thread
+  flavor, but `block_in_place` is not permitted there.
+- When called from an async context that `block_in_place` cannot rescue — a
+  task on a `current_thread` runtime, or any thread driving a `current_thread`
+  runtime's `Runtime::block_on`/`Handle::block_on` (a *multi-thread* runtime's
+  `block_on` driver takes the `block_in_place` path and is fine) — this panics
+  with Tokio's "Cannot block the current thread from within a runtime".
+  Parking such a thread would freeze its runtime, starving every actor on it:
+  for the full timeout where one is in play, and forever where there is none —
+  a silent hang that not even `kill()` could break. The loud panic surfaces the
+  bug instead. Call from a [`spawn_blocking`](tokio::task::spawn_blocking)
+  thread, or use this method's async counterpart, instead.
+- When a timeout is in play and the caller's own multi-thread runtime was built
+  **without a time driver** (no `enable_time()` / `enable_all()`): the
+  `block_in_place` path awaits the timeout on that runtime, so
+  `tokio::time::timeout` panics because no timer is available. The slow-path
+  temporary runtime always enables timers, so only the caller's own runtime is
+  affected. On the two methods whose `timeout` is optional
+  (`blocking_tell`/`blocking_ask`), passing `None` avoids this condition
+  entirely; the `*_priority` methods always take a deadline.

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,8 +53,14 @@ impl Operation {
 }
 
 impl std::fmt::Display for Operation {
+    /// Uses [`Formatter::pad`](std::fmt::Formatter::pad) rather than `write_str` so
+    /// format specifiers are honored, for downstream tabular logging where
+    /// `{:>24}` must actually pad. Note `pad` also treats a **precision** as a
+    /// maximum length, so `{:.10}` truncates — enough to make `BlockingAsk` and
+    /// `BlockingAskPriority` render identically. Use [`as_str`](Self::as_str)
+    /// when an unabridged, stable label is required.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -81,8 +87,9 @@ impl Channel {
 }
 
 impl std::fmt::Display for Channel {
+    /// Pads like [`Operation`]'s impl — see its note on `Formatter::pad`.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
+        f.pad(self.as_str())
     }
 }
 
@@ -294,11 +301,19 @@ impl std::fmt::Display for Error {
             Error::MailboxCapacity { message } => {
                 write!(f, "Mailbox capacity error: {message}")
             }
-            Error::Join { identity, source } => {
-                write!(
-                    f,
-                    "Failed to join spawned task from actor {identity}: {source}"
-                )
+            // The `JoinError` is deliberately NOT interpolated here: it is
+            // returned from `source()` below, and a `Display` that repeats its
+            // own source makes a chain-walking reporter (anyhow, eyre, or the
+            // manual loop in `debugging_tips`' example) print the same text
+            // twice. Matches how `Error::Runtime` drops its `source` from the
+            // message.
+            //
+            // Note this means `{}` alone no longer shows the panic message —
+            // `std::error::Error` has no alternate-flag chain walking, so
+            // `{:#}` does not add it either. Callers that want the cause must
+            // walk `source()`; see the example on `debugging_tips`.
+            Error::Join { identity, .. } => {
+                write!(f, "Failed to join spawned task from actor {identity}")
             }
             Error::PriorityChannelNotEnabled { identity } => {
                 write!(
@@ -401,9 +416,16 @@ impl Error {
     /// use rsactor::Error;
     ///
     /// fn log_error(err: &Error) {
-    ///     eprintln!("Error: {}", err);
+    ///     eprintln!("Error: {err}");
+    ///     // `Display` never repeats `source()`, so walk the chain explicitly —
+    ///     // this is where an `Error::Join`'s panic message lives.
+    ///     let mut cause = std::error::Error::source(err);
+    ///     while let Some(e) = cause {
+    ///         eprintln!("  caused by: {e}");
+    ///         cause = e.source();
+    ///     }
     ///     for tip in err.debugging_tips() {
-    ///         eprintln!("  - {}", tip);
+    ///         eprintln!("  - {tip}");
     ///     }
     /// }
     /// ```
@@ -674,45 +696,119 @@ mod tests {
     }
 
     #[test]
+    fn operation_and_channel_display_honor_format_specifiers() {
+        // `Formatter::write_str` silently ignores width/alignment/fill; these
+        // labels are meant for tabular log output, so `Display` must go through
+        // `Formatter::pad`.
+        assert_eq!(format!("{}", Operation::Ask), "ask");
+        assert_eq!(format!("{:>8}|", Operation::Ask), "     ask|");
+        assert_eq!(format!("{:<8}|", Operation::Ask), "ask     |");
+        assert_eq!(format!("{:*^9}|", Operation::Ask), "***ask***|");
+        assert_eq!(
+            format!("{:>24}|", Operation::BlockingAskPriority),
+            "   blocking_ask_priority|"
+        );
+
+        assert_eq!(format!("{}", Channel::IdleSubscribe), "idle_subscribe");
+        assert_eq!(
+            format!("{:>16}|", Channel::IdleSubscribe),
+            "  idle_subscribe|"
+        );
+    }
+
+    #[test]
     fn error_display_all_variants() {
         let identity = Identity::new(1, "TestActor");
 
-        let errors = vec![
-            Error::Send {
-                identity,
-                details: "channel closed",
-            },
-            Error::Receive {
-                identity,
-                details: "reply dropped",
-            },
-            Error::Timeout {
-                identity,
-                timeout: Duration::from_secs(5),
-                operation: Operation::Ask,
-            },
-            Error::Downcast {
-                identity,
-                expected_type: "String",
-            },
-            Error::Runtime {
-                identity,
-                details: "panic in handler".into(),
-                source: None,
-            },
-            Error::MailboxCapacity {
-                message: "capacity must be > 0",
-            },
-            Error::ChannelFull {
-                identity,
-                channel: Channel::IdleSubscribe,
-            },
+        // Each case pins the variant-specific wording. Asserting only on
+        // "non-empty" would let a `Display` that collapsed every variant to one
+        // generic string pass, i.e. the test would survive deletion of the
+        // behavior it exists to check.
+        let cases: Vec<(Error, &[&str])> = vec![
+            (
+                Error::Send {
+                    identity,
+                    details: "channel closed",
+                },
+                &["Failed to send message to actor", "channel closed"],
+            ),
+            (
+                Error::Receive {
+                    identity,
+                    details: "reply dropped",
+                },
+                &["Failed to receive reply from actor", "reply dropped"],
+            ),
+            (
+                Error::Timeout {
+                    identity,
+                    timeout: Duration::from_secs(5),
+                    operation: Operation::Ask,
+                },
+                &["ask", "timed out after", "5s"],
+            ),
+            (
+                Error::Downcast {
+                    identity,
+                    expected_type: "String",
+                },
+                &["Failed to downcast reply", "String"],
+            ),
+            (
+                Error::Runtime {
+                    identity,
+                    details: "panic in handler".into(),
+                    source: None,
+                },
+                &["Runtime error in actor", "panic in handler"],
+            ),
+            (
+                Error::MailboxCapacity {
+                    message: "capacity must be > 0",
+                },
+                &["Mailbox capacity error", "capacity must be > 0"],
+            ),
+            (
+                Error::ChannelFull {
+                    identity,
+                    channel: Channel::IdleSubscribe,
+                },
+                &["idle_subscribe", "at capacity"],
+            ),
+            // These two differ only by their trailing suffix, so a copy-paste
+            // swap between them is the realistic failure mode; pin both.
+            (
+                Error::PriorityChannelNotEnabled { identity },
+                &["Priority channel is not enabled", "with_priority()"],
+            ),
+            (
+                Error::IdleChannelNotEnabled { identity },
+                &["Idle channel is not enabled", "with_idle()"],
+            ),
         ];
 
-        for err in &errors {
-            let display = format!("{}", err);
-            assert!(!display.is_empty(), "Display should not be empty");
-            assert!(display.len() > 5, "Display should be descriptive");
+        for (err, expected) in &cases {
+            let display = format!("{err}");
+            for needle in *expected {
+                assert!(
+                    display.contains(needle),
+                    "Display for {err:?} is {display:?}, missing {needle:?}"
+                );
+            }
+        }
+
+        // Every identity-carrying case above must name the actor;
+        // MailboxCapacity is the only one of them with no identity to report.
+        // (`Error::Join` is covered separately by `error_join_display`.)
+        for (err, _) in &cases {
+            if matches!(err, Error::MailboxCapacity { .. }) {
+                continue;
+            }
+            let display = format!("{err}");
+            assert!(
+                display.contains("TestActor"),
+                "Display for {err:?} is {display:?}, missing the actor identity"
+            );
         }
     }
 
@@ -815,6 +911,14 @@ mod tests {
         assert!(display.contains("Failed to join"));
         assert!(display.contains("TestActor"));
         assert!(error.source().is_some(), "Join error should have a source");
+
+        // Regression guard: `Display` must not repeat what `source()` reports,
+        // or chain-walking reporters print the panic message twice.
+        let source_text = error.source().unwrap().to_string();
+        assert!(
+            !display.contains(&source_text),
+            "Display {display:?} must not embed its own source {source_text:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -88,13 +88,12 @@ pub trait TellHandler<M: Send + 'static>: Send + Sync {
     ///
     /// # Panics
     ///
-    /// Panics only when the mailbox is full (the `try_send` hot path never
-    /// blocks): from inside a `LocalSet` running on a multi-thread runtime,
-    /// or from an async context that cannot block — a task on a
-    /// `current_thread` runtime or a thread driving a `current_thread`
-    /// runtime's `block_on` (see
-    /// [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell) for both
-    /// conditions).
+    /// Panics only when the mailbox is full — the `try_send` hot path never
+    /// blocks. See
+    /// [`ActorRef::blocking_tell`](crate::ActorRef::blocking_tell) for the
+    /// execution paths these conditions map onto.
+    ///
+    #[doc = include_str!("doc/blocking_panics.md")]
     fn blocking_tell(&self, msg: M, timeout: Option<Duration>) -> Result<()>;
 
     /// Clone this handler into a new boxed instance.
@@ -148,12 +147,12 @@ pub trait AskHandler<M: Send + 'static, R: Send + 'static>: Send + Sync {
     ///
     /// # Panics
     ///
-    /// Panics when called from inside a `LocalSet` running on a multi-thread
-    /// runtime, and when called from an async context that cannot block — a
-    /// task on a `current_thread` runtime or a thread driving a
-    /// `current_thread` runtime's `block_on` (see
-    /// [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask) for both
-    /// conditions).
+    /// These apply even when the mailbox has room — unlike `blocking_tell`
+    /// there is no non-blocking fast path, because the reply must always be
+    /// awaited. See [`ActorRef::blocking_ask`](crate::ActorRef::blocking_ask)
+    /// for the execution paths these conditions map onto.
+    ///
+    #[doc = include_str!("doc/blocking_panics.md")]
     fn blocking_ask(&self, msg: M, timeout: Option<Duration>) -> Result<R>;
 
     /// Clone this handler into a new boxed instance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,8 +424,17 @@ where
 /// A boxed future that is Send and can be stored in collections.
 ///
 /// This type alias is used throughout the handler traits for object-safe async methods.
-/// Identical to `futures::future::BoxFuture` but defined locally to avoid exposing
-/// the `futures` crate in the public API surface.
+/// Identical to `futures::future::BoxFuture`, but spelled out locally so the public
+/// signatures name a plain `Pin<Box<dyn Future + Send>>` instead of a `futures` path.
+///
+/// This is a naming choice only — it does **not** keep `futures` out of the public API
+/// surface, which already carries it: [`ActorRef::subscribe_idle`](crate::ActorRef::subscribe_idle)
+/// bounds its parameter on `futures::stream::Stream`, and
+/// [`IdleSubscribeError::take_stream`](crate::IdleSubscribeError::take_stream) /
+/// [`into_parts`](crate::IdleSubscribeError::into_parts) return
+/// `futures::stream::BoxStream`. A semver-breaking `futures` release is therefore a
+/// breaking change for this crate; genuinely encapsulating it would require wrapping the
+/// idle-stream types as well.
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 impl<A, T> PayloadHandler<A> for T

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -46,7 +46,15 @@ pub(crate) struct MetricsCollector {
     total_idle_processing_nanos: AtomicU64,
     /// Maximum `on_idle` processing time observed in nanoseconds
     max_idle_processing_nanos: AtomicU64,
-    /// Last activity timestamp as milliseconds since UNIX_EPOCH
+    /// Last activity timestamp, stored **biased by one**: `0` means "no work
+    /// has completed yet", and any other value is `millis_since_epoch + 1`.
+    ///
+    /// The bias exists because a raw `0` is a legitimate timestamp whenever the
+    /// wall clock is at or before `UNIX_EPOCH` (an embedded board before NTP
+    /// sync); using it as the "never" sentinel would report a busy actor as
+    /// having done no work. Biasing keeps that distinction in a single atomic,
+    /// so this field needs no ordering relationship with any other. The `+ 1`
+    /// cannot overflow: wall-clock milliseconds are ~2^44, far below `u64::MAX`.
     last_activity_millis: AtomicU64,
     /// Collector construction time. Used as the uptime baseline until the actor
     /// finishes `on_start` (see `started_at`).
@@ -171,17 +179,18 @@ impl MetricsCollector {
             .unwrap_or(Duration::ZERO)
             .as_millis()
             .min(u64::MAX as u128) as u64;
-        self.last_activity_millis.store(millis, Ordering::Relaxed);
+        // Stored biased by one so `0` stays reserved for "never". Saturating is
+        // unreachable (see the field docs) but costs nothing on this cold path.
+        self.last_activity_millis
+            .store(millis.saturating_add(1), Ordering::Relaxed);
     }
 
     /// Converts the last activity timestamp to SystemTime.
     fn get_last_activity(&self) -> Option<SystemTime> {
-        let millis = self.last_activity_millis.load(Ordering::Relaxed);
-        if millis == 0 {
-            None
-        } else {
-            SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(millis))
-        }
+        // `0` is the "never" sentinel; every stored value is biased by one.
+        let biased = self.last_activity_millis.load(Ordering::Relaxed);
+        let millis = biased.checked_sub(1)?;
+        SystemTime::UNIX_EPOCH.checked_add(Duration::from_millis(millis))
     }
 
     /// Creates an immutable snapshot of current metrics.
@@ -359,6 +368,30 @@ mod tests {
         assert_eq!(snapshot.avg_processing_time, Duration::ZERO);
         assert_eq!(snapshot.max_processing_time, Duration::ZERO);
         assert!(snapshot.last_activity.is_none());
+    }
+
+    #[test]
+    fn last_activity_zero_timestamp_is_not_read_as_never() {
+        let collector = MetricsCollector::new();
+        assert!(
+            collector.get_last_activity().is_none(),
+            "a fresh collector has no activity"
+        );
+
+        // Simulate a wall clock at (or before) UNIX_EPOCH, where
+        // `update_last_activity` computes 0 millis. Without the +1 bias, 0
+        // doubled as the "never" sentinel and this reported None for an actor
+        // that had actually done work.
+        collector.record_message(Duration::from_millis(1));
+        // Biased encoding of a raw timestamp of 0.
+        collector.last_activity_millis.store(1, Ordering::Relaxed);
+
+        assert_eq!(
+            collector.get_last_activity(),
+            Some(SystemTime::UNIX_EPOCH),
+            "a recorded timestamp of 0 must still report as activity"
+        );
+        assert_eq!(collector.snapshot().message_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A follow-up review over `src/` (7,900 lines). Zero Critical/Major *code* defects were found — no `unsafe`, all feature combinations clean, full suite green. But nearly every finding was a **documentation contract that disagreed with the implementation**.

That matters here because this crate specifies panic conditions, deadlock-vs-stall semantics, and dead-letter label meanings **only in rustdoc** — and none of it is validated by `fmt`, `clippy`, `rustdoc`, or the tests. A doc comment can state the exact opposite of what the code does and every gate stays green.

## Breaking changes

- **`FailurePhase` and `ActorFailure` are now `#[non_exhaustive]`** — downstream matches need a `_` arm. Applied at the *enum* level only: unlike `Error`, the variants stay externally constructible so downstream tests can still build an `ActorResult` by hand. (Variant-level was implemented, evaluated, and deliberately rejected — it forbids external construction outright with no `..` escape and broke 9 sites in our own test suite.)
- **`Error::Join`'s `Display` no longer embeds its own source.** Repeating it made chain-walking reporters print the panic message twice. The `JoinError` is reachable via `source()`; the `debugging_tips` example now walks the chain.
- **`Operation` / `Channel` / `FailurePhase` `Display` honor format specifiers.** They pad as expected, but a *precision* now truncates (`{:.10}` renders both `BlockingAsk` and `BlockingAskPriority` as `blocking_a`). Use `as_str()` for an unabridged label.

## Notable corrections

- `ask` / `ask_with_timeout` documented **no self-ask hazard at all**, while every sibling API did. A self-`ask` deadlocks even on an empty mailbox and panics under `deadlock-detection`; `ask_with_timeout` is a *bounded stall*, not a deadlock, and can panic on a runtime built without a time driver.
- `blocking_ask` / `blocking_ask_priority` rendered `# Panics` **twice**, the two copies contradicting each other — one wrongly claiming `blocking_ask(msg, None)` panics on a timerless runtime.
- `blocking_*` panic conditions are now **single-sourced** via `include_str!` after drifting across three of six methods. The shared text distinguishes a bounded stall (mandatory `timeout`) from an unbounded hang (`timeout: None`) — a distinction the original per-method wording had right and a naive unification would flatten.
- `Actor::on_stop`'s contract was wrong: a message handler returning `Err` does **not** terminate the actor. Task cancellation, which *does* skip `on_stop`, was missing.
- The dead-letter `operation` contract ignored the shutdown drain, which cannot know the sending API. The recorder now takes a typed `Operation`, so the emitted label and `Error::Timeout` can no longer drift — the doc promise is now compiler-enforced.
- `register_ask_edge` claimed no cycle can form outside an actor context. It is a **detection blind spot**, not a proof — covering `tokio::spawn`, `spawn_blocking` (the pattern `blocking_ask` itself recommends), and hand-rolled threads.
- `MetricsCollector` reported an active actor as idle when the wall clock sat at or before `UNIX_EPOCH` (`0` doubled as the "never" sentinel). Timestamps are now stored biased by one, which also removes an atomic and keeps the type's all-`Relaxed` contract true.
- The `ActorResult` supervision example discarded the `on_stop` cleanup error and restarted the actor, because `is_runtime_failed()` matches the composite `OnIdleThenOnStop` phase before `is_stop_failed()` can see it.
- `error_display_all_variants` asserted only non-emptiness and skipped `PriorityChannelNotEnabled`/`IdleChannelNotEnabled` — two near-identical messages where a copy-paste swap was undetectable.

`Cargo.toml` now sets `exclude` so working notes and tooling (`plan/`, `book/`, `skills/`, `.github/`, `.claude/`, `.vscode/`) stay out of the published crate.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps --all-features` with `-D rustdoc::broken_intra_doc_links`
- `cargo test --all-features` — **437 passed, 0 failed**
- Each feature combination built individually (`""`, `tracing`, `metrics`, `test-utils`, `deadlock-detection`, all) — **0 warnings**. This caught a regression CI would have missed: the `Operation` refactor left a variable used only under `deadlock-detection`, and CI runs clippy solely with `--all-features`.
- Verified the shared doc fragment renders at all 6 include sites and that no duplicate remains (rendered `LocalSet` bullets: 6 → 4).

### Known unrelated issue

`cargo package` cannot run its verify build — `rsactor-derive 0.18` is not yet on crates.io, so the stripped path dependency fails to resolve. Pre-existing and independent of this PR. `cargo package --list` confirms `src/doc/blocking_panics.md` is included, which is what `include_str!` needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)