### PR TITLE
chore(ci): lint example headers against the code they describe

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Check example headers
+        run: python3 scripts/check_example_headers.py
+
   # Security audit
   security:
     name: Security Audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cargo fmt --check` - Check formatting without modifying files (CI validation)
 - `cargo clippy --all-targets --all-features -- -D warnings` - Lint with clippy (CI configuration)
 - `cargo check --all-features` - Type check without building
+- `python3 scripts/check_example_headers.py` - Verify that APIs named in an example's `//!` header are actually used by that example (CI validation)
 
 **Before committing:** Always run `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` to ensure CI passes.
 

--- a/scripts/check_example_headers.py
+++ b/scripts/check_example_headers.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Check that API paths named in an example's `//!` header are used by that example.
+
+Example headers say what the example demonstrates, but nothing verifies them:
+examples are not rendered by `cargo doc`, their `//!` blocks are never doctested,
+and clippy stays silent about message types left behind by a refactor. So a header
+can advertise an API the example dropped long ago -- see issue #119, where
+`examples/actor_task.rs` promised an `mpsc::channel` that had been deleted 15
+months earlier and survived a dozen later edits to the same file.
+
+Rule enforced here: every `a::b`-shaped path in a `//!` header must appear
+somewhere in the example's code. Deliberate exceptions -- an API a header names
+in order to warn against it -- are listed in the allowlist file.
+
+This catches drift at the token level only. A header that describes the wrong
+direction of a data flow, or the wrong reason for a pattern, still needs a human
+reader; see CLAUDE.md on documentation being part of the contract.
+
+Usage: python3 scripts/check_example_headers.py [example.rs ...]
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+ALLOWLIST = REPO_ROOT / "scripts" / "example-header-allowlist.txt"
+
+# Rust paths such as `mpsc::channel` or `SpawnOptions::with_idle`. Single
+# identifiers are deliberately not checked: headers legitimately mention other
+# examples by name, which would produce noise without catching more drift.
+PATH_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)+\b")
+
+
+def load_allowlist() -> set[tuple[str, str]]:
+    """Read `<example path> <path token>` pairs that are exempt from the rule."""
+    allowed: set[tuple[str, str]] = set()
+    if not ALLOWLIST.exists():
+        return allowed
+    for line in ALLOWLIST.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        example, _, token = line.partition(" ")
+        if not token.strip():
+            sys.exit(f"{ALLOWLIST}: malformed entry (want '<file> <token>'): {line!r}")
+        allowed.add((example, token.strip()))
+    return allowed
+
+
+def check(path: pathlib.Path, allowed: set[tuple[str, str]]) -> list[str]:
+    """Return the header paths that never occur in this example's code."""
+    lines = path.read_text().splitlines()
+    header = " ".join(line[3:] for line in lines if line.startswith("//!"))
+    code = "\n".join(line for line in lines if not line.startswith("//!"))
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    return sorted(
+        {
+            token
+            for token in PATH_RE.findall(header)
+            if token not in code and (rel, token) not in allowed
+        }
+    )
+
+
+def main(argv: list[str]) -> int:
+    paths = (
+        [pathlib.Path(a).resolve() for a in argv]
+        if argv
+        else sorted((REPO_ROOT / "examples").glob("*.rs"))
+    )
+    allowed = load_allowlist()
+    failed = False
+
+    for path in paths:
+        missing = check(path, allowed)
+        if missing:
+            failed = True
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            print(f"{rel}: header names {', '.join(missing)}, but the code never uses it")
+
+    if failed:
+        print(
+            "\nThe `//!` header and the code disagree. Fix whichever is wrong -- and if\n"
+            "the header names an API on purpose without using it (to warn against it,\n"
+            f"say), add a '<file> <token>' line to {ALLOWLIST.relative_to(REPO_ROOT)}.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"checked {len(paths)} example header(s): all named APIs are used")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/example-header-allowlist.txt
+++ b/scripts/example-header-allowlist.txt
@@ -1,0 +1,7 @@
+# Paths an example's `//!` header names on purpose without using them, one
+# '<example file> <path>' pair per line. Keep each entry justified by a comment:
+# an unexplained entry is indistinguishable from the drift this lint exists to catch.
+
+# The header warns that the blocking API must NOT be used from threads created
+# this way, so naming it without using it is the point.
+examples/actor_blocking_task.rs std::thread::spawn


### PR DESCRIPTION
Follow-up to #119 / #120: the fix, but also the reason nobody noticed for 15 months.

> **Stacked on #120** — based on `fix/actor-task-example-mismatch`, because the lint fails on today's `main` (that is the point). GitHub will retarget this to `main` once #120 merges.

## Why nothing caught #119

The `//!` header of an example is invisible to every tool in this repo:

- `cargo doc --no-deps --all-features` produces **0** files for `actor_task` — example targets are not rendered by rustdoc, so no doc-link or doc-test check ever reads those lines.
- `cargo run --example` only asks whether the example runs, not whether it does what it says.
- clippy stayed green even with a `ProcessedData` message that nothing constructed, because the `Message` impl generated by `#[message_handlers]` counts as a use — the strongest available signal that a refactor left a fossil behind was erased.

So when dd6e6af (2025-05-18) deleted the `tokio::spawn` + `mpsc::channel` body and replaced it with `on_run`, the header stayed. Twelve later commits touched that file, all of them mechanical API migrations, and none re-read the prose.

## What this adds

One rule, over the part of the prose a machine can judge:

> every `a::b`-shaped path named in a `//!` header must appear in the example's code.

```
$ python3 scripts/check_example_headers.py
checked 17 example header(s): all named APIs are used
```

## Evidence

| Input | Result |
|---|---|
| `dd6e6af:examples/actor_task.rs` (the commit that introduced the drift) | **flags `mpsc::channel`** |
| `origin/main:examples/actor_task.rs` (today, pre-#120) | **flags `mpsc::channel`** |
| current 17 examples | 16 clean, 1 justified exception |

The single exception is [`actor_blocking_task.rs`](./examples/actor_blocking_task.rs), whose header names `std::thread::spawn` in order to warn *against* it — hence `scripts/example-header-allowlist.txt`, where each entry has to carry a comment justifying itself.

## Scope, deliberately

- **Single identifiers are not checked.** Headers legitimately mention other examples by name (`basic.rs`, `spawn_blocking`), so checking bare identifiers adds noise without catching more drift.
- **Semantic drift is out of reach.** A header that describes the wrong direction of a data flow still needs a human reader. This narrows the gap; it does not close it.

## Not included

`.github/workflows/rust.yml:123` swallows example failures with `|| echo "... failed"`, so a panicking example keeps CI green. That is a real hole, but unrelated to #119 — all 17 examples currently exit 0 in ~42s, so it can be removed safely in its own PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)