### PR TITLE
chore(cargo): resolve dependencies against the workspace MSRV

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,16 @@
+# Resolve dependencies against the workspace MSRV instead of always taking the
+# newest release.
+#
+# Cargo's default resolver picks maximum versions with no awareness of
+# `rust-version`, so `cargo update` can pull a transitive dependency that
+# silently raises the required compiler; the breakage then surfaces only in the
+# separate MSRV workflow, after the lockfile has already been committed. With
+# `fallback`, Cargo prefers versions compatible with the workspace
+# `rust-version` and reaches past it only when no compatible version exists.
+#
+# Honoured by Cargo 1.84+. Older toolchains -- including the MSRV build itself
+# -- ignore the key, so this setting cannot break an MSRV build. Keep it in
+# sync with `rust-version` in Cargo.toml: the value is read from there, not
+# duplicated here.
+[resolver]
+incompatible-rust-versions = "fallback"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Security and Dependencies
 - `cargo audit` - Run security audit (requires cargo-audit installation)
+- `cargo update` - Resolves against the workspace MSRV: `.cargo/config.toml` enables MSRV-aware resolution, so dependency versions requiring a newer compiler than `rust-version` are not selected (needs cargo 1.84+; older toolchains ignore the setting)
 
 ## Repository Architecture
 


### PR DESCRIPTION
`cargo update` currently resolves with no knowledge of our MSRV. It picks maximum versions, so a transitive dependency can raise the required compiler above `rust-version = "1.75.0"` without anything objecting — the breakage only surfaces later in `msrv.yml`, after the lockfile has been committed.

This enables MSRV-aware resolution so such versions are never selected.

```toml
# .cargo/config.toml
[resolver]
incompatible-rust-versions = "fallback"
```

`resolver = "3"` cannot be used for this: cargo 1.75 fails to parse it, breaking the very build we are protecting. The config key is ignored by older toolchains, so it holds on both ends.

## Verification

| Check | Result |
|---|---|
| cargo 1.96 resolution message | `Locking 8 packages to latest Rust 1.75.0 compatible versions` |
| Selected versions vs. without the file | **identical today** — a guard against future drift, not a lockfile change |
| Same, with `rust-version` temporarily set to `1.70.0` | 8 packages → **50 packages** re-resolved, confirming the setting has teeth rather than only changing a message |
| `cargo +1.75.0 check --all-features` | rc=0 |
| `cargo +1.75.0 build --all-features` | rc=0 |
| `cargo +1.75.0 test --all-features` | rc=0 |
| `Cargo.lock` | unchanged |

The MSRV toolchain results confirm the third bullet directly: cargo 1.75 ignores the key rather than choking on it.

## Interaction with existing CI

The Android jobs pass linkers through `CARGO_TARGET_*_LINKER` environment variables ([rust.yml:182-200](.github/workflows/rust.yml#L182-L200)) rather than a cargo config file, so nothing is shadowed by adding one.

## Limits

- Takes effect only with cargo 1.84+. Contributors on older toolchains resolve as before; `msrv.yml` remains the backstop.
- Whether Dependabot honours a repository's cargo config during its own resolution is **not verified here**. Its PRs are still gated by `msrv.yml`, so this is defence in depth, not a replacement.
- It guards resolution, not the declared MSRV: raising `rust-version` in `Cargo.toml` is still a deliberate, reviewable act.

Related: #119, #120, #121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)