### PR TITLE
fix(examples): make actor_task do what its docs claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ rsActor comes with several examples that demonstrate various features and use ca
 * **[basic](./examples/basic.rs)** - Simple counter actor demonstrating core concepts with `#[message_handlers]` macro
 * **[actor_with_timeout](./examples/actor_with_timeout.rs)** - Using timeouts for actor communication
 * **[actor_async_worker](./examples/actor_async_worker.rs)** - Inter-actor communication with async tasks
+* **[actor_task](./examples/actor_task.rs)** - Spawning an async background task from `on_start` and exchanging data with it over an mpsc channel
 * **[actor_blocking_task](./examples/actor_blocking_task.rs)** - Using blocking APIs with actors
 * **[dining_philosophers](./examples/dining_philosophers.rs)** - Classic concurrency problem implementation
 * **[weak_reference_demo](./examples/weak_reference_demo.rs)** - Working with weak actor references and lifecycle

--- a/examples/actor_task.rs
+++ b/examples/actor_task.rs
@@ -4,15 +4,21 @@
 //! Actor-Task Communication Example
 //!
 //! This example demonstrates how to:
-//! 1. Spawn a background task from an actor's on_start lifecycle method
-//! 2. Send data from the actor to the background task using mpsc::channel
-//! 3. Send data from the background task back to the actor using actor messages
+//! 1. Spawn an async background task from an actor's on_start lifecycle method
+//! 2. Send commands from the actor to the background task using tokio's mpsc::channel
+//! 3. Send data from the background task back to the actor using actor messages (`tell`)
+//! 4. Shut the task down from `on_stop` so it never outlives the actor
+//!
+//! This is the async counterpart of `actor_blocking_task.rs`, which drives the same
+//! pattern from a synchronous `spawn_blocking` task. If you only need periodic work
+//! inside the actor itself — with no separate task and no channel — use the
+//! stream-based idle handler instead (see `basic.rs`).
 
 use anyhow::Result;
-use futures::stream::StreamExt;
 use rsactor::{message_handlers, Actor, ActorRef, ActorWeak};
 use std::time::Duration;
-use tokio_stream::wrappers::IntervalStream;
+use tokio::sync::mpsc;
+use tokio::task;
 use tracing::{debug, info};
 
 // Define message types for our actor
@@ -23,30 +29,24 @@ struct GetState;
 /// Message to change the processing factor
 struct SetFactor(f64);
 
-/// Message sent from the background task to the actor with processed data
+/// Message sent from the background task to the actor with generated data
 struct ProcessedData {
     value: f64,
     timestamp: std::time::Instant,
 }
 
-/// Commands that the actor can send to update its event processing
+/// Commands that the actor can send to the background task
 enum TaskCommand {
     /// Change the interval between data generations
     ChangeInterval(Duration),
+    /// Stop the background task
+    Stop,
 }
 
-/// Message to send a command to the background task
+/// Message asking the actor to relay a command to its background task
 struct SendTaskCommand(TaskCommand);
 
-/// Idle events delivered by the periodic stream subscribed in `on_start`.
-#[derive(Debug, Clone, Copy)]
-struct GenerateData;
-
-/// Define our actor — driven by a subscribed `IntervalStream` rather than by
-/// open-coded timer state inside `on_run`. The interval can be reconfigured at
-/// runtime via [`SendTaskCommand`]; the previous stream is replaced by simply
-/// subscribing a new one and letting the old one complete (here it never
-/// completes, so both keep firing — see the handler comment).
+/// Define our actor, which owns an async background task spawned in `on_start`.
 struct DataProcessorActor {
     /// Current processing factor (multiplier for incoming values)
     factor: f64,
@@ -54,12 +54,16 @@ struct DataProcessorActor {
     latest_value: Option<f64>,
     /// Latest timestamp when data was received
     latest_timestamp: Option<std::time::Instant>,
+    /// Sender used to command the background task
+    task_sender: mpsc::Sender<TaskCommand>,
+    /// Handle of the background task, so callers can await its completion
+    task_handle: task::JoinHandle<()>,
 }
 
 impl Actor for DataProcessorActor {
     type Args = ();
     type Error = anyhow::Error;
-    type IdleEvent = GenerateData;
+    type IdleEvent = ();
 
     async fn on_start(_args: Self::Args, actor_ref: &ActorRef<Self>) -> Result<Self, Self::Error> {
         info!(
@@ -67,32 +71,73 @@ impl Actor for DataProcessorActor {
             actor_ref.identity()
         );
 
-        actor_ref.subscribe_idle(
-            IntervalStream::new(tokio::time::interval(Duration::from_millis(500)))
-                .map(|_| GenerateData),
-        )?;
+        // Channel for actor -> task communication.
+        let (task_tx, mut task_rx) = mpsc::channel::<TaskCommand>(32);
 
-        info!("DataProcessorActor started with event-based processing");
+        // Clone the actor_ref so the task can send messages back to the actor.
+        let task_actor_ref = actor_ref.clone();
+
+        // Spawn the async background task.
+        let task_handle = task::spawn(async move {
+            info!("Background task started");
+
+            let mut interval = tokio::time::interval(Duration::from_millis(500));
+
+            loop {
+                tokio::select! {
+                    // Periodically generate a value and send it to the actor.
+                    _ = interval.tick() => {
+                        let raw_value = rand::random::<f64>() * 100.0;
+                        debug!("Task sending value {raw_value:.2} to actor");
+
+                        if let Err(e) = task_actor_ref
+                            .tell(ProcessedData {
+                                value: raw_value,
+                                timestamp: std::time::Instant::now(),
+                            })
+                            .await
+                        {
+                            info!("Failed to send data to actor: {e}");
+                            break;
+                        }
+                    }
+
+                    // Handle commands coming from the actor.
+                    cmd = task_rx.recv() => match cmd {
+                        Some(TaskCommand::ChangeInterval(new_interval)) => {
+                            info!("Task changing interval to {new_interval:?}");
+                            interval = tokio::time::interval(new_interval);
+                        }
+                        Some(TaskCommand::Stop) => {
+                            info!("Task received stop command");
+                            break;
+                        }
+                        None => {
+                            info!("Task command channel closed, stopping task");
+                            break;
+                        }
+                    },
+                }
+            }
+
+            info!("Background task stopping");
+        });
+
+        info!("DataProcessorActor started and background task spawned");
         Ok(Self {
             factor: 1.0,
             latest_value: None,
             latest_timestamp: None,
+            task_sender: task_tx,
+            task_handle,
         })
     }
 
-    async fn on_idle(
-        &mut self,
-        _event: GenerateData,
-        _actor_ref: &ActorWeak<Self>,
-    ) -> Result<(), Self::Error> {
-        // Generate a random value (simulating sensor data or similar)
-        let raw_value = rand::random::<f64>() * 100.0;
-        let processed_value = raw_value * self.factor;
-
-        self.latest_value = Some(processed_value);
-        self.latest_timestamp = Some(std::time::Instant::now());
-
-        debug!("Generated data: original={raw_value:.2}, processed={processed_value:.2}");
+    async fn on_stop(&mut self, _actor_weak: &ActorWeak<Self>, _killed: bool) -> Result<()> {
+        // Ask the task to stop. It also exits on its own if this channel is
+        // dropped, which is what happens when the actor is killed before
+        // `on_stop` can run to completion.
+        let _ = self.task_sender.send(TaskCommand::Stop).await;
         Ok(())
     }
 }
@@ -138,28 +183,15 @@ impl DataProcessorActor {
     }
 
     #[handler]
-    async fn handle_send_task_command(
-        &mut self,
-        msg: SendTaskCommand,
-        actor_ref: &ActorRef<Self>,
-    ) -> bool {
-        match msg.0 {
-            TaskCommand::ChangeInterval(new_interval) => {
-                // Subscribe an additional IntervalStream at the new cadence.
-                // The original 500ms stream continues to fire — this is the
-                // intentional contract of `subscribe_idle` (additive, not
-                // replacement). Use a per-stream cancellation token, a finite
-                // `take_until`, or a fused-stream pattern if you need
-                // replacement semantics.
-                let result = actor_ref.subscribe_idle(
-                    IntervalStream::new(tokio::time::interval(new_interval)).map(|_| GenerateData),
-                );
-                if result.is_ok() {
-                    info!("Subscribed additional generator at {:?}", new_interval);
-                    true
-                } else {
-                    false
-                }
+    async fn handle_send_task_command(&mut self, msg: SendTaskCommand, _: &ActorRef<Self>) -> bool {
+        match self.task_sender.send(msg.0).await {
+            Ok(()) => {
+                info!("Sent command to background task");
+                true
+            }
+            Err(_) => {
+                info!("Failed to send command to background task");
+                false
             }
         }
     }
@@ -174,12 +206,8 @@ async fn main() -> Result<()> {
 
     info!("Starting actor-task communication example");
 
-    // Create and spawn our actor. `with_idle()` enables the idle-event channel
-    // used by the streams subscribed in `on_start` (off by default).
-    let (actor_ref, join_handle) = rsactor::spawn_with_options::<DataProcessorActor>(
-        (),
-        rsactor::SpawnOptions::new().with_idle(),
-    );
+    // Create and spawn our actor. The background task is spawned inside `on_start`.
+    let (actor_ref, join_handle) = rsactor::spawn::<DataProcessorActor>(());
 
     // Wait a bit to get some initial data
     tokio::time::sleep(Duration::from_secs(2)).await;
@@ -202,7 +230,7 @@ async fn main() -> Result<()> {
     println!("Changing the task's data generation interval...");
 
     // Now we can send our command via actor messaging
-    let command_result = actor_ref
+    let command_result: bool = actor_ref
         .ask(SendTaskCommand(TaskCommand::ChangeInterval(
             Duration::from_millis(200),
         )))
@@ -226,11 +254,10 @@ async fn main() -> Result<()> {
         println!("Data age: {:?}", ts.elapsed());
     }
 
-    // Stop the actor gracefully
+    // Stop the actor gracefully. `on_stop` tells the background task to stop.
     println!("Stopping actor...");
     actor_ref.stop().await;
 
-    // Wait for the actor to finish (this will also wait for the background task)
     let result = join_handle.await?;
 
     match result {
@@ -240,6 +267,8 @@ async fn main() -> Result<()> {
                 "Final state: factor={:.2}, latest_value={:?}",
                 actor.factor, actor.latest_value
             );
+            // The actor is returned by value, so we can await its task here.
+            actor.task_handle.await.expect("Failed to join task handle");
         }
         rsactor::ActorResult::Failed { failure, killed } => {
             println!(


### PR DESCRIPTION
Closes #119

## Problem

The header of `examples/actor_task.rs` promised:

```
//! 1. Spawn a background task from an actor's on_start lifecycle method
//! 2. Send data from the actor to the background task using mpsc::channel
//! 3. Send data from the background task back to the actor using actor messages
```

but commit 92caa71 (`feat(actor)!: replace on_run with stream-based on_idle handler`) rewrote the example onto `subscribe_idle` and left the prose behind — along with `ProcessedData`, `TaskCommand` and `SendTaskCommand`, which had become leftovers of the old version (`ProcessedData` was handled but never sent by anything).

## Approach

Restored the example to the documented pattern rather than rewriting the prose to match the drift:

- the idle-stream lesson is already covered by `examples/basic.rs` (two `subscribe_idle` streams + `on_idle`), so nothing is lost;
- the async counterpart of `examples/actor_blocking_task.rs` had silently disappeared, leaving only the `spawn_blocking` variant of this pattern in the example suite.

## Changes

- `on_start` creates a `tokio::sync::mpsc` channel and spawns an async task that `select!`s between an interval tick (`tell(ProcessedData)` back to the actor) and incoming `TaskCommand`s.
- `SendTaskCommand` relays commands from the actor into the channel, so `ChangeInterval` now actually reconfigures the task instead of stacking another idle stream.
- `on_stop` shuts the task down and `main` joins its handle from the returned actor, so the task cannot outlive the actor. This is the one addition beyond the literal header claim.
- `actor_task` added to the README examples list, where it was the only example missing.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo run --example actor_task` — runs end to end: data flows task → actor, the 500ms → 200ms interval change takes effect, and the task exits on stop before the process ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)